### PR TITLE
build(nDPI): Speed up nDPI download

### DIFF
--- a/lib/compile_ndpi.sh
+++ b/lib/compile_ndpi.sh
@@ -2,7 +2,7 @@
 
 set -e
 
-LIBNDPI_SOURCE_DIR=./nDPI
+LIBNDPI_SOURCE_DIR="$2"
 LIBNDPI_INSTALL_DIR=$1/ndpi
 LIBPCAP_INSTALL_DIR=$1/pcap
 LIBPCAP_INCLUDE_PATH=${LIBPCAP_INSTALL_DIR}/include
@@ -14,9 +14,6 @@ echo "NDPI lib source dir: ${LIBNDPI_SOURCE_DIR}"
 echo "NDPI lib install dir: ${LIBNDPI_INSTALL_DIR}"
 echo "NDPI lib config host: ${CONFIG_HOST}"
 
-rm -rf "${LIBNDPI_SOURCE_DIR}"
-git clone --depth 1 --branch 3.4 https://github.com/ntop/nDPI
-
 cd "${LIBNDPI_SOURCE_DIR}"
 ./autogen.sh
 
@@ -25,4 +22,3 @@ make
 make install
 make clean
 cd ../
-rm -rf "${LIBNDPI_SOURCE_DIR}"

--- a/lib/ndpi.cmake
+++ b/lib/ndpi.cmake
@@ -9,7 +9,15 @@ if (BUILD_NDPI_LIB AND NOT (BUILD_ONLY_DOCS))
   if (LIBNDPI_LIB)
     message("Found libndpi library: ${LIBNDPI_LIB}")
   ELSE ()
-    execute_process(COMMAND bash ${CMAKE_SOURCE_DIR}/lib/compile_ndpi.sh ${LIBNDPI_INSTALL_ROOT})
+    FetchContent_Declare(
+      ndpi_src
+      URL https://github.com/ntop/nDPI/archive/refs/tags/3.4.tar.gz
+      URL_HASH SHA3_256=84e4710df21ffa32a68a1b6fa51ef17b22caeaa34389db3f222c02210519aa6d
+
+    )
+    FetchContent_Populate(ndpi_src)
+
+    execute_process(COMMAND bash ${CMAKE_SOURCE_DIR}/lib/compile_ndpi.sh ${LIBNDPI_INSTALL_ROOT} ${ndpi_src_SOURCE_DIR})
     find_library(LIBNDPI_LIB NAMES ndpi libndpi PATHS "${LIBNDPI_LIB_DIR}" NO_DEFAULT_PATH)
   endif ()
 endif ()


### PR DESCRIPTION
Speed up nDPI download by using CMake's FetchContent to download a .tar.gz file instead of doing a `git clone`.

We use a sha3_256 hash of the file, so this should also be more secure.

Additionally, we no longer delete the source dir, which means recovering from a failed build is faster.