### PR TITLE
Adds link-time-optimization to the executables

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -28,23 +28,32 @@ target_link_libraries(config minIni mac_mapper)
 add_executable(mdnsf mdnsf.c)
 target_include_directories(mdnsf PRIVATE ${LIBPCAP_INCLUDE_PATH} ${PROJECT_BINARY_DIR})
 target_link_libraries(mdnsf PRIVATE mdns_service subnet_service config minIni squeue log os)
+# link time optimization
+set_target_properties(capsrv PROPERTIES INTERPROCEDURAL_OPTIMIZATION TRUE)
+
 
 if (BUILD_CAPTURE_SERVICE)
   add_executable(capsrv capsrv.c)
   target_include_directories(capsrv PRIVATE ${LIBPCAP_INCLUDE_PATH} ${PROJECT_BINARY_DIR})
   target_link_libraries(capsrv capture_service capture_config config minIni os hashmap ${LIBPCAP_LIB})
+  # link time optimization
+  set_target_properties(capsrv PROPERTIES INTERPROCEDURAL_OPTIMIZATION TRUE)
 endif ()
 
 if (BUILD_REST_SERVER AND BUILD_MICROHTTPD_LIB)
   add_executable(restsrv restsrv.c)
   target_include_directories(restsrv PRIVATE ${LIBMICROHTTPD_INCLUDE_DIR} ${PROJECT_BINARY_DIR})
   target_link_libraries(restsrv config minIni base64 os hashmap ap_service cmd_processor ${LIBMICROHTTPD_LIB})
+  # link time optimization
+  set_target_properties(restsrv PROPERTIES INTERPROCEDURAL_OPTIMIZATION TRUE)
 endif ()
 
 if (BUILD_SQLSYNC_SERVICE)
   add_executable(sqlsyncsrv sqlsyncsrv.cc)
   target_include_directories(sqlsyncsrv PRIVATE ${PROJECT_BINARY_DIR} ${LIBSQLITE_INCLUDE_DIR})
   target_link_libraries(sqlsyncsrv PUBLIC sqlite_header_writer os sqlite_grpc_proto GRPC::grpc++_reflection ${LIBSQLITE_LIB})
+  # link time optimization
+  set_target_properties(sqlsyncsrv PROPERTIES INTERPROCEDURAL_OPTIMIZATION TRUE)
 endif ()
 
 if (BUILD_REVERSE_SERVICE)
@@ -55,8 +64,13 @@ if (BUILD_REVERSE_SERVICE)
   add_executable(revsrv revsrv.cc)
   target_include_directories(revsrv PRIVATE ${PROJECT_BINARY_DIR})
   target_link_libraries(revsrv os log eloop domain reverse_grpc_proto GRPC::grpc++_reflection)
+
+  # link time optimization
+  set_target_properties(revclient revsrv PROPERTIES INTERPROCEDURAL_OPTIMIZATION TRUE)
 endif ()
 
 add_executable(edgesec edgesec.c)
 target_include_directories(edgesec PRIVATE ${PROJECT_BINARY_DIR} ${LIBOPENSSL_INCLUDE_PATH})
 target_link_libraries(edgesec eloop config engine minIni os hashmap)
+# link time optimization
+set_target_properties(edgesec PROPERTIES INTERPROCEDURAL_OPTIMIZATION TRUE)


### PR DESCRIPTION
It should make them faster and more optimized, since we are statically linking a lot of libraries together.

From what I noticed from the binary files, it makes some of them about 1 kB-ish larger, I'm guessing there is some loop unrolling or similar going on.

The only risk is that now linking the `.exes` might use up too much RAM, but since they're pretty small, it should be okay.