### PR TITLE
Use C11 to compile C code

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -146,6 +146,10 @@ set(CMAKE_CXX_STANDARD 11)
 set(CMAKE_CXX_STANDARD_REQUIRED ON)
 # use -std=c++11 rather than -std=gnu++11
 set(CMAKE_CXX_EXTENSIONS OFF)
+set(CMAKE_C_STANDARD 11)
+set(CMAKE_C_STANDARD_REQUIRED ON)
+# hostapd and libnetlink relies on GNU specific features, like strncasecmp
+set(CMAKE_C_EXTENSIONS ON)
 
 # The edgesec version number.
 set(EDGESEC_VERSION_MAJOR 0)


### PR DESCRIPTION
Modern versions of the GCC compiler default to using `-std=gnu11`, but it's good to explicitly state this in the CMakeLists.txt file, so that an error will be thrown if the compiler is too old to support C11.

We explicitly allow GNU C compiler extensions, since we use `strncasecmp` in `hostapd` and `libnetlink`, which isn't part of standard C. (side-note, this means that compiling with LLVM/clang probably won't work)