### PR TITLE
Update OpenSSL build instructions

### DIFF
--- a/lib/compile_openssl.sh
+++ b/lib/compile_openssl.sh
@@ -2,24 +2,17 @@
 
 set -e
 
-LIBOPENSSL_SOURCE_DIR=./openssl
-LIBOPENSSL_INSTALL_DIR=$1/openssl
-CONFIG_HOST=$3
+LIBOPENSSL_SOURCE_DIR="$1"
+LIBOPENSSL_INSTALL_DIR="$2"
+CONFIG_HOST="$3"
 
 echo "OPENSSL lib source dir: ${LIBOPENSSL_SOURCE_DIR}"
 echo "OPENSSL lib install dir: ${LIBOPENSSL_INSTALL_DIR}"
-echo "OPENSSL lib config host: ${CONFIG_HOST}"
-
-rm -rf "${LIBOPENSSL_SOURCE_DIR}"
-
-git clone --depth 1 --branch openssl-3.0.0-beta1 https://github.com/openssl/openssl
+echo "OPENSSL lib cross-compile config host: ${CONFIG_HOST}"
 
 cd "${LIBOPENSSL_SOURCE_DIR}"
 
-./Configure --prefix=${LIBOPENSSL_INSTALL_DIR} --openssldir=${LIBOPENSSL_INSTALL_DIR} -lpthread no-dtls no-dtls1 no-psk no-srp no-ec2m no-weak-ssl-ciphers no-dso no-engine no-threads
+# CONFIG_HOST is UNQUOTED, so that OpenSSL picks default if it's not set
+./Configure ${CONFIG_HOST} --prefix=${LIBOPENSSL_INSTALL_DIR} --openssldir=${LIBOPENSSL_INSTALL_DIR} -lpthread no-dtls no-dtls1 no-psk no-srp no-ec2m no-weak-ssl-ciphers no-dso no-engine no-threads
 make
 make install
-make clean
-
-cd ../
-rm -rf "${LIBOPENSSL_SOURCE_DIR}"

--- a/lib/openssl.cmake
+++ b/lib/openssl.cmake
@@ -8,7 +8,22 @@ if (BUILD_OPENSSL_LIB AND NOT (BUILD_ONLY_DOCS))
   if (LIBCRYPTO_LIB)
     message("Found libcrypto library: ${LIBCRYPTO_LIB}")
   ELSE ()
-    execute_process(COMMAND bash ${CMAKE_SOURCE_DIR}/lib/compile_openssl.sh ${LIBOPENSSL_INSTALL_ROOT})
+    FetchContent_Declare(
+      openssl_src
+      URL https://github.com/openssl/openssl/archive/refs/tags/openssl-3.0.0-beta1.tar.gz
+      URL_HASH SHA256=4ba637257737a3bcdf059ceb6db8424698afca89de7bed1c189853253097d0f2
+    )
+    FetchContent_Populate(openssl_src)
+
+    if (CMAKE_CROSSCOMPILING)
+      if (CMAKE_SYSTEM_NAME STREQUAL "Linux" AND CMAKE_SYSTEM_PROCESSOR STREQUAL "aarch64")
+        set(openssl_config "linux-aarch64")
+      else(CMAKE_SYSTEM_NAME STREQUAL "Linux" AND CMAKE_SYSTEM_PROCESSOR STREQUAL "aarch64")
+        message(FATAL_ERROR "Could not figure out config for cross compiling openssl")
+      endif (CMAKE_SYSTEM_NAME STREQUAL "Linux" AND CMAKE_SYSTEM_PROCESSOR STREQUAL "aarch64")
+    endif (CMAKE_CROSSCOMPILING)
+
+    execute_process(COMMAND bash ${CMAKE_SOURCE_DIR}/lib/compile_openssl.sh ${openssl_src_SOURCE_DIR} ${LIBOPENSSL_INSTALL_DIR} ${openssl_config})
     find_library(LIBCRYPTO_LIB NAMES libcrypto.a PATHS "${LIBOPENSSL_LIB_PATH}" NO_DEFAULT_PATH)
   endif ()
 endif ()


### PR DESCRIPTION
Firstly, we download OpenSSL in the build/ directory using FetchContent.

This lets us use the slightly faster HTTP download.

Secondly, while cross-compiling, we set a custom target for OpenSSL, since it [uses some strange cross-compiling configs](https://github.com/openssl/openssl/blob/58608487a44b3991ecc6d431d6273b2ca8c980a6/Configurations/10-main.conf#L771-L775).

Currently only `linux-aarch64` is supported for cross-compiling.