### PR TITLE
Create `edgesec-mdnsf.deb` debian file

### DIFF
--- a/CMakeModules/install.cmake
+++ b/CMakeModules/install.cmake
@@ -1,6 +1,6 @@
 include(GNUInstallDirs) # automagically setup install dir locations
 install(
-  TARGETS edgesec capsrv
+  TARGETS edgesec capsrv mdnsf
   RUNTIME
 )
 if (BUILD_REST_SERVER AND LIBMICROHTTPD_LIB)

--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,9 @@
+edgesec (0.9.9-alpha5) UNRELEASED; urgency=low
+
+  * Add `edgesec-mdnsf` package that creates the `mdnsf` executable.
+
+ -- Alois Klink <alois@nquiringminds.com>  Tue, 30 Nov 2021 10:04:50 +0000
+
 edgesec (0.9.9-alpha4) UNRELEASED; urgency=low
 
   * Use `libmnl0` instead of building our own libmnl.

--- a/debian/control
+++ b/debian/control
@@ -26,6 +26,7 @@ Depends: libedgesec (= ${binary:Version}),
     edgesec-capsrv (= ${binary:Version}),
     edgesec-revclient (= ${binary:Version}),
     edgesec-restsrv (= ${binary:Version}),
+    edgesec-mdnsf (= ${binary:Version}),
     ${shlibs:Depends},
     ${misc:Depends},
     dnsmasq, jq
@@ -84,6 +85,18 @@ Description: NquiringMinds EDGESEC RESTful server.
  Provides a HTTP/HTTPS RESTful Server that can
  be used to communicate with the `edgesec` process,
  as it only provides an Unix Domain Socket.
+
+Package: edgesec-mdnsf
+Architecture: any
+Multi-Arch: foreign
+Depends: libedgesec (= ${binary:Version}),
+    edgesec-common (= ${source:Version}),
+    ${shlibs:Depends},
+    ${misc:Depends}
+Description: NquiringMinds EDGESEC mdns forwarder.
+ Forwards and captures EDGESEC mDNS network traffic for each connected device.
+ The resulting captured mDNS traffic is forwarded across subnets and bridge
+ commands are issued accordingly.
 
 Package: edgesec-capsrv
 Architecture: any

--- a/debian/edgesec-mdnsf.install
+++ b/debian/edgesec-mdnsf.install
@@ -1,0 +1,1 @@
+usr/bin/mdnsf


### PR DESCRIPTION
Not tested yet on a Raspberry Pi, so that's still todo.

## Todo

- [ ] Test that `mdnsf` actually runs on a Raspberry Pi