### PR TITLE
Document more libuuid dependencies

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,6 +16,7 @@ build_dependencies=(
     build-essential # C and C++ compilers
     libnl-genl-3-dev libnl-route-3-dev # netlink dependencies
     automake # required by libmicrohttpd for some reason?
+    autopoint gettext # required by libuuid
     autoconf # required by compile_sqlite.sh
     libtool-bin # required by autoconf somewhere
     pkg-config # seems to be required by nDPI

--- a/debian/control
+++ b/debian/control
@@ -2,7 +2,7 @@ Source: edgesec-0.9.9-alpha1
 Section: unknown
 Priority: optional
 Maintainer: Alois Klink <alois@nquiringminds.com>
-Build-Depends: git, cmake (>=3.11.0), debhelper (>=9), doxygen, graphviz, texinfo, libnl-genl-3-dev, libnl-route-3-dev, automake, autoconf, libtool-bin, pkg-config, libjson-c-dev, libssl-dev, flex, bison, libmnl0
+Build-Depends: git, cmake (>=3.11.0), debhelper (>=9), doxygen, graphviz, texinfo, libnl-genl-3-dev, libnl-route-3-dev, automake, autoconf, libtool-bin, pkg-config, libjson-c-dev, libssl-dev, flex, bison, libmnl0, autopoint, gettext
 Standards-Version: 3.9.8
 Homepage: https://github.com/nqminds/EDGESec
 


### PR DESCRIPTION
For some reason, my laptop didn't have these installed,
even though the newly installed desktop PC did.

Maybe there is something different with Ubuntu 20.04 desktop
edition vs server edition.