### PR TITLE
Set default `riskScore` to `-1`

### DIFF
--- a/config.ini.in
+++ b/config.ini.in
@@ -12,7 +12,8 @@ apDetect = false
 generateSsid = true
 defaultOpenVlanId = 0
 quarantineVlanId = 10
-riskScore = 100
+# @mereacre, can you add a short comment of what this means?
+riskScore = -1
 killRunningProcess = false
 # Set to `true` to let edgesec process start hostapd
 execAp = true


### PR DESCRIPTION
Hey Alex, is there any chance you can add a short comment on what this means? Does `-1` mean max risk score?

You can use GitHub's suggestion feature to easily add code that you want to change:

![image](https://user-images.githubusercontent.com/19716675/138851850-acf8d14e-8ef6-4393-b5e0-8fc4476a2c60.png)
