### PR TITLE
Fix missing config.ini file when creating .deb

### DIFF
--- a/CMakeModules/EdgesecInstallLocations.cmake
+++ b/CMakeModules/EdgesecInstallLocations.cmake
@@ -31,10 +31,10 @@ set(EDGESEC_cert_location "${EDGESEC_config_dir}/CA/CA.pem") # CACHE FILEPATH "P
 # makes dirs like EDGESEC_full_libexec_dir
 foreach(dir in private_lib_dir libexec_dir config_dir log_dir local_lib_dir runstate_dir cert_location)
     GNUInstallDirs_get_absolute_install_dir(
-        EDGESEC_full_${dir} EDGESEC_${dir} ${dir}
+        EDGESEC_full_no_destdir_${dir} EDGESEC_${dir} ${dir}
     )
     # FULL_PATH isn't actually always absolute due to destdir
-    set(with_destdir "$ENV{DESTDIR}${EDGESEC_full_${dir}}")
+    set(with_destdir "$ENV{DESTDIR}${EDGESEC_full_no_destdir_${dir}}")
     if (NOT IS_ABSOLUTE "${with_destdir}")
         # make paths in config.ini absolute, so we can call them from different working dir
         get_filename_component(with_destdir

--- a/CMakeModules/InstallConfigFile.cmake
+++ b/CMakeModules/InstallConfigFile.cmake
@@ -33,4 +33,5 @@ foreach(required_var IN ITEMS CMAKE_INSTALL_PREFIX CMAKE_INSTALL_LIBDIR build_di
 endforeach()
 
 configure_file("config.ini.in" "${build_dir}/config.ini" ESCAPE_QUOTES @ONLY)
-file(INSTALL "${build_dir}/config.ini" DESTINATION ${EDGESEC_full_config_dir})
+# cannot use EDGESEC_full_config_dir, since that will add DESTDIR TWICE
+file(INSTALL "${build_dir}/config.ini" DESTINATION "${EDGESEC_full_no_destdir_config_dir}")

--- a/debian/edgesec-common.install
+++ b/debian/edgesec-common.install
@@ -1,1 +1,1 @@
-etc/edgesec
+etc/edgesec/*


### PR DESCRIPTION
I didn't notice that #49 broke adding the config.ini file.

The issue was that we were adding DESTDIR to the front
of the install location twice, as file(INSTALL) adds
DESTDIR automatically.

I've now made a *full_without_destdir* var so we don't
double add destdir