### PR TITLE
Document some of capsrv CLI args

### DIFF
--- a/src/capsrv.c
+++ b/src/capsrv.c
@@ -84,6 +84,8 @@ int show_app_help(char *app_name)
   show_app_version();
   fprintf(stdout, "Usage:\n");
   fprintf(stdout, CAPTURE_USAGE_STRING, basename(app_name));
+  fprintf(stdout, "\n");
+  fprintf(stdout, CAPTURE_DESC_STRING);
   fprintf(stdout, "\nOptions:\n");
   fprintf(stdout, "%s", CAPTURE_OPT_DEFS);
   fprintf(stdout, "Copyright NQMCyber Ltd\n\n");

--- a/src/capture/capture_config.h
+++ b/src/capture/capture_config.h
@@ -54,9 +54,18 @@
 #define CAPTURE_MAX_OPT       26
                               
 #define CAPTURE_OPT_STRING    ":c:i:q:f:t:n:p:y:a:o:x:z:r:k:b:dvhmewus"   // gjl
-#define CAPTURE_USAGE_STRING  "\t%s [-c config] [-d] [-h] [-v] [-i interface] [-q domain]" \
+#define CAPTURE_USAGE_STRING  "\t%s [-c config] [-d] [-h] [-v] [(-y engine [-w] [-u] [-s -a address -o port -k path]) | (-b size)] [-i interface] [-q domain]" \
                               "[-f filter] [-m] [-t timeout] [-n interval] " \
-                              "[-e] [-y engine][-w] [-u] [-s] [-p path] [-a address] [-o port] [-k path] [-r params] [-b size]\n"
+                              "[-e] [-r params]\n"
+#define CAPTURE_DESC_STRING   "EDGESec Capture Server\n" \
+                              "\n" \
+                              "EDGESec can be run in two different modes:\n" \
+                              "\tCapture Mode:\n" \
+                              "\t\tPass [-y engine] to enable capture mode.\n" \
+                              "\tCleaning Mode:\n" \
+                              "\t\tPass [-b SIZE] to enable cleaning mode\n" \
+                              "\t\tThe capture server will wait until SIZE KiB of PCAP data has been saved.\n" \
+                              "\t\tThen it will cleanup the PCAP data.\n"
 #define CAPTURE_OPT_DEFS      "\t-c config\t Path to the config file name\n" \
                               "\t-q domain\t The UNIX domain path\n" \
                               "\t-x command\t The UNIX domain command\n" \


### PR DESCRIPTION
~After much going through the source code and trying out options, it looks cleaning mode is broken.~

~Cleaning mode fails with `pcap-meta.sqlite does not exist`.~

~I went through the source code, and it looks like that file is only created during analysis mode.~

~Trying to run both analysis mode and cleaning mode at the same time doesn't work however:~
  ~cleaning mode is ignored, and only analysis mode is run.~
  
Nevermind, seems like capsrv is working now. I think maybe it was because before I was only running `capsrv` by itself, and now I'm running all the `edgesec` services at the same time, so maybe a different service is creating `pcap-meta.sqlite`.

I'll leave this PR anyway, since it improves the documentation slightly for `capsrv`. The CLI is still pretty undocumented, but hopefully I won't need to touch it again since it seems to be working.