### PR TITLE
Use pre-compiled GRPC from Ubuntu repos 

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -55,7 +55,7 @@ option(BUILD_MICROHTTPD_LIB "Build microhttpd library" ON)
 option(BUILD_UUID_LIB "Build uuid library" ON)
 option(BUILD_PCAP_LIB "Build pcap library" ON)
 option(BUILD_NDPI_LIB "Build nDPI library" ON)
-option(BUILD_GRPC_LIB "Build gRPC library (warning, cross-compiling does not work well)" ON)
+option(BUILD_GRPC_LIB "Build gRPC library (warning, cross-compiling does not work well)" OFF)
 option(BUILD_SQLSYNC_SERVICE "Build sqlsync service" ON)
 option(BUILD_REVERSE_SERVICE "Build Reverse service" ON)
 


### PR DESCRIPTION
Compiling the `.debs` with continuous integration does not like building GRPC from source.

@mereacre, any chance you can try running the following commands on your PC?
(you can just copy-and-paste them into a terminal and wait 30 minutes in the background)

I just want to see if it will work fine to use GRPC from `apt` on a fresh folder.

First, install the dependencies:

```bash
sudo apt update
build_dependencies=(
    cmake # build-tool
    git # required to download dependencies
    ca-certificates # required for git+https downloads
    doxygen texinfo graphviz # documentation
    build-essential # C and C++ compilers
    libnl-genl-3-dev libnl-route-3-dev # netlink dependencies
    automake # required by libmicrohttpd
    autopoint gettext # required by libuuid
    autoconf # required by compile_sqlite.sh
    libtool-bin # required by autoconf somewhere
    pkg-config # seems to be required by nDPI
    libjson-c-dev
    flex bison # required by pcap
    libgnutls28-dev # required by libmicrohttpd
    libssl-dev # required by hostapd only. GRPC uses own version, and we compile OpenSSL 3 for EDGESec
    protobuf-compiler-grpc libprotobuf-dev libgrpc++-dev # GRPC, can be removed if -DBUILD_GRPC_LIB=ON
    libcmocka-dev # cmocka, can be removed if -DBUILD_CMOCKA_LIB=ON
    libmnl-dev # libmnl, can be removed if -DBUILD_LIBMNL_LIB=ON
)
runtime_dependencies=(
    dnsmasq
    jq # required by predictable wifi name script
)
sudo apt install -y "${build_dependencies[@]}" "${runtime_dependencies[@]}"
```

Download, build, and compile src:

```bash
cd /tmp
git clone git@github.com:nqminds/EDGESec.git
cd /tmp/EDGESec
git switch set-grpc-to-use-apt
cmake -B build/ -S . -DLIB_MAKEFLAGS="--jobs=$(nproc)"
cmake --build build/ -j4
cmake --build build/ --target test -j4
```

Closes #68 if it works on your PC.