### PR TITLE
Fix docusuarus baseUrl

### DIFF
--- a/docs/docusaurus/docusaurus.config.js
+++ b/docs/docusaurus/docusaurus.config.js
@@ -2,7 +2,7 @@ module.exports = {
   title: "EDGESec",
   tagline: "Secure IoT router implementation",
   url: "https://nqminds.github.io",
-  baseUrl: "/", // usually your repo name, must contain a trailing and starting slash
+  baseUrl: "/EDGESec/", // usually your repo name, must contain a trailing and starting slash
   favicon: "img/logo.svg",
   organizationName: "nqmcyber", // Usually your GitHub org/user name.
   projectName: "edgesec", // Usually your repo name.


### PR DESCRIPTION
On GitHub Pages, this documentation will be hosted on:
https://nqminds.github.io/EDGESec/

This means we need to set `baseUrl` to `/EDGESec/`