### PR TITLE
Remove GRPC git submodule

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,3 +1,0 @@
-[submodule "lib/grpc"]
-	path = lib/grpc
-	url = https://github.com/grpc/grpc


### PR DESCRIPTION
We no longer install GRPC as a git submodule.