### PR TITLE
build(grpc): Use FetchContent to clone GRPC src

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -91,7 +91,6 @@ lib/libmicrohttpd-0.9.72/libmicrohttpd.pc
 lib/libmicrohttpd-0.9.72/libtool
 lib/libmicrohttpd-0.9.72/MHD_config.h
 lib/libmicrohttpd-0.9.72/stamp-h1
-lib/grpc/cmake/build/**
 lib/libuuid-1.0.3/build/**
 lib/libuuid-1.0.3/*.o
 lib/libuuid-1.0.3/*.deps

--- a/lib/compile_grpc.sh
+++ b/lib/compile_grpc.sh
@@ -2,23 +2,19 @@
 
 set -e
 
-LIBGRPC_SOURCE_DIR=./grpc
-LIBGRPC_INSTALL_DIR=$1/grpc
-CONFIG_HOST=$2
+LIBGRPC_SOURCE_DIR="$1"
+LIBGRPC_BUILD_DIR="$2"
+LIBGRPC_INSTALL_DIR="$3/grpc"
+CONFIG_HOST="$4"
 
 echo "GRPC lib source dir: ${LIBGRPC_SOURCE_DIR}"
+echo "GRPC lib build dir: ${LIBGRPC_BUILD_DIR}"
 echo "GRPC lib install dir: ${LIBGRPC_INSTALL_DIR}"
 echo "GRPC lib config host: ${CONFIG_HOST}"
 
-rm -rf "${LIBGRPC_SOURCE_DIR}"
-git clone -b v1.36.4 https://github.com/grpc/grpc
-
-cd ${LIBGRPC_SOURCE_DIR}
-git submodule update --init
-
 # Install gRPC
-mkdir -p "cmake/build"
-pushd "cmake/build"
+mkdir -p "${LIBGRPC_BUILD_DIR}"
+pushd "${LIBGRPC_BUILD_DIR}"
 cmake \
   -DCMAKE_BUILD_TYPE=Release \
   -DBUILD_SHARED_LIBS=ON \
@@ -33,8 +29,6 @@ cmake \
   -DgRPC_ZLIB_PROVIDER=module \
   -DCMAKE_INSTALL_RPATH=\$ORIGIN \
   -DCMAKE_INSTALL_PREFIX=$LIBGRPC_INSTALL_DIR \
-  ../..
-make -j4 install
+  "${LIBGRPC_SOURCE_DIR}"
+make -j9 install
 popd
-
-rm -rf "${LIBGRPC_SOURCE_DIR}"

--- a/lib/grpc.cmake
+++ b/lib/grpc.cmake
@@ -19,7 +19,7 @@ if (BUILD_GRPC_LIB AND NOT (BUILD_ONLY_DOCS))
   set(LIBGRPC_BIN_DIR "${LIBGRPC_INSTALL_DIR}/bin")
 
   FIND_GRPC_PATHS()
-  
+
   if (LIBGRPCPP_LIB AND LIBPROTOBUF_LIB AND LIBGRPCPP_REFLECTION_LIB AND PROTOC_BIN AND GRPC_CPP_PLUGIN_BIN)
     message("Found libgrpc_plugin_support library: ${LIBGRPC_PLUGIN_SUPPORT_LIB}")
     message("Found libgrpc library: ${LIBGRPC_LIB}")
@@ -30,7 +30,21 @@ if (BUILD_GRPC_LIB AND NOT (BUILD_ONLY_DOCS))
     message("Found protoc binary: ${PROTOC_BIN}")
     message("Found grpc_cpp_plugin binary: ${GRPC_CPP_PLUGIN_BIN}")
   ELSE ()
-    execute_process(COMMAND bash ${CMAKE_SOURCE_DIR}/lib/compile_grpc.sh ${LIBGRPC_INSTALL_ROOT})
+    FetchContent_Declare(
+      gRPC
+      GIT_REPOSITORY https://github.com/grpc/grpc
+      GIT_TAG        v1.36.4
+      GIT_SHALLOW true # only download latest commit
+      GIT_PROGRESS true # downloading loads of submodules, so we want to see progress
+    )
+    set(FETCHCONTENT_QUIET OFF)
+    FetchContent_Populate(gRPC)
+
+    execute_process(COMMAND bash ${CMAKE_SOURCE_DIR}/lib/compile_grpc.sh
+      "${grpc_SOURCE_DIR}"
+      "${grpc_BINARY_DIR}"
+      "${LIBGRPC_INSTALL_ROOT}"
+    )
 
     FIND_GRPC_PATHS()
 
@@ -67,5 +81,5 @@ if (BUILD_GRPC_LIB AND NOT (BUILD_ONLY_DOCS))
   #set(_REFLECTION grpc++_reflection)
   #set(_PROTOBUF_PROTOC $<TARGET_FILE:protoc>)
   #set(_GRPC_GRPCPP grpc++)
-  #set(_GRPC_CPP_PLUGIN_EXECUTABLE $<TARGET_FILE:grpc_cpp_plugin>)  
+  #set(_GRPC_CPP_PLUGIN_EXECUTABLE $<TARGET_FILE:grpc_cpp_plugin>)
 endif ()


### PR DESCRIPTION
Instead of using the bash script to download GRPC, we use CMake's FetchContent to download the GRPC source-code instead.

This download is faster and shows progress.

Instead of deleting the folder, we now cache it, to make building/testing muuch faster, especially since the @nqminds office has an awful internet connection.

However, the GRPC source and build folders are now subfolders of the GRPC folder, so we can clear it easily.

**We still use the bash script to compile GRPC**, however, since @mereacre was having issues with cross-compilation.