### PR TITLE
Fix GitHub Pages CI typo

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -40,7 +40,7 @@ jobs:
       run: cmake --build build/ --target doxydocs -j2
 
     - name: publish docs (main-branch only)
-      if: github.ref == 'ref/head/main'
+      if: github.ref == 'ref/heads/main'
       uses: peaceiris/actions-gh-pages@v3
       with:
         github_token: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
I accidentally forgot an "s" in ref/heads/main