### PR TITLE
Add PCAP include path to mdns_mapper

### DIFF
--- a/src/dns/CMakeLists.txt
+++ b/src/dns/CMakeLists.txt
@@ -6,7 +6,7 @@ add_library(mdns_list mdns_list.c)
 target_link_libraries(mdns_list PRIVATE os)
 
 add_library(mdns_mapper mdns_mapper.c)
-#target_include_directories(mdns_mapper PUBLIC ${LIBPCAP_INCLUDE_PATH})
+target_include_directories(mdns_mapper PUBLIC ${LIBPCAP_INCLUDE_PATH})
 target_link_libraries(mdns_mapper PRIVATE mdns_list os)
 
 add_library(mcast mcast.c)
@@ -17,4 +17,4 @@ target_link_libraries(reflection_list PRIVATE os log)
 
 add_library(mdns_service mdns_service.c)
 target_include_directories(mdns_service PRIVATE "${LIBSQLITE_INCLUDE_DIR}")
-target_link_libraries(mdns_service PRIVATE mdns_mapper reflection_list mcast mdns_decoder domain eloop if os log)
+target_link_libraries(mdns_service PUBLIC mdns_mapper PRIVATE reflection_list mcast mdns_decoder domain eloop if os log)


### PR DESCRIPTION
Fixed compiling on my PC and CI/CD for you :+1:

It's worth looking at how `PUBLIC`/`PRIVATE`/`INTERFACE` works with CMake `target_link...` and `target_include...`.

Generally, it's pretty useful, since then `CMake` will automatically propagate dependencies.

E.g., making `LIBPCAP_INCLUDE_PATH` a `PUBLIC` include dir of `mdns_mapper` means that anything that `target_link_libraries` to `mdns_mapper` will also include `LIBPCAP_INCLUDE_PATH`.