### PR TITLE
Fix merge commit that reintroduced libmnl0

### DIFF
--- a/debian/control
+++ b/debian/control
@@ -15,7 +15,7 @@ Depends: libedgesec (= ${binary:Version}),
     edgesec-revclient (= ${binary:Version}),
     ${shlibs:Depends},
     ${misc:Depends},
-    dnsmasq, jq, libmnl0
+    dnsmasq, jq
 Description: NquiringMinds EDGESec Network Security Router.
  This is NquiringMind's EDGESec Network Analyser.
  It usually creates a secure and paritioned Wifi access point, using vlans,


### PR DESCRIPTION
#39 removed this, but due to a merge conflict, it was accidentally added back in again in when we merged from `master` in #41