### PR TITLE
Fix apt unattended updates

### DIFF
--- a/deployment/README.md
+++ b/deployment/README.md
@@ -108,7 +108,7 @@ After logging in, you can do the following:
   ```
   Unattended-Upgrade::Allowed-Origins {
     // edgesec
-    "nqminds.github.io/edgesec-packages:${distro_codename}";
+    "nqminds.github.io/edgesec-packages:";
   };
   ```
 


### PR DESCRIPTION
Apt repos created via reprepro
(e.g. https://github.com/nqminds/edgesec-packages)
do not have an Archive tag in the Release file.

This means that the Archive tag must be empty,
when settting up our origin for downloads.

E.g. compare the official Ubuntu Release file:
http://ports.ubuntu.com/ubuntu-ports/dists/focal/main/binary-arm64/Release

with our unoffocial edgesec-packages Release file:
https://nqminds.github.io/edgesec-packages/debian/dists/focal/Release