### PR TITLE
Add create debs action

### DIFF
--- a/.github/workflows/create-debs.yml
+++ b/.github/workflows/create-debs.yml
@@ -1,0 +1,48 @@
+on:
+  release:
+    types: [created]
+
+name: Upload Debs to Release
+
+jobs:
+  build:
+    env:
+      OTHER_MIRROR:
+        deb [arch=arm64] http://ports.ubuntu.com/ubuntu-ports focal main universe | deb [arch=amd64] http://gb.archive.ubuntu.com/ubuntu focal main universe
+      PBUILDER_RC: |
+        # Enable network access, since `cmake` downloads dependencies
+        USENETWORK=yes
+        # Faster than default, and is requried if we want to do cross-compiling
+        PBUILDERSATISFYDEPENDSCMD="/usr/lib/pbuilder/pbuilder-satisfydepends-apt"
+    name: Upload built .deb
+    runs-on: ubuntu-latest
+    matrix:
+      architecture: [arm64]
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v2
+      - name: Install dependencies
+        run: |
+          sudo apt update && sudo apt install pbuilder -y
+      - name: Setup pdebuilderrc for cross-compiling
+        run: |
+          echo "$PBUILDER_RC" | sudo tee -a /etc/pbuilderrc
+      - name: Build .deb
+        run: |
+          pdebuild --debbuildopts "-us -uc" -- --override-config --distribution focal --mirror "" --othermirror "$OTHER_MIRROR" --host-arch arm64
+      - name: Load output .deb name
+        id: load-deb-name
+        run: |
+          DEB_PATH="$(ls -rt /var/cache/pbuilder/result/edgesec*.deb | head -1)"
+          echo " ::set-output name=deb-path::${DEB_PATH}"
+          echo " ::set-output name=deb-name::$(basename "${DEB_PATH}"")"
+      - name: Upload .deb as Release Asset
+        id: upload-release-asset 
+        uses: actions/upload-release-asset@v1
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        with:
+          upload_url: ${{ github.event.release.upload_url }} # This will only exist if this action was started by a GitHub Release Event
+          asset_path: ${{ steps.load-deb-name.output.deb-path }}
+          asset_name: ${{ steps.load-deb-name.output.deb-name }}
+          asset_content_type: application/vnd.debian.binary-package


### PR DESCRIPTION
Adds a GitHub Actions that should compile the .deb
when a new GitHub Release is made.

Currently only creates a release for arm64,
since otherwise this probably will be far too slow.