### PR TITLE
Refactor Build-Depends in debian/control

### DIFF
--- a/debian/control
+++ b/debian/control
@@ -2,7 +2,17 @@ Source: edgesec
 Section: net
 Priority: optional
 Maintainer: Alois Klink <alois@nquiringminds.com>
-Build-Depends: git, ca-certificates, cmake (>=3.15.0), debhelper-compat (= 12), doxygen, graphviz, texinfo, libnl-genl-3-dev, libnl-route-3-dev, automake, autoconf, libtool-bin, pkg-config, libjson-c-dev, libgnutls28-dev, libssl-dev, flex, bison, protobuf-compiler-grpc:native, libprotobuf-dev, libgrpc++-dev, libcmocka-dev (>=1.1.5), libmnl-dev (>= 1.0.4)
+Build-Depends: debhelper-compat (= 12),
+    git, ca-certificates, cmake (>=3.15.0), 
+    doxygen, graphviz, texinfo,
+    libnl-genl-3-dev, libnl-route-3-dev,
+    automake, autoconf, flex, bison,
+    libtool-bin, pkg-config,
+    libjson-c-dev,
+    libgnutls28-dev, libssl-dev,
+    protobuf-compiler-grpc:native, libprotobuf-dev, libgrpc++-dev,
+    libcmocka-dev (>=1.1.5),
+    libmnl-dev (>= 1.0.4)
 Standards-Version: 4.5.0
 Homepage: https://github.com/nqminds/EDGESec
 Vcs-Browser: https://github.com/nqminds/EDGESec


### PR DESCRIPTION
Just adds newline chars, so it's easier to read, and should
prevent some git-merge conflicts when multiple PRs edit
Build-Depends.