### PR TITLE
Change libnetlink CMake min version to 3.13

### DIFF
--- a/lib/libnetlink/CMakeLists.txt
+++ b/lib/libnetlink/CMakeLists.txt
@@ -1,6 +1,7 @@
 project(LIBNETLINK)
 
-cmake_minimum_required(VERSION 3.10)
+# at least v3.13 is required for install(x) where x is from add_subdirectory()
+cmake_minimum_required(VERSION 3.13)
 SET(LIB_PATH "" CACHE STRING "lib path")
 SET(C_COMPILER "" CACHE STRING "c compiler")
 SET(CXX_COMPILER "" CACHE STRING "c++ compiler")


### PR DESCRIPTION
At least v3.13 is required for `install(x)` where x is a target from `add_subdirectory()`.

Bug discovered on an Elementary OS 5 machine, which had both a v3.10 cmake installed from `apt`, and cmake 3.21 installed from `snap`.

Running `cmake` on the main project used 3.21. However, the `compile_libnetlink.sh` script called the old cmake v3.10.