### PR TITLE
Disable slow RE2 tests when compiling GRPC

### DIFF
--- a/lib/grpc.cmake
+++ b/lib/grpc.cmake
@@ -41,6 +41,8 @@ if (BUILD_GRPC_LIB AND NOT (BUILD_ONLY_DOCS))
     set(CARES_INSTALL OFF CACHE INTERNAL "Disable CARES Installation") # no need to install, since it's static lib
   endif (CUSTOM_GRPC_INSTALL_LIBS)
 
+  set(RE2_BUILD_TESTING OFF CACHE INTERNAL "Disable super slow RE2 tests")
+
   FetchContent_MakeAvailable(gRPC)
 
   #if cross-compiling, find host plugin


### PR DESCRIPTION
These RE2 tests take minutes, and are such very long.

There are still 2 additional tests added by [zlib](https://github.com/madler/zlib/blob/master/CMakeLists.txt) (a dependency of GRPC). However, as you can see from the below console, they only take 0.00 seconds to run.

Fixes #23.

## Test Output

```console
alois@polite-pcspecialist:~/EDGESec$ cmake --build build/ --target test -j12
Running tests...
Test project /home/alois/EDGESec/build
      Start  1: example
 1/30 Test  #1: example ..........................   Passed    0.00 sec
      Start  2: example64
 2/30 Test  #2: example64 ........................   Passed    0.00 sec
      Start  3: test_engine
 3/30 Test  #3: test_engine ......................   Passed    0.00 sec
      Start  4: test_default_analyser
 4/30 Test  #4: test_default_analyser ............***Failed    0.00 sec
      Start  5: test_packet_queue
 5/30 Test  #5: test_packet_queue ................   Passed    0.00 sec
      Start  6: test_pcap_queue
 6/30 Test  #6: test_pcap_queue ..................   Passed    0.00 sec
      Start  7: test_capture_config
 7/30 Test  #7: test_capture_config ..............   Passed    0.00 sec
      Start  8: test_sqlite_pcap_writer
 8/30 Test  #8: test_sqlite_pcap_writer ..........   Passed    0.00 sec
      Start  9: test_sqlite_header_writer
 9/30 Test  #9: test_sqlite_header_writer ........   Passed    0.00 sec
      Start 10: test_sqlite_crypt_writer
10/30 Test #10: test_sqlite_crypt_writer .........   Passed    0.00 sec
      Start 11: test_crypt_service
11/30 Test #11: test_crypt_service ...............   Passed    0.01 sec
      Start 12: test_if
12/30 Test #12: test_if ..........................   Passed    0.00 sec
      Start 13: test_os
13/30 Test #13: test_os ..........................   Passed    0.00 sec
      Start 14: test_hashmap
14/30 Test #14: test_hashmap .....................   Passed    0.00 sec
      Start 15: test_utarray
15/30 Test #15: test_utarray .....................   Passed    0.00 sec
      Start 16: test_minIni
16/30 Test #16: test_minIni ......................   Passed    0.00 sec
      Start 17: test_squeue
17/30 Test #17: test_squeue ......................   Passed    0.00 sec
      Start 18: test_log_thread_safe
18/30 Test #18: test_log_thread_safe .............   Passed    0.01 sec
      Start 19: test_log_level
19/30 Test #19: test_log_level ...................   Passed    0.00 sec
      Start 20: test_log_err
20/30 Test #20: test_log_err .....................   Passed    0.00 sec
      Start 21: test_bridge_list
21/30 Test #21: test_bridge_list .................   Passed    0.00 sec
      Start 22: test_domain_server
22/30 Test #22: test_domain_server ...............   Passed    0.00 sec
      Start 23: test_cmd_processor
23/30 Test #23: test_cmd_processor ...............   Passed    0.00 sec
      Start 24: test_mac_mapper
24/30 Test #24: test_mac_mapper ..................   Passed    0.00 sec
      Start 25: test_sqlite_fingerprint_writer
25/30 Test #25: test_sqlite_fingerprint_writer ...   Passed    0.00 sec
      Start 26: test_sqlite_macconn_writer
26/30 Test #26: test_sqlite_macconn_writer .......   Passed    0.00 sec
      Start 27: test_radius_server
27/30 Test #27: test_radius_server ...............   Passed    0.00 sec
      Start 28: test_hostapd
28/30 Test #28: test_hostapd .....................   Passed    1.00 sec
      Start 29: test_dnsmasq
29/30 Test #29: test_dnsmasq .....................   Passed    0.00 sec
      Start 30: test_subnet_service
30/30 Test #30: test_subnet_service ..............   Passed    0.00 sec

97% tests passed, 1 tests failed out of 30

Total Test time (real) =   1.07 sec

The following tests FAILED:
	  4 - test_default_analyser (Failed)
Errors while running CTest
make: *** [Makefile:107: test] Error 8
```

I had a look at why test 4 was failing, and the error is the following:

```ctest
test 4
      Start  4: test_default_analyser

4: Test command: /home/alois/EDGESec/build/tests/capture/test_default_analyser
4: Test timeout computed to be: 1500
4: [==========] Running 2 test(s).
4: [ RUN      ] test_start_default_analyser
4: 2021-10-18 09:24:12.149  DEBUG os.c:1006: creating dir path=./db/pcap
4: 2021-10-18 09:24:12.149  ERROR[ENOENT(2)] os.c:1010: [No such file or directory] mkdir
4: 2021-10-18 09:24:12.149  DEBUG default_analyser.c:227: create_dir fail
4: [  ERROR   ] --- 0xffffffffffffffff != 0
4: [   LINE   ] --- /home/alois/EDGESec/tests/capture/test_default_analyser.c:160: error: Failure!
4: [  FAILED  ] test_start_default_analyser
4: [ RUN      ] test_pcap_callback
4: 2021-10-18 09:24:12.149  TRACE default_analyser.c:104: Pushed packet size=100
4: [       OK ] test_pcap_callback
4: [==========] 2 test(s) run.
4: [  PASSED  ] 1 test(s).
4: [  FAILED  ] 1 test(s), listed below:
4: [  FAILED  ] test_start_default_analyser
4: 
4:  1 FAILED TEST(S)
 4/30 Test  #4: test_default_analyser ............***Failed    0.00 sec
```