### PR TITLE
Disable unit tests when compiling OpenSSL

### DIFF
--- a/lib/compile_openssl.sh
+++ b/lib/compile_openssl.sh
@@ -14,7 +14,7 @@ cd "${LIBOPENSSL_SOURCE_DIR}"
 
 # CONFIG_HOST is UNQUOTED, so that OpenSSL picks default if it's not set
 # Set --libdir=lib, since otherwise sometimes OpenSSL installs in /lib64
-./Configure ${CONFIG_HOST} --prefix=${LIBOPENSSL_INSTALL_DIR} --libdir=lib --openssldir=${LIBOPENSSL_INSTALL_DIR} -lpthread no-dtls no-dtls1 no-psk no-srp no-ec2m no-weak-ssl-ciphers no-dso no-engine no-threads
+./Configure ${CONFIG_HOST} --prefix=${LIBOPENSSL_INSTALL_DIR} --libdir=lib --openssldir=${LIBOPENSSL_INSTALL_DIR} -lpthread no-dtls no-dtls1 no-psk no-srp no-ec2m no-weak-ssl-ciphers no-dso no-engine no-threads no-unit-test
 make
 # only install software, don't install or build docs
 make install_sw


### PR DESCRIPTION
Feature was accidentally removed due to merge conflicts in #42.