### PR TITLE
Split error logging into `log_errno()` and `log_error()`

### DIFF
--- a/lib/hostap/src/radius/radius_server.c
+++ b/lib/hostap/src/radius/radius_server.c
@@ -1942,7 +1942,7 @@ static int radius_server_open_socket(int port)
 
 	s = socket(PF_INET, SOCK_DGRAM, 0);
 	if (s < 0) {
-		log_err("RADIUS: socket");
+		log_errno("RADIUS: socket");
 		return -1;
 	}
 

--- a/lib/hostap/src/radius/radius_server.c
+++ b/lib/hostap/src/radius/radius_server.c
@@ -1952,7 +1952,7 @@ static int radius_server_open_socket(int port)
 	addr.sin_family = AF_INET;
 	addr.sin_port = htons(port);
 	if (bind(s, (struct sockaddr *) &addr, sizeof(addr)) < 0) {
-		log_trace("RADIUS: bind");
+		log_errno("RADIUS: bind");
 		close(s);
 		return -1;
 	}

--- a/src/ap/ap_service.c
+++ b/src/ap/ap_service.c
@@ -18,11 +18,11 @@
  ****************************************************************************/
 
 /**
- * @file hostapd_service.c 
- * @author Alexandru Mereacre 
+ * @file hostapd_service.c
+ * @author Alexandru Mereacre
  * @brief File containing the implementation of the hostapd service.
- * 
- * Defines the functions to start and stop the acces point service (AP). It also 
+ *
+ * Defines the functions to start and stop the acces point service (AP). It also
  * defines auxiliary commands to manage the acces control list for stations
  * connected to the AP.
  */
@@ -80,7 +80,7 @@ int denyacl_ap_command(struct apconf *hconf, char *cmd, char *mac_addr)
   }
 
   if ((buffer = os_zalloc(strlen(cmd) + strlen(mac_addr) + 1)) == NULL) {
-    log_err("os_zalloc");
+    log_errno("os_zalloc");
     return -1;
   }
 
@@ -136,7 +136,7 @@ int check_sta_ap_command(struct apconf *hconf, char *mac_addr)
   }
 
   if ((buffer = os_zalloc(strlen(STA_AP_COMMAND) + strlen(mac_addr) + 1)) == NULL) {
-    log_err("os_zalloc");
+    log_errno("os_zalloc");
     return -1;
   }
 
@@ -205,13 +205,13 @@ void ap_sock_handler(int sock, void *eloop_ctx, void *sock_ctx)
   ap_service_fn fn = (ap_service_fn) eloop_ctx;
 
   if (ioctl(sock, FIONREAD, &bytes_available) == -1) {
-    log_err("ioctl");
+    log_errno("ioctl");
     return;
   }
 
   rec_data = os_zalloc(bytes_available + 1);
   if (rec_data == NULL) {
-    log_err("os_zalloc");
+    log_errno("os_zalloc");
     return;
   }
 

--- a/src/ap/hostapd.c
+++ b/src/ap/hostapd.c
@@ -19,9 +19,9 @@
 
 /**
  * @file hostapd.c
- * @author Alexandru Mereacre 
+ * @author Alexandru Mereacre
  * @brief File containing the implementation of hostapd config generation utilities.
- * 
+ *
  * Defines function that generate the hostapd daemon configuration file and
  * manages (execute, kill and signal) the hostapd process.
  */
@@ -65,14 +65,14 @@ int generate_vlan_conf(char *vlan_file, char *interface)
   int stat = unlink(vlan_file);
 
   if (stat == -1 && errno != ENOENT) {
-    log_err("unlink");
+    log_errno("unlink");
     return -1;
   }
 
   FILE *fp = fopen(vlan_file, "a+");
 
   if (fp == NULL) {
-    log_err("fopen");
+    log_errno("fopen");
     return -1;
   }
 
@@ -136,14 +136,14 @@ int generate_hostapd_conf(struct apconf *hconf, struct radius_conf *rconf)
   int stat = unlink(hconf->ap_file_path);
 
   if (stat == -1 && errno != ENOENT) {
-    log_err("unlink");
+    log_errno("unlink");
     return -1;
   }
 
   FILE *fp = fopen(hconf->ap_file_path, "a+");
 
   if (fp == NULL) {
-    log_err("fopen");
+    log_errno("fopen");
     return -1;
   }
 

--- a/src/capture/capture_cleaner.c
+++ b/src/capture/capture_cleaner.c
@@ -18,12 +18,12 @@
  ****************************************************************************/
 
 /**
- * @file capture_cleaner.c 
- * @author Alexandru Mereacre 
+ * @file capture_cleaner.c
+ * @author Alexandru Mereacre
  * @brief File containing the implementation of the capture cleaner service structures.
- * 
+ *
  * Defines the start function for the capturte cleaner service, which
- * removes the capture files from the database folder when it 
+ * removes the capture files from the database folder when it
  * reaches a given size specified in the capture_conf structure. The
  * store size is give by the parameter capture_store_size in Kb.
  */
@@ -55,9 +55,9 @@ int clean_capture(struct cleaner_context *context)
   struct pcap_file_meta *p = NULL;
   UT_array *pcap_meta_arr = NULL;
   uint64_t timestamp = context->low_timestamp, lt;
-  char *path; 
+  char *path;
   utarray_new(pcap_meta_arr, &pcap_file_meta_icd);
-  
+
   while(timestamp <= context->next_timestamp) {
     lt = timestamp;
     if (get_pcap_meta_array(context->pcap_db, timestamp, CLEANER_GROUP_INTERVAL, pcap_meta_arr) < 0) {
@@ -68,12 +68,12 @@ int clean_capture(struct cleaner_context *context)
 
     while((p = (struct pcap_file_meta *) utarray_next(pcap_meta_arr, p)) != NULL) {
       if ((path = construct_path(context->pcap_path, p->name)) == NULL) {
-        log_err("os_malloc");
+        log_errno("os_malloc");
       }
 
       log_trace("deleting %s at timestamp=%llu", path, p->timestamp);
       if (remove(path) < 0) {
-        log_err("remove");
+        log_errno("remove");
       }
 
       if (path != NULL) {
@@ -90,7 +90,7 @@ int clean_capture(struct cleaner_context *context)
     if (delete_pcap_entries(context->pcap_db, lt, timestamp) < 0) {
       log_trace("delete_pcap_entries fail");
       utarray_free(pcap_meta_arr);
-      return -1;    
+      return -1;
     }
   }
 
@@ -119,7 +119,7 @@ void eloop_cleaner_handler(void *eloop_ctx, void *user_ctx)
     context->low_timestamp = lt;
     context->store_sum = caplen;
   }
-  
+
   ht = lt;
 
   if (lt) {
@@ -188,7 +188,7 @@ int start_capture_cleaner(struct capture_conf *config)
   if (open_sqlite_pcap_db(pcap_db_path, (sqlite3**)&context.pcap_db) < 0) {
     log_trace("open_sqlite_pcap_db fail");
     os_free(pcap_db_path);
-    return -1;  
+    return -1;
   }
   os_free(pcap_db_path);
 

--- a/src/capture/capture_config.c
+++ b/src/capture/capture_config.c
@@ -19,11 +19,11 @@
 
 /**
  * @file capture_config.c
- * @author Alexandru Mereacre 
+ * @author Alexandru Mereacre
  * @brief File containing the implementation of the capture config structures.
- * 
- * Defines the function to generate the config parameters for the capture 
- * service. It also defines all the metadata and database schema for the 
+ *
+ * Defines the function to generate the config parameters for the capture
+ * service. It also defines all the metadata and database schema for the
  * captured packets.
  */
 
@@ -58,7 +58,7 @@ long get_opt_num(char *num)
 {
   if (!is_number(num))
     return -1;
-  
+
   return strtol(num, NULL, 10);
 }
 
@@ -188,7 +188,7 @@ int capture_opt2config(char key, char *value, struct capture_conf *config)
         return -1;
       }
       if (UINT32_MAX != ULONG_MAX && conversion > UINT32_MAX) {
-        log_err("Overflow, byte size %s exceeds uint32", value);
+        log_errno("Overflow, byte size %s exceeds uint32", value);
         return -1;
       }
 
@@ -276,7 +276,7 @@ char** capture_config2opt(struct capture_conf *config)
 
     opt_str[idx] = os_malloc(MAX_ANALYSER_NAME_SIZE);
     os_strlcpy(opt_str[idx], config->analyser, MAX_ANALYSER_NAME_SIZE);
-    idx ++; 
+    idx ++;
   }
 
   //immediate, -e

--- a/src/capture/default_analyser.c
+++ b/src/capture/default_analyser.c
@@ -18,7 +18,7 @@
  ****************************************************************************/
 /**
  * @file default_analyser.c
- * @author Alexandru Mereacre 
+ * @author Alexandru Mereacre
  * @brief File containing the implementation of the default analyser service.
  */
 
@@ -163,7 +163,7 @@ void send_domain_data(struct capture_context *context, char *data)
   send_len += strlen(data) + 1;
 
   if ((buf = os_zalloc(send_len)) == NULL) {
-    log_err("os_zalloc");
+    log_errno("os_zalloc");
     return;
   }
 
@@ -299,7 +299,7 @@ int start_default_analyser(struct capture_conf *config)
     os_free(header_db_path);
     return -1;
   }
-  
+
   if ((context.domain_client = create_domain_client(NULL)) < 0) {
     log_trace("create_domain_client fail");
     os_free(header_db_path);

--- a/src/capture/mdns_decoder.c
+++ b/src/capture/mdns_decoder.c
@@ -18,8 +18,8 @@
  ****************************************************************************/
 
 /**
- * @file mdns_decoder.c 
- * @author Alexandru Mereacre 
+ * @file mdns_decoder.c
+ * @author Alexandru Mereacre
  * @brief File containing the implementation of the mdns packet decoder utilities.
  */
 
@@ -61,7 +61,7 @@ int copy_mdns_query_name(uint8_t *start, char **out)
   }
 
   if ((qname = os_zalloc(start[0] + 2)) == NULL) {
-    log_err("os_zalloc");
+    log_errno("os_zalloc");
     return -1;
   }
 
@@ -271,7 +271,7 @@ bool decode_mdns_packet(struct capture_packet *cpac)
   //     os_free(qname);
   //   }
   // }
-  
+
   log_trace("mDNS id=%d flags=0x%x nqueries=%d nanswers=%d nauth=%d nother=%d qname=%s",
     cpac->mdnss.tid, cpac->mdnss.flags, cpac->mdnss.nqueries, cpac->mdnss.nanswers,
     cpac->mdnss.nauth, cpac->mdnss.nother, cpac->mdnss.qname);

--- a/src/capture/packet_decoder.c
+++ b/src/capture/packet_decoder.c
@@ -19,7 +19,7 @@
 
 /**
  * @file packet_decoder.c
- * @author Alexandru Mereacre 
+ * @author Alexandru Mereacre
  * @brief File containing the implementation of the packet decoder utilities.
  */
 
@@ -377,7 +377,7 @@ int extract_packets(char *ltype, const struct pcap_pkthdr *header, const uint8_t
   if ((count = decode_packet(header, packet, &cpac)) > 0) {
     if (cpac.ethh != NULL) {
       if ((tp.packet = os_malloc(sizeof(struct eth_schema))) == NULL) {
-        log_err("os_malloc");
+        log_errno("os_malloc");
         return -1;
       }
       os_memcpy(tp.packet, &cpac.eths, sizeof(struct eth_schema));
@@ -386,7 +386,7 @@ int extract_packets(char *ltype, const struct pcap_pkthdr *header, const uint8_t
     }
     if (cpac.arph != NULL) {
       if ((tp.packet = os_malloc(sizeof(struct arp_schema))) == NULL) {
-        log_err("os_malloc");
+        log_errno("os_malloc");
         return -1;
       }
       os_memcpy(tp.packet, &cpac.arps, sizeof(struct arp_schema));
@@ -395,7 +395,7 @@ int extract_packets(char *ltype, const struct pcap_pkthdr *header, const uint8_t
     }
     if (cpac.ip4h != NULL) {
       if ((tp.packet = os_malloc(sizeof(struct ip4_schema))) == NULL) {
-        log_err("os_malloc");
+        log_errno("os_malloc");
         return -1;
       }
       os_memcpy(tp.packet, &cpac.ip4s, sizeof(struct ip4_schema));
@@ -404,7 +404,7 @@ int extract_packets(char *ltype, const struct pcap_pkthdr *header, const uint8_t
     };
     if (cpac.ip6h != NULL) {
       if ((tp.packet = os_malloc(sizeof(struct ip6_schema))) == NULL) {
-        log_err("os_malloc");
+        log_errno("os_malloc");
         return -1;
       }
       os_memcpy(tp.packet, &cpac.ip6s, sizeof(struct ip6_schema));
@@ -413,7 +413,7 @@ int extract_packets(char *ltype, const struct pcap_pkthdr *header, const uint8_t
     };
     if (cpac.tcph != NULL) {
       if ((tp.packet = os_malloc(sizeof(struct tcp_schema))) == NULL) {
-        log_err("os_malloc");
+        log_errno("os_malloc");
         return -1;
       }
       os_memcpy(tp.packet, &cpac.tcps, sizeof(struct tcp_schema));
@@ -422,7 +422,7 @@ int extract_packets(char *ltype, const struct pcap_pkthdr *header, const uint8_t
     };
     if (cpac.udph != NULL) {
       if ((tp.packet = os_malloc(sizeof(struct udp_schema))) == NULL) {
-        log_err("os_malloc");
+        log_errno("os_malloc");
         return -1;
       }
       os_memcpy(tp.packet, &cpac.udps, sizeof(struct udp_schema));
@@ -431,7 +431,7 @@ int extract_packets(char *ltype, const struct pcap_pkthdr *header, const uint8_t
     };
     if (cpac.icmp4h != NULL) {
       if ((tp.packet = os_malloc(sizeof(struct icmp4_schema))) == NULL) {
-        log_err("os_malloc");
+        log_errno("os_malloc");
         return -1;
       }
       os_memcpy(tp.packet, &cpac.icmp4s, sizeof(struct icmp4_schema));
@@ -440,7 +440,7 @@ int extract_packets(char *ltype, const struct pcap_pkthdr *header, const uint8_t
     };
     if (cpac.icmp6h != NULL) {
       if ((tp.packet = os_malloc(sizeof(struct icmp6_schema))) == NULL) {
-        log_err("os_malloc");
+        log_errno("os_malloc");
         return -1;
       }
       os_memcpy(tp.packet, &cpac.icmp6s, sizeof(struct icmp6_schema));
@@ -449,7 +449,7 @@ int extract_packets(char *ltype, const struct pcap_pkthdr *header, const uint8_t
     };
     if (cpac.dnsh != NULL) {
       if ((tp.packet = os_malloc(sizeof(struct dns_schema))) == NULL) {
-        log_err("os_malloc");
+        log_errno("os_malloc");
         return -1;
       }
       os_memcpy(tp.packet, &cpac.dnss, sizeof(struct dns_schema));
@@ -458,7 +458,7 @@ int extract_packets(char *ltype, const struct pcap_pkthdr *header, const uint8_t
     };
     if (cpac.mdnsh != NULL) {
       if ((tp.packet = os_malloc(sizeof(struct mdns_schema))) == NULL) {
-        log_err("os_malloc");
+        log_errno("os_malloc");
         return -1;
       }
       os_memcpy(tp.packet, &cpac.mdnss, sizeof(struct mdns_schema));
@@ -467,7 +467,7 @@ int extract_packets(char *ltype, const struct pcap_pkthdr *header, const uint8_t
     };
     if (cpac.dhcph != NULL) {
       if ((tp.packet = os_malloc(sizeof(struct dhcp_schema))) == NULL) {
-        log_err("os_malloc");
+        log_errno("os_malloc");
         return -1;
       }
       os_memcpy(tp.packet, &cpac.dhcps, sizeof(struct dhcp_schema));

--- a/src/capture/packet_queue.c
+++ b/src/capture/packet_queue.c
@@ -19,7 +19,7 @@
 
 /**
  * @file packet_queue.c
- * @author Alexandru Mereacre 
+ * @author Alexandru Mereacre
  * @brief File containing the implementation of the packet queue utilities.
  */
 
@@ -39,7 +39,7 @@ struct packet_queue* init_packet_queue(void)
   queue = os_zalloc(sizeof(*queue));
 
   if (queue == NULL) {
-    log_err("os_zalloc");
+    log_errno("os_zalloc");
     return NULL;
   }
 
@@ -56,7 +56,7 @@ struct packet_queue* push_packet_queue(struct packet_queue* queue, struct tuple_
     log_debug("queue param is NULL");
     return NULL;
   }
-  
+
   if ((el = init_packet_queue()) == NULL) {
     log_debug("init_packet_queue fail");
     return NULL;

--- a/src/capture/pcap_queue.c
+++ b/src/capture/pcap_queue.c
@@ -19,7 +19,7 @@
 
 /**
  * @file pcap_queue.c
- * @author Alexandru Mereacre 
+ * @author Alexandru Mereacre
  * @brief File containing the implementation of the pcap queue utilities.
  */
 
@@ -39,7 +39,7 @@ struct pcap_queue* init_pcap_queue(void)
   queue = os_zalloc(sizeof(*queue));
 
   if (queue == NULL) {
-    log_err("os_zalloc");
+    log_errno("os_zalloc");
     return NULL;
   }
 
@@ -75,7 +75,7 @@ struct pcap_queue* push_pcap_queue(struct pcap_queue* queue, struct pcap_pkthdr 
   os_memcpy(&el->header, header, sizeof(struct pcap_pkthdr));
   el->packet = os_malloc(header->caplen);
   if (el->packet ==  NULL) {
-    log_err("os_malloc");
+    log_errno("os_malloc");
     return NULL;
   }
 

--- a/src/config.c
+++ b/src/config.c
@@ -18,8 +18,8 @@
  ****************************************************************************/
 
 /**
- * @file config.c 
- * @author Alexandru Mereacre 
+ * @file config.c
+ * @author Alexandru Mereacre
  * @brief File containing the implementation of the app configuration utilities.
  */
 
@@ -393,7 +393,7 @@ bool load_ap_conf(const char *filename, struct app_config *config)
   ini_gets("ap", "rsnPairwise", "CCMP", value, INI_BUFFERSIZE, filename);
   os_strlcpy(config->hconfig.rsn_pairwise, value, AP_RSN_PAIRWISE_LEN);
   os_free(value);
-  
+
   // Load ap ctrlInterface
   value = os_malloc(INI_BUFFERSIZE);
   ini_gets("ap", "ctrlInterface", "/var/run/hostapd", value, INI_BUFFERSIZE, filename);
@@ -822,7 +822,7 @@ bool load_app_config(const char *filename, struct app_config *config)
   FILE *fp = fopen(filename, "rb");
 
   if (fp == NULL) {
-    log_err("Couldn't open %s config file.\n", filename);
+    log_errno("Couldn't open %s config file.\n", filename);
     return false;
   }
   fclose(fp);
@@ -913,7 +913,7 @@ void free_app_config(struct app_config *config)
   if (config->dhcp_config.config_dhcpinfo_array != NULL) {
     utarray_free(config->dhcp_config.config_dhcpinfo_array);
   }
-  
+
   if (config->dns_config.server_array != NULL) {
     utarray_free(config->dns_config.server_array);
   }

--- a/src/crypt/crypt_service.c
+++ b/src/crypt/crypt_service.c
@@ -19,7 +19,7 @@
 
 /**
  * @file crypt_service.c
- * @author Alexandru Mereacre 
+ * @author Alexandru Mereacre
  * @brief File containing the implementation of crypt service configuration utilities.
  */
 
@@ -61,7 +61,7 @@ struct secrets_row* prepare_secret_entry(char *key_id, uint8_t *key, int key_siz
   struct secrets_row *row = os_zalloc(sizeof(struct secrets_row));
 
   if (row == NULL) {
-    log_err("os_zalloc");
+    log_errno("os_zalloc");
     return NULL;
   }
 
@@ -89,7 +89,7 @@ int extract_secret_entry(struct secrets_row* row, uint8_t *key, int *key_size,
 {
   size_t out_len;
   char *buf;
-  
+
   if (row->value == NULL && key_size != NULL) {
     *key_size = 0;
   } else if (row->value != NULL && key != NULL && key_size != NULL) {
@@ -193,7 +193,7 @@ struct secrets_row * generate_user_crypto_key_entry(char *key_id, uint8_t *user_
   int enc_crypto_key_size;
   if (!crypto_gensalt(user_key_salt, SALT_SIZE)) {
     log_trace("crypto_gensalt fail");
-    return NULL;        
+    return NULL;
   }
 
   // Generate the enc/dec key using the user supplied key
@@ -238,7 +238,7 @@ struct crypt_context* load_crypt_service(char *crypt_db_path, char *key_id,
 
   context = (struct crypt_context*) os_zalloc(sizeof(struct crypt_context));
   if (context == NULL) {
-    log_err("os_zalloc");
+    log_errno("os_zalloc");
     free_sqlite_crypt_db(db);
     return NULL;
   }
@@ -268,7 +268,7 @@ struct crypt_context* load_crypt_service(char *crypt_db_path, char *key_id,
       }
 
       log_debug("Using user supplied secret");
-      
+
       if ((row_secret = generate_user_crypto_key_entry(key_id, user_secret, user_secret_size,
                                                     context->crypto_key)) == NULL)
       {
@@ -374,7 +374,7 @@ struct crypt_context* load_crypt_service(char *crypt_db_path, char *key_id,
       os_free(crypto_buf);
     }
   }
-  
+
   free_sqlite_secrets_row(row_secret);
   return context;
 }
@@ -409,7 +409,7 @@ struct crypt_pair* get_crypt_pair(struct crypt_context *ctx, char *key)
 
   pair = (struct crypt_pair *) os_malloc(sizeof(struct crypt_pair));
   if (pair == NULL) {
-    log_err("os_malloc");
+    log_errno("os_malloc");
     return NULL;
   }
 
@@ -434,7 +434,7 @@ struct crypt_pair* get_crypt_pair(struct crypt_context *ctx, char *key)
 
     pair->value = os_malloc(value_size);
     if (pair->value == NULL) {
-      log_err("os_malloc");
+      log_errno("os_malloc");
       os_free(iv);
       os_free(enc_value);
       free_crypt_pair(pair);
@@ -495,7 +495,7 @@ int put_crypt_pair(struct crypt_context *ctx, struct crypt_pair *pair)
     enc_value = os_malloc(pair->value_size + AES_BLOCK_SIZE);
 
     if (enc_value == NULL) {
-      log_err("os_malloc");
+      log_errno("os_malloc");
       return -1;
     }
 

--- a/src/crypt/generic_hsm_driver.c
+++ b/src/crypt/generic_hsm_driver.c
@@ -19,7 +19,7 @@
 
 /**
  * @file generic_hsm_driver.c
- * @author Alexandru Mereacre 
+ * @author Alexandru Mereacre
  * @brief File containing the implementation of generic HSM driver configuration utilities.
  */
 #include <sys/types.h>
@@ -39,7 +39,7 @@ struct hsm_context* init_hsm(void)
   struct hsm_context* context = os_zalloc(sizeof(struct hsm_context));
 
   if (context == NULL) {
-    log_err("os_zalloc");
+    log_errno("os_zalloc");
     return NULL;
   }
 

--- a/src/crypt/zymkey4_driver.c
+++ b/src/crypt/zymkey4_driver.c
@@ -19,7 +19,7 @@
 
 /**
  * @file zymkey4_driver.c
- * @author Alexandru Mereacre 
+ * @author Alexandru Mereacre
  * @brief File containing the implementation of zymkey4 driver configuration utilities.
  */
 
@@ -34,7 +34,7 @@ zkCTX* init_zymkey4(void)
 {
   zkCTX* context = os_zalloc(sizeof(zkCTX));
   if (context == NULL) {
-    log_err("os_zalloc");
+    log_errno("os_zalloc");
     return NULL;
   }
 
@@ -66,7 +66,7 @@ int generate_zymkey4_key(zkCTX *ctx, uint8_t *key, size_t key_size)
     log_trace("zkGetRandBytes fail");
     return -1;
   }
-  
+
   if (rdata == NULL) {
     log_trace("zkGetRandBytes fail");
     return -1;

--- a/src/dhcp/dnsmasq.c
+++ b/src/dhcp/dnsmasq.c
@@ -19,7 +19,7 @@
 
 /**
  * @file dnsmasq.c
- * @author Alexandru Mereacre 
+ * @author Alexandru Mereacre
  * @brief File containing the implementation of dnsmasq service configuration utilities.
  */
 
@@ -162,14 +162,14 @@ int generate_dnsmasq_conf(struct dhcp_conf *dconf, UT_array *dns_server_array)
   int stat = unlink(dconf->dhcp_conf_path);
 
   if (stat == -1 && errno != ENOENT) {
-    log_err("unlink");
+    log_errno("unlink");
     return -1;
   }
 
   FILE *fp = fopen(dconf->dhcp_conf_path, "a+");
 
   if (fp == NULL) {
-    log_err("fopen");
+    log_errno("fopen");
     return -1;
   }
 
@@ -200,14 +200,14 @@ int generate_dnsmasq_script(char *dhcp_script_path, char *domain_server_path)
   int stat = unlink(dhcp_script_path);
 
   if (stat == -1 && errno != ENOENT) {
-    log_err("unlink");
+    log_errno("unlink");
     return -1;
   }
 
   FILE *fp = fopen(dhcp_script_path, "a+");
 
   if (fp == NULL) {
-    log_err("fopen");
+    log_errno("fopen");
     return -1;
   }
 
@@ -218,7 +218,7 @@ int generate_dnsmasq_script(char *dhcp_script_path, char *domain_server_path)
   int fd = fileno(fp);
 
   if (fd == -1) {
-    log_err("fileno");
+    log_errno("fileno");
     fclose(fp);
     return -1;
   }
@@ -255,7 +255,7 @@ char* get_dnsmasq_args(char *dnsmasq_bin_path, char *dnsmasq_conf_path, char *ar
   char *conf_arg = os_malloc(sizeof(char)*(MAX_OS_PATH_LEN + strlen(DNSMASQ_CONF_FILE_OPTION) + 1));
 
   if (conf_arg == NULL) {
-    log_err("os_malloc");
+    log_errno("os_malloc");
     return NULL;
   }
 
@@ -468,7 +468,7 @@ int clear_dhcp_lease_entry(char *mac_addr, char *dhcp_leasefile_path)
   }
 
   if ((fp = fopen(dhcp_leasefile_path, "w+")) == NULL) {
-    log_err("fopen");
+    log_errno("fopen");
     os_free(out);
     return -1;
   }

--- a/src/dns/command_mapper.c
+++ b/src/dns/command_mapper.c
@@ -18,8 +18,8 @@
  ****************************************************************************/
 
 /**
- * @file command_mapper.c 
- * @author Alexandru Mereacre 
+ * @file command_mapper.c
+ * @author Alexandru Mereacre
  * @brief File containing the implementation of the command mapper.
  */
 
@@ -61,7 +61,7 @@ int put_command_mapper(hmap_command_conn **hmap, char *command)
   if (s == NULL) {
     s = (hmap_command_conn *) os_malloc(sizeof(hmap_command_conn));
 	if (s == NULL) {
-	  log_err("os_malloc");
+	  log_errno("os_malloc");
       return -1;
 	}
 
@@ -93,6 +93,6 @@ int check_command_mapper(hmap_command_conn **hmap, char *command)
   hash_key = md_hash(command, strlen(command));
 
   HASH_FIND(hh, *hmap, &hash_key, sizeof(uint32_t), s);
-    
+
   return (s != NULL);
 }

--- a/src/dns/mcast.c
+++ b/src/dns/mcast.c
@@ -19,7 +19,7 @@
 
 /**
  * @file mcast.c
- * @author Alexandru Mereacre 
+ * @author Alexandru Mereacre
  * @brief File containing the implementation of mDNS utils.
  */
 
@@ -74,7 +74,7 @@ int join_mcast(int fd, const struct sockaddr_storage *sa, socklen_t sa_len, uint
   (void) ifreq;
   (void) mreq4;
   if (setsockopt(fd, level, MCAST_JOIN_GROUP, &req, sizeof(struct group_req)) < 0) {
-    log_err("setsockopt");
+    log_errno("setsockopt");
     return -1;
   }
 #else
@@ -86,7 +86,7 @@ int join_mcast(int fd, const struct sockaddr_storage *sa, socklen_t sa_len, uint
       mreq6.ipv6mr_interface = ifindex;
       memcpy(&mreq6.ipv6mr_multiaddr, &((struct sockaddr_in6 *) sa)->sin6_addr, sizeof(struct in6_addr));
       if (setsockopt(fd, IPPROTO_IPV6, IPV6_JOIN_GROUP, &mreq6, sizeof(mreq6)) < 0) {
-        log_err("setsockopt")
+        log_errno("setsockopt")
         return -1;
       }
       break;
@@ -94,12 +94,12 @@ int join_mcast(int fd, const struct sockaddr_storage *sa, socklen_t sa_len, uint
     case AF_INET: {
       if (ifindex > 0) {
         if (if_indextoname(ifindex, ifreq.ifr_name) == NULL) {
-          log_err("if_indextoname")
+          log_errno("if_indextoname")
           return -1;
         }
 
         if (ioctl(fd, SIOCGIFADDR, &ifreq) == -1) {
-          log_err("ioctl")
+          log_errno("ioctl")
           return -1;
         }
 
@@ -110,7 +110,7 @@ int join_mcast(int fd, const struct sockaddr_storage *sa, socklen_t sa_len, uint
       }
       memcpy(&mreq4.imr_multiaddr, &((struct sockaddr_in *) sa)->sin_addr, sizeof(struct in_addr));
       if (setsockopt(fd, IPPROTO_IP, IP_ADD_MEMBERSHIP, &mreq4, sizeof(mreq4)) < 0) {
-        log_err("setsockopt")
+        log_errno("setsockopt")
         return -1;
       }
       break;
@@ -133,37 +133,37 @@ int create_recv_mcast(const struct sockaddr_storage *sa, socklen_t sa_len, uint3
   switch (sa->ss_family) {
     case AF_INET6:
       if ((fd = socket(AF_INET6, SOCK_DGRAM, 0)) < 0) {
-        log_err("socket");
+        log_errno("socket");
         close(fd);
         return -1;
       }
 
       if (setsockopt(fd, IPPROTO_IPV6, IPV6_V6ONLY, &on, sizeof(on)) < 0) {
-        log_err("setsockopt");
+        log_errno("setsockopt");
         close(fd);
         return -1;
       }
 
       if (setsockopt(fd, IPPROTO_IPV6, IPV6_RECVPKTINFO, &on, sizeof(on)) < 0) {
-        log_err("setsockopt");
+        log_errno("setsockopt");
         close(fd);
         return -1;
       }
 #if defined(SO_BINDTODEVICE)
       if (if_indextoname(ifindex, ifr.ifr_ifrn.ifrn_name) == NULL) {
-        log_err("if_indextoname");
+        log_errno("if_indextoname");
         close(fd);
         return -1;
       }
 
       if (setsockopt(fd, SOL_SOCKET, SO_BINDTODEVICE, &ifr, sizeof(ifr)) < 0) {
-        log_err("setsockopt");
+        log_errno("setsockopt");
         close(fd);
         return -1;
       }
 #elif defined(IPV6_BOUND_IF)
       if (setsockopt(fd, IPPROTO_IPV6, IPV6_BOUND_IF, &ifindex, sizeof(ifindex)) < 0) {
-        log_err("setsockopt");
+        log_errno("setsockopt");
         close(fd);
         return -1;
       }
@@ -171,37 +171,37 @@ int create_recv_mcast(const struct sockaddr_storage *sa, socklen_t sa_len, uint3
         break;
     case AF_INET:
       if ((fd = socket(AF_INET, SOCK_DGRAM, 0)) < 0) {
-        log_err("socket");
+        log_errno("socket");
         return -1;
       }
 #if defined(IP_PKTINFO)
       if (setsockopt(fd, IPPROTO_IP, IP_PKTINFO, &on, sizeof(on)) < 0) {
-        log_err("setsockopt");
+        log_errno("setsockopt");
         close(fd);
         return -1;
       }
 #elif defined(IP_RECVDSTADDR)
       if (setsockopt(fd, IPPROTO_IP, IP_RECVDSTADDR, &on, sizeof(on)) < 0) {
-        log_err("setsockopt");
+        log_errno("setsockopt");
         close(fd);
         return -1;
       }
 #endif
 #if defined(SO_BINDTODEVICE)
       if (if_indextoname(ifindex, ifr.ifr_ifrn.ifrn_name) == NULL) {
-        log_err("if_indextoname");
+        log_errno("if_indextoname");
         close(fd);
         return -1;
       }
 
       if (setsockopt(fd, SOL_SOCKET, SO_BINDTODEVICE, &ifr, sizeof(ifr)) < 0) {
-        log_err("setsockopt");
+        log_errno("setsockopt");
         close(fd);
         return -1;
       }
 #elif defined(IP_BOUND_IF)
       if (setsockopt(fd, IPPROTO_IP, IP_BOUND_IF, &ifindex, sizeof(ifindex)) < 0) {
-        log_err("setsockopt");
+        log_errno("setsockopt");
         close(fd);
         return -1;
       }
@@ -213,31 +213,31 @@ int create_recv_mcast(const struct sockaddr_storage *sa, socklen_t sa_len, uint3
   }
 
   if (setsockopt(fd, SOL_SOCKET, SO_REUSEADDR, &on, sizeof(on)) < 0) {
-    log_err("setsockopt");
+    log_errno("setsockopt");
     close(fd);
     return -1;
   }
 #if defined(SO_REUSEPORT) && !defined(__linux__)
   if (setsockopt(fd, SOL_SOCKET, SO_REUSEPORT, &on, sizeof(on)) < 0) {
-    log_err("setsockopt");
+    log_errno("setsockopt");
     close(fd);
     return -1;
   }
 #endif
   if ((flags = fcntl(fd, F_GETFL, 0)) < 0) {
-    log_err("fcntl");
+    log_errno("fcntl");
     close(fd);
     return -1;
   }
 
   if (fcntl(fd, F_SETFL, flags | O_NONBLOCK) < 0) {
-    log_err("fcntl");
+    log_errno("fcntl");
     close(fd);
     return -1;
   }
 
   if (bind(fd, (struct sockaddr *) sa, sa_len) < 0) {
-    log_err("bind");
+    log_errno("bind");
     close(fd);
     return -1;
   }
@@ -255,24 +255,24 @@ int create_send_mcast(const struct sockaddr_storage *sa, socklen_t sa_len, uint3
   switch (sa->ss_family) {
     case AF_INET6:
       if ((fd = socket(AF_INET6, SOCK_DGRAM, 0)) < 0) {
-        log_err("socket");
+        log_errno("socket");
         return -1;
       }
 
       if (setsockopt(fd, IPPROTO_IPV6, IPV6_V6ONLY, &on, sizeof(on)) < 0) {
-        log_err("setsockopt");
+        log_errno("setsockopt");
         close(fd);
         return -1;
       }
 
       if (setsockopt(fd, IPPROTO_IPV6, IPV6_MULTICAST_IF, &ifindex, sizeof(ifindex)) < 0) {
-        log_err("setsockopt");
+        log_errno("setsockopt");
         close(fd);
         return -1;
       }
 
       if (setsockopt(fd, IPPROTO_IPV6, IPV6_MULTICAST_LOOP, &off, sizeof(off)) < 0) {
-        log_err("setsockopt");
+        log_errno("setsockopt");
         close(fd);
         return -1;
       }
@@ -280,7 +280,7 @@ int create_send_mcast(const struct sockaddr_storage *sa, socklen_t sa_len, uint3
       break;
     case AF_INET:
       if ((fd = socket(AF_INET, SOCK_DGRAM, 0)) < 0) {
-        log_err("socket");
+        log_errno("socket");
         return -1;
       }
 
@@ -297,13 +297,13 @@ int create_send_mcast(const struct sockaddr_storage *sa, socklen_t sa_len, uint3
       }
 
       if (setsockopt(fd, IPPROTO_IP, IP_MULTICAST_IF, &src_addr4->sin_addr, sizeof(src_addr4->sin_addr)) < 0) {
-        log_err("setsockopt");
+        log_errno("setsockopt");
         close(fd);
         return -1;
       }
 
       if (setsockopt(fd, IPPROTO_IP, IP_MULTICAST_LOOP, &off, sizeof(on)) < 0) {
-        log_err("setsockopt");
+        log_errno("setsockopt");
         close(fd);
         return -1;
       }
@@ -314,31 +314,31 @@ int create_send_mcast(const struct sockaddr_storage *sa, socklen_t sa_len, uint3
   }
 
   if (setsockopt(fd, SOL_SOCKET, SO_REUSEADDR, &on, sizeof(on)) < 0) {
-    log_err("setsockopt");
+    log_errno("setsockopt");
     close(fd);
     return -1;
   }
 #if defined(SO_REUSEPORT) && !defined(__linux__)
   if (setsockopt(fd, SOL_SOCKET, SO_REUSEPORT, &on, sizeof(on)) < 0) {
-    log_err("setsockopt");
+    log_errno("setsockopt");
     close(fd);
     return -1;
   }
 #endif
   if ((flags = fcntl(fd, F_GETFL, 0)) < 0) {
-    log_err("fcntl");
+    log_errno("fcntl");
     close(fd);
     return -1;
   }
 
   if (fcntl(fd, F_SETFL, flags | O_NONBLOCK) < 0) {
-    log_err("fcntl");
+    log_errno("fcntl");
     close(fd);
     return -1;
   }
 
   if (bind(fd, (struct sockaddr *) sa, sa_len) < 0) {
-    log_err("bind");
+    log_errno("bind");
     close(fd);
     return -1;
   }

--- a/src/dns/mdns_list.c
+++ b/src/dns/mdns_list.c
@@ -19,7 +19,7 @@
 
 /**
  * @file mdns_list.c
- * @author Alexandru Mereacre 
+ * @author Alexandru Mereacre
  * @brief File containing the implementation of mdns list utils.
  */
 
@@ -37,7 +37,7 @@ struct mdns_list* init_mdns_list(void)
   struct mdns_list *mlist;
 
   if ((mlist = os_zalloc(sizeof(struct mdns_list))) == NULL) {
-    log_err("os_zalloc");
+    log_errno("os_zalloc");
     return NULL;
   }
 
@@ -103,7 +103,7 @@ int push_mdns_list(struct mdns_list* mlist, struct mdns_list_info *info)
   el->info = *info;
 
   if ((el->info.name = os_strdup(info->name)) == NULL) {
-    log_err("os_strdup");
+    log_errno("os_strdup");
     free_mdns_list_el(el);
     return -1;
   }

--- a/src/dns/mdns_mapper.c
+++ b/src/dns/mdns_mapper.c
@@ -19,7 +19,7 @@
 
 /**
  * @file mdns_mapper.c
- * @author Alexandru Mereacre 
+ * @author Alexandru Mereacre
  * @brief File containing the implementation of the mdns mapper utils.
  */
 
@@ -39,7 +39,7 @@ int put_mdns_info(hmap_mdns_conn **imap, uint8_t *ip, struct mdns_list_info *inf
 
   if (s == NULL) {
     if ((el = (hmap_mdns_conn *) os_malloc(sizeof(hmap_mdns_conn))) == NULL) {
-      log_err("os_malloc");
+      log_errno("os_malloc");
       return -1;
     }
 
@@ -91,7 +91,7 @@ int put_mdns_query_mapper(hmap_mdns_conn **imap, uint8_t *ip, struct mdns_query_
   info.name = query->qname;
   info.qtype = query->qtype;
   info.request = MDNS_REQUEST_QUERY;
-  
+
   if (put_mdns_info(imap, ip, &info) < 0) {
     log_trace("put_mdns_info fail");
     return -1;
@@ -123,7 +123,7 @@ int put_mdns_answer_mapper(hmap_mdns_conn **imap, uint8_t *ip, struct mdns_answe
   info.rrtype = answer->rrtype;
   info.ttl = answer->ttl;
   info.request = MDNS_REQUEST_ANSWER;
-  
+
   if (put_mdns_info(imap, ip, &info) < 0) {
     log_trace("put_mdns_info fail");
     return -1;
@@ -157,7 +157,7 @@ int check_mdns_mapper_req(hmap_mdns_conn **imap, uint8_t *ip, enum MDNS_REQUEST_
     log_trace("ip param is NULL");
     return -1;
   }
-  
+
   HASH_FIND(hh, *imap, ip, IP_ALEN, s);     /* IP already in the hash? */
 
   if (s == NULL) {

--- a/src/dns/reflection_list.c
+++ b/src/dns/reflection_list.c
@@ -19,7 +19,7 @@
 
 /**
  * @file reflection_list.c
- * @author Alexandru Mereacre 
+ * @author Alexandru Mereacre
  * @brief File containing the implementation of reflection list structures.
  */
 
@@ -42,7 +42,7 @@ void setup_reflection_if_el(struct reflection_list *el, unsigned int ifindex, co
   if (ifname == NULL) {
     os_memset(el->ifname, 0, IFNAMSIZ);
   } else {
-    snprintf(el->ifname, IFNAMSIZ, "%s", ifname);   
+    snprintf(el->ifname, IFNAMSIZ, "%s", ifname);
   }
 }
 
@@ -50,7 +50,7 @@ struct reflection_list * init_reflection_list(void)
 {
   struct reflection_list *rif = os_zalloc(sizeof(struct reflection_list));
   if (rif == NULL) {
-    log_err("os_zalloc");
+    log_errno("os_zalloc");
     return NULL;
   }
 
@@ -68,7 +68,7 @@ struct reflection_list* push_reflection_list(struct reflection_list *rif, unsign
     log_debug("rif param is NULL");
     return NULL;
   }
-  
+
   if ((el = init_reflection_list()) == NULL) {
     log_debug("init_reflection_list fail");
     return NULL;
@@ -105,5 +105,5 @@ void free_reflection_list(struct reflection_list *rif)
     free_reflection_list_el(el);
   }
 
-  free_reflection_list_el(rif);  
+  free_reflection_list_el(rif);
 }

--- a/src/engine.c
+++ b/src/engine.c
@@ -277,6 +277,10 @@ int init_context(struct app_config *app_config, struct supervisor_context *ctx)
     return -1;
   }
 
+  if (app_config->config_ifinfo_array == NULL) {
+    log_error("Invalid empty config_ifinfo_array");
+    return -1;
+  }
   utarray_new(ctx->config_ifinfo_array, &config_ifinfo_icd);
   copy_ifinfo(app_config->config_ifinfo_array, ctx->config_ifinfo_array);
 

--- a/src/engine.c
+++ b/src/engine.c
@@ -18,8 +18,8 @@
  ****************************************************************************/
 
 /**
- * @file engine.c 
- * @author Alexandru Mereacre 
+ * @file engine.c
+ * @author Alexandru Mereacre
  * @brief File containing the implementation of the app configuration structure.
  */
 
@@ -75,11 +75,11 @@ void copy_ifinfo(UT_array *in, UT_array *out)
 
 /**
  * @brief Check if the system binaries are present and return their absolute paths
- * 
+ *
  * @param commands Array of system binaries name strings
  * @param bin_path_arr Array of system binaries default fodler paths
  * @param hmap_bin_hashes Map of systems binaries to hashes
- * @return hmap_str_keychar* Map for binary to path 
+ * @return hmap_str_keychar* Map for binary to path
  */
 hmap_str_keychar *check_systems_commands(char *commands[], UT_array *bin_path_arr, hmap_str_keychar *hmap_bin_hashes)
 {
@@ -91,7 +91,7 @@ hmap_str_keychar *check_systems_commands(char *commands[], UT_array *bin_path_ar
   }
 
   hmap_str_keychar *hmap_bin_paths = hmap_str_keychar_new();
-  
+
   for(uint8_t idx = 0; commands[idx] != NULL; idx ++) {
     log_debug("Checking %s command...", commands[idx]);
     char *path = get_secure_path(bin_path_arr, commands[idx], false);
@@ -157,7 +157,7 @@ bool create_mac_mapper(struct supervisor_context *ctx)
     utarray_free(mac_conn_arr);
     return false;
   }
-  
+
   if (mac_conn_arr != NULL) {
     while((p = (struct mac_conn *) utarray_next(mac_conn_arr, p)) != NULL) {
       log_trace("Adding mac=" MACSTR " with id=%s vlanid=%d ifname=%s nat=%d allow=%d label=%s status=%d",
@@ -222,13 +222,13 @@ bool get_nat_if_ip(char *nat_interface, char *ip_buf)
   interfaces = iface_get(nat_interface);
 
   if (interfaces == NULL) {
-    log_err("Interface %s not found", nat_interface);
+    log_errno("Interface %s not found", nat_interface);
     goto err;
   }
 
   netif_info_t *el = (netif_info_t*) utarray_back(interfaces);
   if (el == NULL) {
-    log_err("Interface list empty");
+    log_errno("Interface list empty");
     goto err;
   }
 
@@ -307,7 +307,7 @@ int init_context(struct app_config *app_config, struct supervisor_context *ctx)
   ctx->risk_score = app_config->risk_score;
   ctx->wpa_passphrase_len = os_strnlen_s(app_config->hconfig.wpa_passphrase, AP_SECRET_LEN);
   os_memcpy(ctx->wpa_passphrase, app_config->hconfig.wpa_passphrase, ctx->wpa_passphrase_len);
-  
+
   os_memcpy(ctx->nat_bridge, app_config->nat_bridge, IFNAMSIZ);
   os_memcpy(ctx->nat_interface, app_config->nat_interface, IFNAMSIZ);
   os_memcpy(ctx->db_path, app_config->db_path, MAX_OS_PATH_LEN);
@@ -374,7 +374,7 @@ int init_context(struct app_config *app_config, struct supervisor_context *ctx)
        return -1;
      }
   }
-  
+
   return 0;
 }
 
@@ -391,7 +391,7 @@ int run_mdns_forwarder(char *mdns_bin_path, char *config_ini_path)
   ret = run_process(process_argv, &child_pid);
 
   if ((proc_name = os_strdup(basename(process_argv[0]))) == NULL) {
-    log_err("os_strdup");
+    log_errno("os_strdup");
     return -1;
   }
 

--- a/src/firewall/firewall_service.c
+++ b/src/firewall/firewall_service.c
@@ -18,8 +18,8 @@
  ****************************************************************************/
 
 /**
- * @file firewall_service.c 
- * @author Alexandru Mereacre 
+ * @file firewall_service.c
+ * @author Alexandru Mereacre
  * @brief File containing the implementation of the firewall service commands.
  */
 
@@ -135,7 +135,7 @@ struct fwctx* fw_init_context(hmap_if_conn *if_mapper,
   struct fwctx* fw_ctx = os_zalloc(sizeof(struct fwctx));
 
   if (fw_ctx == NULL) {
-    log_err("os_zalloc");
+    log_errno("os_zalloc");
     return NULL;
   }
 
@@ -377,7 +377,7 @@ int fw_set_ip_forward(void)
   char buf[2];
   int fd = open(IP_FORWARD_PATH, O_RDWR);
   if (read(fd, buf, 1) < 0) {
-    log_err("read");
+    log_errno("read");
     close(fd);
     return -1;
   }
@@ -387,7 +387,7 @@ int fw_set_ip_forward(void)
   if (buf[0] == 0x30) {
     log_trace("Setting IP forward flag to 1");
     if (lseek(fd, 0 , SEEK_SET) < 0) {
-      log_err("lseek")  ;
+      log_errno("lseek")  ;
       close(fd);
       return -1;
     }
@@ -395,11 +395,11 @@ int fw_set_ip_forward(void)
     buf[0] = 0x31;
 
 	  if (write(fd, buf, 1) < 0) {
-      log_err("write");
+      log_errno("write");
         close(fd);
         return -1;
     }
   }
   close(fd);
-  return 0; 
+  return 0;
 }

--- a/src/radius/radius_server.c
+++ b/src/radius/radius_server.c
@@ -7,7 +7,7 @@
  */
 
 /**
- * @file radius_server.h 
+ * @file radius_server.h
  * @authors Jouni Malinen, Alexandru Mereacre
  * @brief RADIUS authentication server.
  */
@@ -115,12 +115,12 @@ struct hostapd_radius_attr * get_password_attribute(const uint8_t *req_authentic
 		log_trace("os_get_random fail");
 		return NULL;
 	}
-	
+
 	salt |= 0x8000;
 
 	buf = os_zalloc(packet_len);
 	if (buf == NULL) {
-		log_err("os_zalloc");
+		log_errno("os_zalloc");
 		return 0;
 	}
 
@@ -132,7 +132,7 @@ struct hostapd_radius_attr * get_password_attribute(const uint8_t *req_authentic
 
 	attr = os_zalloc(sizeof(*attr));
 	if (!attr) {
-		log_err("os_zalloc");
+		log_errno("os_zalloc");
 		os_free(buf);
 		return NULL;
 	}
@@ -147,7 +147,7 @@ struct hostapd_radius_attr * get_password_attribute(const uint8_t *req_authentic
 struct hostapd_radius_attr * get_vlan_attribute(uint16_t vlan_id)
 {
 	char id_str[5];
-	struct hostapd_radius_attr *attr, 
+	struct hostapd_radius_attr *attr,
 		*attr_medium_type, *attr_id;
 
 #define RADIUS_ATTR_TUNNEL_VALUE 		13
@@ -155,7 +155,7 @@ struct hostapd_radius_attr * get_vlan_attribute(uint16_t vlan_id)
 
 	attr = os_zalloc(sizeof(*attr));
 	if (!attr) {
-		log_err("os_zalloc");
+		log_errno("os_zalloc");
 		return NULL;
 	}
 
@@ -163,10 +163,10 @@ struct hostapd_radius_attr * get_vlan_attribute(uint16_t vlan_id)
 	attr->val = wpabuf_alloc(4);
 	if (attr->val)
 		wpabuf_put_be32(attr->val, RADIUS_ATTR_TUNNEL_VALUE);
-	
+
 	attr_medium_type = os_zalloc(sizeof(*attr_medium_type));
 	if (!attr_medium_type) {
-		log_err("os_zalloc");
+		log_errno("os_zalloc");
 		free_radius_attr(attr);
 		return NULL;
 	}
@@ -177,7 +177,7 @@ struct hostapd_radius_attr * get_vlan_attribute(uint16_t vlan_id)
 
 	attr_id = os_zalloc(sizeof(*attr_id));
 	if (!attr_id) {
-		log_err("os_zalloc");
+		log_errno("os_zalloc");
 		free_radius_attr(attr);
 		free_radius_attr(attr_medium_type);
 		return NULL;
@@ -469,7 +469,7 @@ radius_server_macacl(struct radius_server_data *data,
 end:
 	if (attr != NULL)
 		free_radius_attr(attr);
-	return NULL;	
+	return NULL;
 }
 
 
@@ -513,7 +513,7 @@ static int radius_server_reject(struct radius_server_data *data,
 	buf = radius_msg_get_buf(msg);
 	if (sendto(data->auth_sock, wpabuf_head(buf), wpabuf_len(buf), 0,
 		   (struct sockaddr *) from, sizeof(*from)) < 0) {
-		log_err("sendto[RADIUS SRV]");
+		log_errno("sendto[RADIUS SRV]");
 		ret = -1;
 	}
 
@@ -580,7 +580,7 @@ static int radius_server_request(struct radius_server_data *data,
 				     wpabuf_len(buf), 0,
 				     (struct sockaddr *) from, fromlen);
 			if (res < 0) {
-				log_err("sendto[RADIUS SRV]");
+				log_errno("sendto[RADIUS SRV]");
 			}
 			return 0;
 		}
@@ -623,7 +623,7 @@ static int radius_server_request(struct radius_server_data *data,
 			     wpabuf_len(buf), 0,
 			     (struct sockaddr *) from, fromlen);
 		if (res < 0) {
-			log_err("sendto[RADIUS SRV]");
+			log_errno("sendto[RADIUS SRV]");
 		}
 		radius_msg_free(sess->last_reply);
 		sess->last_reply = reply;
@@ -675,7 +675,7 @@ static void radius_server_receive_auth(int sock, void *eloop_ctx,
 	len = recvfrom(sock, buf, RADIUS_MAX_MSG_LEN, 0,
 		       (struct sockaddr *) &from.ss, &fromlen);
 	if (len < 0) {
-		log_err("recvfrom[radius_server]");
+		log_errno("recvfrom[radius_server]");
 		goto fail;
 	}
 
@@ -743,7 +743,7 @@ static int radius_server_disable_pmtu_discovery(int s)
 	r = setsockopt(s, IPPROTO_IP, IP_MTU_DISCOVER, &action,
 		       sizeof(action));
 	if (r == -1)
-		log_err("Failed to set IP_MTU_DISCOVER:");
+		log_errno("Failed to set IP_MTU_DISCOVER:");
 #endif
 	return r;
 }
@@ -766,7 +766,7 @@ static int radius_server_open_socket(int port)
 	addr.sin_family = AF_INET;
 	addr.sin_port = htons(port);
 	if (bind(s, (struct sockaddr *) &addr, sizeof(addr)) < 0) {
-		log_err("RADIUS: bind");
+		log_errno("RADIUS: bind");
 		close(s);
 		return -1;
 	}
@@ -818,13 +818,13 @@ struct radius_client *init_radius_client(struct radius_conf *conf,
 
 	entry = os_zalloc(sizeof(*entry));
 	if (entry == NULL) {
-		log_err("os_zalloc");
+		log_errno("os_zalloc");
 		return NULL;
 	}
 
 	entry->shared_secret = os_strdup(conf->radius_secret);
 	if (entry->shared_secret == NULL) {
-		log_err("os_strdup");
+		log_errno("os_strdup");
 		os_free(entry);
 		return NULL;
 	}

--- a/src/supervisor/bridge_list.c
+++ b/src/supervisor/bridge_list.c
@@ -18,8 +18,8 @@
  ****************************************************************************/
 
 /**
- * @file bridge_list.c 
- * @author Alexandru Mereacre 
+ * @file bridge_list.c
+ * @author Alexandru Mereacre
  * @brief File containing the implementation of the bridge creation functions.
  */
 
@@ -41,7 +41,7 @@ struct bridge_mac_list *init_bridge_list(void)
   e = os_zalloc(sizeof(*e));
 
   if (e == NULL) {
-    log_err("os_zalloc");
+    log_errno("os_zalloc");
     return NULL;
   }
 
@@ -155,16 +155,16 @@ int add_bridge_mac(struct bridge_mac_list *ml, const uint8_t *mac_addr_left, con
   // Existing edge
 	if(ret.left_edge && ret.right_edge)
     return 0;
-  
+
 	src_el = os_zalloc(sizeof(*src_el));
 	if (src_el == NULL) {
-    log_err("os_zalloc");
+    log_errno("os_zalloc");
     return -1;
   }
 
 	dst_el = os_zalloc(sizeof(*dst_el));
 	if (dst_el == NULL) {
-    log_err("os_zalloc");
+    log_errno("os_zalloc");
     return -1;
   }
 
@@ -200,10 +200,10 @@ int remove_bridge_mac(struct bridge_mac_list *ml, const uint8_t *mac_addr_left, 
 	if (e.left_edge == NULL || e.right_edge == NULL) {
     log_trace("Missing edge");
   }
-  
+
   bridge_mac_list_free(e.left_edge);
   bridge_mac_list_free(e.right_edge);
-  
+
   return 0;
 }
 

--- a/src/supervisor/cmd_processor.c
+++ b/src/supervisor/cmd_processor.c
@@ -19,7 +19,7 @@
 
 /**
  * @file cmd_processor.c
- * @author Alexandru Mereacre 
+ * @author Alexandru Mereacre
  * @brief File containing the implementation of the command processor functions.
  */
 
@@ -57,7 +57,7 @@ bool process_domain_buffer(char *domain_buffer, size_t domain_buffer_len, UT_arr
 
   char *cmd_line = os_malloc(domain_buffer_len + 1);
   if (cmd_line == NULL) {
-    log_err("malloc");
+    log_errno("malloc");
     return false;
   }
 
@@ -125,7 +125,7 @@ ssize_t process_accept_mac_cmd(int sock, struct client_address *client_addr,
           return write_domain_data(sock, OK_REPLY, strlen(OK_REPLY), client_addr);
         }
       }
-    } 
+    }
   }
 
   return write_domain_data(sock, FAIL_REPLY, strlen(FAIL_REPLY), client_addr);
@@ -147,7 +147,7 @@ ssize_t process_deny_mac_cmd(int sock, struct client_address *client_addr,
       }
 
       return write_domain_data(sock, OK_REPLY, strlen(OK_REPLY), client_addr);
-    } 
+    }
   }
 
   return write_domain_data(sock, FAIL_REPLY, strlen(FAIL_REPLY), client_addr);
@@ -169,7 +169,7 @@ ssize_t process_add_nat_cmd(int sock, struct client_address *client_addr,
       }
 
       return write_domain_data(sock, OK_REPLY, strlen(OK_REPLY), client_addr);
-    } 
+    }
   }
 
   return write_domain_data(sock, FAIL_REPLY, strlen(FAIL_REPLY), client_addr);
@@ -191,7 +191,7 @@ ssize_t process_remove_nat_cmd(int sock, struct client_address *client_addr,
       }
 
       return write_domain_data(sock, OK_REPLY, strlen(OK_REPLY), client_addr);
-    } 
+    }
   }
 
   return write_domain_data(sock, FAIL_REPLY, strlen(FAIL_REPLY), client_addr);
@@ -221,7 +221,7 @@ ssize_t process_assign_psk_cmd(int sock, struct client_address *client_addr,
           return write_domain_data(sock, OK_REPLY, strlen(OK_REPLY), client_addr);
         }
       }
-    } 
+    }
   }
 
   return write_domain_data(sock, FAIL_REPLY, strlen(FAIL_REPLY), client_addr);
@@ -253,7 +253,7 @@ ssize_t process_get_map_cmd(int sock, struct client_address *client_addr,
       } else if (!ret) {
         return write_domain_data(sock, OK_REPLY, strlen(OK_REPLY), client_addr);
       }
-    } 
+    }
   }
 
   return write_domain_data(sock, FAIL_REPLY, strlen(FAIL_REPLY), client_addr);
@@ -264,7 +264,7 @@ ssize_t process_get_all_cmd(int sock, struct client_address *client_addr,
 {
   (void) cmd_arr; /* unused */
 
-  char temp[255], *reply_buf = NULL; 
+  char temp[255], *reply_buf = NULL;
   struct mac_conn *mac_list = NULL;
   int mac_list_len = get_mac_list(&context->mac_mapper, &mac_list);
   int total = 0;
@@ -335,7 +335,7 @@ ssize_t process_set_ip_cmd(int sock, struct client_address *client_addr,
         if (validate_ipv4_string(*ptr)) {
           if (set_ip_cmd(context, addr, *ptr, ip_type) < 0) {
             log_trace("set_ip_cmd fail");
-            return write_domain_data(sock, FAIL_REPLY, strlen(FAIL_REPLY), client_addr);  
+            return write_domain_data(sock, FAIL_REPLY, strlen(FAIL_REPLY), client_addr);
           }
 
           return write_domain_data(sock, OK_REPLY, strlen(OK_REPLY), client_addr);
@@ -448,7 +448,7 @@ ssize_t process_get_bridges_cmd(int sock, struct client_address *client_addr,
 {
   (void) cmd_arr; /* unused */
 
-  char temp[255], *reply_buf = NULL; 
+  char temp[255], *reply_buf = NULL;
   UT_array *tuple_list_arr;
   int total = 0;
   struct bridge_mac_tuple *p = NULL;
@@ -497,7 +497,7 @@ ssize_t process_set_fingerprint_cmd(int sock, struct client_address *client_addr
   ptr = (char**) utarray_next(cmd_arr, ptr);
   if (ptr != NULL && *ptr != NULL) {
     os_strlcpy(src_mac_addr, *ptr, MACSTR_LEN);
-    
+
     if (hwaddr_aton2(src_mac_addr, addr) == -1) {
       return write_domain_data(sock, FAIL_REPLY, strlen(FAIL_REPLY), client_addr);
     }
@@ -584,7 +584,7 @@ ssize_t process_set_alert_cmd(int sock, struct client_address *client_addr,
       os_free(info);
     }
 
-    return write_domain_data(sock, OK_REPLY, strlen(OK_REPLY), client_addr);  
+    return write_domain_data(sock, OK_REPLY, strlen(OK_REPLY), client_addr);
   }
 
   return write_domain_data(sock, FAIL_REPLY, strlen(FAIL_REPLY), client_addr);
@@ -715,7 +715,7 @@ ssize_t process_put_crypt_cmd(int sock, struct client_address *client_addr, stru
   ptr = (char**) utarray_next(cmd_arr, ptr);
   if (ptr != NULL && *ptr != NULL) {
     if ((key = os_strdup(*ptr)) == NULL) {
-      log_err("os_strdup");
+      log_errno("os_strdup");
       return write_domain_data(sock, FAIL_REPLY, strlen(FAIL_REPLY), client_addr);
     }
 
@@ -723,7 +723,7 @@ ssize_t process_put_crypt_cmd(int sock, struct client_address *client_addr, stru
     ptr = (char**) utarray_next(cmd_arr, ptr);
     if (ptr != NULL && *ptr != NULL) {
       if ((value = os_strdup(*ptr)) == NULL) {
-        log_err("os_strdup");
+        log_errno("os_strdup");
         os_free(key);
         return write_domain_data(sock, FAIL_REPLY, strlen(FAIL_REPLY), client_addr);
       }
@@ -754,7 +754,7 @@ ssize_t process_get_crypt_cmd(int sock, struct client_address *client_addr, stru
   ptr = (char**) utarray_next(cmd_arr, ptr);
   if (ptr != NULL && *ptr != NULL) {
     if ((key = os_strdup(*ptr)) == NULL) {
-      log_err("os_strdup");
+      log_errno("os_strdup");
       return write_domain_data(sock, FAIL_REPLY, strlen(FAIL_REPLY), client_addr);
     }
 
@@ -783,7 +783,7 @@ ssize_t process_gen_randkey_cmd(int sock, struct client_address *client_addr, st
   ptr = (char**) utarray_next(cmd_arr, ptr);
   if (ptr != NULL && *ptr != NULL) {
     if ((keyid = os_strdup(*ptr)) == NULL) {
-      log_err("os_strdup");
+      log_errno("os_strdup");
       return write_domain_data(sock, FAIL_REPLY, strlen(FAIL_REPLY), client_addr);
     }
 
@@ -815,7 +815,7 @@ ssize_t process_gen_privkey_cmd(int sock, struct client_address *client_addr, st
   ptr = (char**) utarray_next(cmd_arr, ptr);
   if (ptr != NULL && *ptr != NULL) {
     if ((keyid = os_strdup(*ptr)) == NULL) {
-      log_err("os_strdup");
+      log_errno("os_strdup");
       return write_domain_data(sock, FAIL_REPLY, strlen(FAIL_REPLY), client_addr);
     }
 
@@ -842,11 +842,11 @@ ssize_t process_gen_pubkey_cmd(int sock, struct client_address *client_addr, str
   char **ptr = (char**) utarray_next(cmd_arr, NULL);
   char *pubid = NULL;
 
-  // public key id  
+  // public key id
   ptr = (char**) utarray_next(cmd_arr, ptr);
   if (ptr != NULL && *ptr != NULL) {
     if ((pubid = os_strdup(*ptr)) == NULL) {
-      log_err("os_strdup");
+      log_errno("os_strdup");
       return write_domain_data(sock, FAIL_REPLY, strlen(FAIL_REPLY), client_addr);
     }
 
@@ -884,7 +884,7 @@ ssize_t process_gen_cert_cmd(int sock, struct client_address *client_addr, struc
   ptr = (char**) utarray_next(cmd_arr, ptr);
   if (ptr != NULL && *ptr != NULL) {
     if ((certid = os_strdup(*ptr)) == NULL) {
-      log_err("os_strdup");
+      log_errno("os_strdup");
       return write_domain_data(sock, FAIL_REPLY, strlen(FAIL_REPLY), client_addr);
     }
 
@@ -892,7 +892,7 @@ ssize_t process_gen_cert_cmd(int sock, struct client_address *client_addr, struc
     ptr = (char**) utarray_next(cmd_arr, ptr);
     if (ptr != NULL && *ptr != NULL) {
       if ((keyid = os_strdup(*ptr)) == NULL) {
-        log_err("os_strdup");
+        log_errno("os_strdup");
         os_free(certid);
         return write_domain_data(sock, FAIL_REPLY, strlen(FAIL_REPLY), client_addr);
       }
@@ -929,7 +929,7 @@ ssize_t process_encrypt_blob_cmd(int sock, struct client_address *client_addr, s
   ptr = (char**) utarray_next(cmd_arr, ptr);
   if (ptr != NULL && *ptr != NULL) {
     if ((keyid = os_strdup(*ptr)) == NULL) {
-      log_err("os_strdup");
+      log_errno("os_strdup");
       return write_domain_data(sock, FAIL_REPLY, strlen(FAIL_REPLY), client_addr);
     }
 
@@ -937,7 +937,7 @@ ssize_t process_encrypt_blob_cmd(int sock, struct client_address *client_addr, s
     ptr = (char**) utarray_next(cmd_arr, ptr);
     if (ptr != NULL && *ptr != NULL) {
       if ((ivid = os_strdup(*ptr)) == NULL) {
-        log_err("os_strdup");
+        log_errno("os_strdup");
         os_free(keyid);
         return write_domain_data(sock, FAIL_REPLY, strlen(FAIL_REPLY), client_addr);
       }
@@ -975,7 +975,7 @@ ssize_t process_decrypt_blob_cmd(int sock, struct client_address *client_addr, s
   ptr = (char**) utarray_next(cmd_arr, ptr);
   if (ptr != NULL && *ptr != NULL) {
     if ((keyid = os_strdup(*ptr)) == NULL) {
-      log_err("os_strdup");
+      log_errno("os_strdup");
       return write_domain_data(sock, FAIL_REPLY, strlen(FAIL_REPLY), client_addr);
     }
 
@@ -983,7 +983,7 @@ ssize_t process_decrypt_blob_cmd(int sock, struct client_address *client_addr, s
     ptr = (char**) utarray_next(cmd_arr, ptr);
     if (ptr != NULL && *ptr != NULL) {
       if ((ivid = os_strdup(*ptr)) == NULL) {
-        log_err("os_strdup");
+        log_errno("os_strdup");
         os_free(keyid);
         return write_domain_data(sock, FAIL_REPLY, strlen(FAIL_REPLY), client_addr);
       }
@@ -1020,7 +1020,7 @@ ssize_t process_sign_blob_cmd(int sock, struct client_address *client_addr, stru
   ptr = (char**) utarray_next(cmd_arr, ptr);
   if (ptr != NULL && *ptr != NULL) {
     if ((keyid = os_strdup(*ptr)) == NULL) {
-      log_err("os_strdup");
+      log_errno("os_strdup");
       return write_domain_data(sock, FAIL_REPLY, strlen(FAIL_REPLY), client_addr);
     }
 

--- a/src/supervisor/crypt_commands.c
+++ b/src/supervisor/crypt_commands.c
@@ -19,7 +19,7 @@
 
 /**
  * @file crypt_commands.c
- * @author Alexandru Mereacre 
+ * @author Alexandru Mereacre
  * @brief File containing the implementation of the crypt commands.
  */
 
@@ -99,7 +99,7 @@ int gen_randkey_cmd(struct supervisor_context *context, char *keyid, uint8_t siz
   log_trace("GEN_RANDKEY for key=%s and size=%d", keyid, size);
 
   if ((pair.value = os_malloc(pair.value_size)) == NULL) {
-    log_err("os_malloc");
+    log_errno("os_malloc");
     return -1;
   }
   if (crypto_genkey(pair.value, pair.value_size) < 0) {
@@ -222,7 +222,7 @@ char* encrypt_blob_cmd(struct supervisor_context *context, char *keyid, char *iv
   if (keypair->value == NULL) {
     log_trace("value is empty");
     free_crypt_pair(keypair);
-    return NULL;  
+    return NULL;
   }
 
   if ((ivpair = get_crypt_pair(context->crypt_ctx, ivid)) == NULL) {
@@ -235,7 +235,7 @@ char* encrypt_blob_cmd(struct supervisor_context *context, char *keyid, char *iv
     log_trace("value is empty");
     free_crypt_pair(keypair);
     free_crypt_pair(ivpair);
-    return NULL;  
+    return NULL;
   }
 
   if ((blob_data = (uint8_t *) base64_url_decode((unsigned char *)blob, strlen(blob), &blob_data_size)) == NULL) {
@@ -246,7 +246,7 @@ char* encrypt_blob_cmd(struct supervisor_context *context, char *keyid, char *iv
   }
 
   if ((encrypted_data = os_malloc(blob_data_size + AES_BLOCK_SIZE)) == NULL) {
-    log_err("os_malloc");
+    log_errno("os_malloc");
     free_crypt_pair(keypair);
     free_crypt_pair(ivpair);
     os_free(blob_data);
@@ -292,7 +292,7 @@ char* decrypt_blob_cmd(struct supervisor_context *context, char *keyid, char *iv
   if (keypair->value == NULL) {
     log_trace("value is empty");
     free_crypt_pair(keypair);
-    return NULL;  
+    return NULL;
   }
 
   if ((ivpair = get_crypt_pair(context->crypt_ctx, ivid)) == NULL) {
@@ -305,7 +305,7 @@ char* decrypt_blob_cmd(struct supervisor_context *context, char *keyid, char *iv
     log_trace("value is empty");
     free_crypt_pair(keypair);
     free_crypt_pair(ivpair);
-    return NULL;  
+    return NULL;
   }
 
   if ((blob_data = (uint8_t *) base64_url_decode((unsigned char *)blob, strlen(blob), &blob_data_size)) == NULL) {
@@ -316,7 +316,7 @@ char* decrypt_blob_cmd(struct supervisor_context *context, char *keyid, char *iv
   }
 
   if ((decrypted_data = os_malloc(blob_data_size + AES_BLOCK_SIZE)) == NULL) {
-    log_err("os_malloc");
+    log_errno("os_malloc");
     free_crypt_pair(keypair);
     free_crypt_pair(ivpair);
     os_free(blob_data);
@@ -362,7 +362,7 @@ char* sign_blob_cmd(struct supervisor_context *context, char *keyid, char *blob)
   if (pair->value == NULL) {
     log_trace("value is empty");
     free_crypt_pair(pair);
-    return NULL;  
+    return NULL;
   }
 
   if ((blob_data = (uint8_t *) base64_url_decode((unsigned char *)blob, strlen(blob), &blob_data_size)) == NULL) {

--- a/src/supervisor/mac_mapper.c
+++ b/src/supervisor/mac_mapper.c
@@ -19,7 +19,7 @@
 
 /**
  * @file mac_mapper.c
- * @author Alexandru Mereacre 
+ * @author Alexandru Mereacre
  * @brief File containing the implementation of the mac mapper.
  */
 #include <stdbool.h>
@@ -59,7 +59,7 @@ int get_mac_mapper(hmap_mac_conn **hmap, uint8_t mac_addr[ETH_ALEN], struct mac_
 		*info = s->value;
     return 1;
   }
- 
+
   return 0;
 }
 
@@ -77,7 +77,7 @@ bool put_mac_mapper(hmap_mac_conn **hmap, struct mac_conn conn)
   if (s == NULL) {
     s = (hmap_mac_conn *) os_malloc(sizeof(hmap_mac_conn));
 		if (s == NULL) {
-			log_err("os_malloc");
+			log_errno("os_malloc");
       return false;
 		}
 

--- a/src/supervisor/monitor_commands.c
+++ b/src/supervisor/monitor_commands.c
@@ -18,8 +18,8 @@
  ****************************************************************************/
 
 /**
- * @file monitor_commands.c 
- * @author Alexandru Mereacre 
+ * @file monitor_commands.c
+ * @author Alexandru Mereacre
  * @brief File containing the implementation of the monitor commands.
  */
 #include <libgen.h>
@@ -117,7 +117,7 @@ ssize_t query_fingerprint_cmd(struct supervisor_context *context, char *mac_addr
     if (p->mac != NULL) {
       row_array[0] = os_malloc(strlen(p->mac) + 2);
       if (row_array[0] == NULL) {
-        log_err("os_malloc");
+        log_errno("os_malloc");
         free_sqlite_fingerprint_rows(rows);
         if (*out != NULL) os_free(*out);
         return -1;
@@ -126,7 +126,7 @@ ssize_t query_fingerprint_cmd(struct supervisor_context *context, char *mac_addr
     } else {
       row_array[0] = os_malloc(2);
       if (row_array[0] == NULL) {
-        log_err("os_malloc");
+        log_errno("os_malloc");
         free_sqlite_fingerprint_rows(rows);
         if (*out != NULL) os_free(*out);
         return -1;
@@ -138,7 +138,7 @@ ssize_t query_fingerprint_cmd(struct supervisor_context *context, char *mac_addr
     if (p->protocol != NULL) {
       row_array[1] = os_malloc(strlen(p->protocol) + 2);
       if (row_array[1] == NULL) {
-        log_err("os_malloc");
+        log_errno("os_malloc");
         free_row_array(row_array);
         free_sqlite_fingerprint_rows(rows);
         if (*out != NULL) os_free(*out);
@@ -149,7 +149,7 @@ ssize_t query_fingerprint_cmd(struct supervisor_context *context, char *mac_addr
     } else {
       row_array[1] = os_malloc(2);
       if (row_array[1] == NULL) {
-        log_err("os_malloc");
+        log_errno("os_malloc");
         free_row_array(row_array);
         free_sqlite_fingerprint_rows(rows);
         if (*out != NULL) os_free(*out);
@@ -161,7 +161,7 @@ ssize_t query_fingerprint_cmd(struct supervisor_context *context, char *mac_addr
     if (p->fingerprint != NULL) {
       row_array[2] = os_malloc(strlen(p->fingerprint) + 2);
       if (row_array[2] == NULL) {
-        log_err("os_malloc");
+        log_errno("os_malloc");
         free_row_array(row_array);
         free_sqlite_fingerprint_rows(rows);
         if (*out != NULL) os_free(*out);
@@ -172,7 +172,7 @@ ssize_t query_fingerprint_cmd(struct supervisor_context *context, char *mac_addr
     } else {
       row_array[2] = os_malloc(2);
       if (row_array[2] == NULL) {
-        log_err("os_malloc");
+        log_errno("os_malloc");
         free_row_array(row_array);
         free_sqlite_fingerprint_rows(rows);
         if (*out != NULL) os_free(*out);
@@ -184,7 +184,7 @@ ssize_t query_fingerprint_cmd(struct supervisor_context *context, char *mac_addr
 
     row_array[3] = os_malloc(MAX_UINT64_DIGITS + 2);
     if (row_array[3] == NULL) {
-      log_err("os_malloc");
+      log_errno("os_malloc");
       free_row_array(row_array);
       free_sqlite_fingerprint_rows(rows);
       if (*out != NULL) os_free(*out);
@@ -195,7 +195,7 @@ ssize_t query_fingerprint_cmd(struct supervisor_context *context, char *mac_addr
     if (p->query != NULL) {
       row_array[4] = os_malloc(strlen(p->query) + 2);
       if (row_array[4] == NULL) {
-        log_err("os_malloc");
+        log_errno("os_malloc");
         free_row_array(row_array);
         free_sqlite_fingerprint_rows(rows);
         if (*out != NULL) os_free(*out);
@@ -205,7 +205,7 @@ ssize_t query_fingerprint_cmd(struct supervisor_context *context, char *mac_addr
     } else {
       row_array[4] = os_malloc(2);
       if (row_array[4] == NULL) {
-        log_err("os_malloc");
+        log_errno("os_malloc");
         free_row_array(row_array);
         free_sqlite_fingerprint_rows(rows);
         if (*out != NULL) os_free(*out);
@@ -218,7 +218,7 @@ ssize_t query_fingerprint_cmd(struct supervisor_context *context, char *mac_addr
                     strlen(row_array[3]) + strlen(row_array[4]) + 1);
 
     if (row == NULL) {
-      log_err("os_zalloc");
+      log_errno("os_zalloc");
       free_row_array(row_array);
       free_sqlite_fingerprint_rows(rows);
       return -1;
@@ -264,31 +264,31 @@ int set_alert_cmd(struct supervisor_context *context, struct alert_meta *meta,
             MAC2STR(meta->dst_mac_addr), meta->timestamp, meta->risk);
 
   if ((row.hostname = os_strdup(meta->hostname)) == NULL) {
-    log_err("os_strdup");
+    log_errno("os_strdup");
     return -1;
   }
 
   if ((row.analyser = os_strdup(meta->analyser)) == NULL) {
-    log_err("os_strdup");
+    log_errno("os_strdup");
     free_sqlite_alert_row(&row);
     return -1;
   }
 
   if ((row.ifname = os_strdup(meta->ifname)) == NULL) {
-    log_err("os_strdup");
+    log_errno("os_strdup");
     free_sqlite_alert_row(&row);
     return -1;
   }
 
   if ((row.src_mac_addr = os_zalloc(MACSTR_LEN)) == NULL) {
-    log_err("os_zalloc");
+    log_errno("os_zalloc");
     free_sqlite_alert_row(&row);
     return -1;
   }
   sprintf(row.src_mac_addr, MACSTR, MAC2STR(meta->src_mac_addr));
 
   if ((row.dst_mac_addr = os_zalloc(MACSTR_LEN)) == NULL) {
-    log_err("os_zalloc");
+    log_errno("os_zalloc");
     free_sqlite_alert_row(&row);
     return -1;
   }
@@ -298,7 +298,7 @@ int set_alert_cmd(struct supervisor_context *context, struct alert_meta *meta,
   row.risk = meta->risk;
 
   if ((row.info = os_zalloc(info_size + 1)) == NULL) {
-    log_err("os_zalloc");
+    log_errno("os_zalloc");
     free_sqlite_alert_row(&row);
     return -1;
   }

--- a/src/supervisor/network_commands.c
+++ b/src/supervisor/network_commands.c
@@ -18,8 +18,8 @@
  ****************************************************************************/
 
 /**
- * @file network_commands.c 
- * @author Alexandru Mereacre 
+ * @file network_commands.c
+ * @author Alexandru Mereacre
  * @brief File containing the implementation of the network commands.
  */
 #include <libgen.h>
@@ -444,7 +444,7 @@ uint8_t* register_ticket_cmd(struct supervisor_context *context, uint8_t *mac_ad
   context->ticket = os_zalloc(sizeof(struct auth_ticket));
 
   if (context->ticket == NULL) {
-    log_err("os_malloc");
+    log_errno("os_malloc");
     return NULL;
   }
 
@@ -469,7 +469,7 @@ uint8_t* register_ticket_cmd(struct supervisor_context *context, uint8_t *mac_ad
 }
 
 int clear_psk_cmd(struct supervisor_context *context, uint8_t *mac_addr)
-{  
+{
   struct mac_conn conn;
   struct mac_conn_info info;
 

--- a/src/supervisor/sqlite_fingerprint_writer.c
+++ b/src/supervisor/sqlite_fingerprint_writer.c
@@ -19,7 +19,7 @@
 
 /**
  * @file sqlite_fingerprint_writer.c
- * @author Alexandru Mereacre 
+ * @author Alexandru Mereacre
  * @brief File containing the implementation of the sqlite fingerprint writer utilities.
  */
 
@@ -47,8 +47,8 @@ int open_sqlite_fingerprint_db(char *db_path, sqlite3** sql)
 {
   sqlite3 *db = NULL;
   int rc;
-  
-  if ((rc = sqlite3_open(db_path, &db)) != SQLITE_OK) {     
+
+  if ((rc = sqlite3_open(db_path, &db)) != SQLITE_OK) {
     log_debug("Cannot open database: %s", sqlite3_errmsg(db));
     sqlite3_close(db);
     return -1;
@@ -174,7 +174,7 @@ int get_sqlite_fingerprint_rows(sqlite3 *db, char *mac, uint64_t timestamp, char
 
   statement = os_malloc(strlen(sql_statement) + 3);
   if (statement == NULL) {
-    log_err("os_malloc");
+    log_errno("os_malloc");
     return -1;
   }
 
@@ -185,7 +185,7 @@ int get_sqlite_fingerprint_rows(sqlite3 *db, char *mac, uint64_t timestamp, char
   } else {
     proto = os_malloc(strlen(protocol) + 3);
     if (proto == NULL) {
-      log_err("os_malloc");
+      log_errno("os_malloc");
       os_free(statement);
       return -1;
     }
@@ -237,7 +237,7 @@ int get_sqlite_fingerprint_rows(sqlite3 *db, char *mac, uint64_t timestamp, char
     if (value != NULL) {
       row.mac = os_strdup(value);
       if (row.mac == NULL) {
-        log_err("os_strdup");
+        log_errno("os_strdup");
         os_free(statement);
         if (proto != NULL) os_free(proto);
         sqlite3_finalize(res);
@@ -249,7 +249,7 @@ int get_sqlite_fingerprint_rows(sqlite3 *db, char *mac, uint64_t timestamp, char
     if (value != NULL) {
       row.protocol = os_strdup(value);
       if (row.protocol == NULL) {
-        log_err("os_strdup");
+        log_errno("os_strdup");
         free_sqlite_fingerprint_row(&row);
         os_free(statement);
         if (proto != NULL) os_free(proto);
@@ -262,7 +262,7 @@ int get_sqlite_fingerprint_rows(sqlite3 *db, char *mac, uint64_t timestamp, char
     if (value != NULL) {
       row.fingerprint = os_strdup(value);
       if (row.fingerprint == NULL) {
-        log_err("os_strdup");
+        log_errno("os_strdup");
         free_sqlite_fingerprint_row(&row);
         os_free(statement);
         if (proto != NULL) os_free(proto);
@@ -277,7 +277,7 @@ int get_sqlite_fingerprint_rows(sqlite3 *db, char *mac, uint64_t timestamp, char
     if (value != NULL) {
       row.query = os_strdup(value);
       if (row.query == NULL) {
-        log_err("os_strdup");
+        log_errno("os_strdup");
         free_sqlite_fingerprint_row(&row);
         os_free(statement);
         if (proto != NULL) os_free(proto);

--- a/src/supervisor/subscriber_events.c
+++ b/src/supervisor/subscriber_events.c
@@ -19,7 +19,7 @@
 
 /**
  * @file subscriber_events.c
- * @author Alexandru Mereacre 
+ * @author Alexandru Mereacre
  * @brief File containing the implementation of the subscriber events structure.
  */
 
@@ -52,7 +52,7 @@ int add_events_subscriber(struct supervisor_context *context, struct client_addr
   p = utarray_find(context->subscribers_array, addr, sort_subscribers_arrray);
   if (p != NULL) {
     log_trace("Client already subscribed with size=%d", p->len);
-    return 0;    
+    return 0;
   }
 
   utarray_push_back(context->subscribers_array, addr);
@@ -69,7 +69,7 @@ int send_events(struct supervisor_context *context,
   vsnprintf(args_buf, MAX_SEND_EVENTS_BUF_SIZE, format, args);
 
   if ((send_buf = os_zalloc(strlen(name) + strlen(args_buf) + 2)) == NULL) {
-    log_err("os_malloc");
+    log_errno("os_malloc");
     return -1;
   }
 

--- a/src/supervisor/supervisor.c
+++ b/src/supervisor/supervisor.c
@@ -19,7 +19,7 @@
 
 /**
  * @file supervisor.c
- * @author Alexandru Mereacre 
+ * @author Alexandru Mereacre
  * @brief File containing the implementation of the supervisor service.
  */
 
@@ -75,7 +75,7 @@ int run_analyser(struct capture_conf *config, pid_t *child_pid)
   ret = run_process(process_argv, child_pid);
 
   if ((proc_name = os_strdup(basename(process_argv[0]))) == NULL) {
-    log_err("os_malloc");
+    log_errno("os_malloc");
     capture_freeopt(process_argv);
     return -1;
   }
@@ -131,7 +131,7 @@ int allocate_vlan(struct supervisor_context *context)
   int vlanid, idx = 0, len;
   config_ifinfo_t *p = NULL;
   UT_array *config_ifinfo_array = context->config_ifinfo_array;
-  
+
   if (!context->allocate_vlans) {
     return context->default_open_vlanid;
   }
@@ -143,7 +143,7 @@ int allocate_vlan(struct supervisor_context *context)
 
   len = utarray_len(config_ifinfo_array) - 1;
   if ((vlan_arr = (int *) os_malloc(sizeof(int) * len)) == NULL) {
-    log_err("os_malloc");
+    log_errno("os_malloc");
     return -1;
   }
 
@@ -262,7 +262,7 @@ struct mac_conn_info get_mac_conn_cmd(uint8_t mac_addr[], void *mac_conn_arg)
 
     return info;
   }
-  
+
   log_trace("REJECTING mac=" MACSTR, MAC2STR(mac_addr));
   info.vlanid = -1;
   return info;
@@ -304,12 +304,12 @@ void eloop_read_sock_handler(int sock, void *eloop_ctx, void *sock_ctx)
   os_memset(&claddr, 0, sizeof(struct client_address));
 
   if (ioctl(sock, FIONREAD, &bytes_available) == -1) {
-    log_err("ioctl");
+    log_errno("ioctl");
     return;
   }
 
   if ((buf = os_malloc(bytes_available)) == NULL) {
-    log_err("os_malloc");
+    log_errno("os_malloc");
     return;
   }
 
@@ -317,7 +317,7 @@ void eloop_read_sock_handler(int sock, void *eloop_ctx, void *sock_ctx)
 
   if ((num_bytes = read_domain_data(sock, buf, bytes_available, &claddr, 0)) == -1) {
     log_trace("read_domain_data fail");
-    goto end;  
+    goto end;
   }
 
   log_trace("Supervisor received %ld bytes from socket length=%d", (long) num_bytes, claddr.len);
@@ -349,7 +349,7 @@ void close_supervisor(struct supervisor_context *context)
 
   if (context->domain_sock != -1) {
     if (close(context->domain_sock) == -1) {
-      log_err("close");
+      log_errno("close");
     }
   }
 

--- a/src/utils/cryptou.c
+++ b/src/utils/cryptou.c
@@ -19,7 +19,7 @@
 
 /**
  * @file cryptou.c
- * @author Alexandru Mereacre 
+ * @author Alexandru Mereacre
  * @brief File containing the implementation of the cryptographic utilities.
  */
 
@@ -157,7 +157,7 @@ ssize_t crypto_decrypt(uint8_t *in, int in_size, uint8_t *key,
 {
 #ifdef WITH_OPENSSL_SERVICE
   EVP_CIPHER_CTX *ctx;
-  
+
   int len = 0;
   int plaintext_len = 0;
 
@@ -266,13 +266,13 @@ EVP_PKEY *crypto_generate_ec_key(void)
   if(!EVP_PKEY_CTX_set_ec_paramgen_curve_nid(ctx, NID_X9_62_prime256v1)) {
     log_trace("EVP_PKEY_CTX_set_ec_paramgen_curve_nid fail with code=%d", ERR_get_error());
     EVP_PKEY_CTX_free(ctx);
-    return NULL;    
+    return NULL;
   }
 
   if (!EVP_PKEY_paramgen(ctx, &params)) {
     log_trace("EVP_PKEY_paramgen fail with code=%d", ERR_get_error());
     EVP_PKEY_CTX_free(ctx);
-    return NULL;    
+    return NULL;
   }
 
 
@@ -280,7 +280,7 @@ EVP_PKEY *crypto_generate_ec_key(void)
 
   if((ctx = EVP_PKEY_CTX_new(params, NULL)) == NULL) {
     log_trace("EVP_PKEY_CTX_new fail with code=%d", ERR_get_error());
-    EVP_PKEY_free(params); 
+    EVP_PKEY_free(params);
     return NULL;
   }
 
@@ -327,7 +327,7 @@ X509* crypto_generate_cert(EVP_PKEY *pkey, struct certificate_meta *meta)
   X509_NAME_add_entry_by_txt(name, "O", MBSTRING_ASC, (unsigned char*)meta->o, -1, -1, 0);
   X509_NAME_add_entry_by_txt(name, "OU", MBSTRING_ASC, (unsigned char*)meta->ou, -1, -1, 0);
   X509_NAME_add_entry_by_txt(name, "CN", MBSTRING_ASC, (unsigned char*)meta->cn, -1, -1, 0);
-  
+
   X509_set_issuer_name(x509, name);
 
   /* sign the certificate with the key. */
@@ -417,7 +417,7 @@ char* crypto_get_key_str(bool private, EVP_PKEY *pkey)
 
   BIO_get_mem_ptr(mem, &ptr);
   if ((key_str = (char *) os_zalloc(ptr->length + 1)) == NULL) {
-    log_err("os_zalloc");
+    log_errno("os_zalloc");
     BIO_free(mem);
     return NULL;
   }
@@ -530,7 +530,7 @@ int crypto_generate_cert_str(struct certificate_meta *meta, uint8_t *key, size_t
 
   BIO_get_mem_ptr(mem, &ptr);
   if ((*cert = (char *) os_zalloc(ptr->length + 1)) == NULL) {
-    log_err("os_zalloc");
+    log_errno("os_zalloc");
     X509_free(x509);
     EVP_PKEY_free(pkey);
     BIO_free(mem);
@@ -652,7 +652,7 @@ ssize_t crypto_sign_data(uint8_t *key, size_t key_size, uint8_t *in, size_t in_s
   }
 
   if ((out_sig = os_malloc(sizeof(unsigned char) * (sig_len))) == NULL) {
-    log_err("os_malloc");
+    log_errno("os_malloc");
     EVP_PKEY_free(pkey);
     EVP_MD_CTX_destroy(ctx);
     return -1;

--- a/src/utils/domain.c
+++ b/src/utils/domain.c
@@ -18,8 +18,8 @@
  ****************************************************************************/
 
 /**
- * @file domain.c 
- * @author Alexandru Mereacre 
+ * @file domain.c
+ * @author Alexandru Mereacre
  * @brief File containing the implementation of the domain utils.
  */
 
@@ -72,7 +72,7 @@ int create_domain_client(char *addr)
 
   sock = socket(AF_UNIX, SOCK_DGRAM, 0);
   if (sock == -1) {
-    log_err("socket");
+    log_errno("socket");
     return -1;
   }
 
@@ -90,10 +90,10 @@ int create_domain_client(char *addr)
     addrlen = sizeof(struct sockaddr_un);
   }
 
-  
+
 
   if (bind(sock, (struct sockaddr *) &claddr, addrlen) == -1) {
-    log_err("bind");
+    log_errno("bind");
     return -1;
   }
 
@@ -107,7 +107,7 @@ int create_domain_server(char *server_path)
 
   sfd = socket(AF_UNIX, SOCK_DGRAM, 0);       /* Create server socket */
   if (sfd == -1) {
-    log_err("socket");
+    log_errno("socket");
     return -1;
   }
 
@@ -122,14 +122,14 @@ int create_domain_server(char *server_path)
   }
 
   if (remove(server_path) == -1 && errno != ENOENT) {
-    log_err("remove-%s", server_path);
+    log_errno("remove-%s", server_path);
     return -1;
   }
 
   init_domain_addr(&svaddr, server_path);
 
   if (bind(sfd, (struct sockaddr *) &svaddr, sizeof(struct sockaddr_un)) == -1) {
-    log_err("bind");
+    log_errno("bind");
     return -1;
   }
 
@@ -153,7 +153,7 @@ ssize_t read_domain_data(int sock, char *data, size_t data_len,
 
   ssize_t num_bytes = recvfrom(sock, data, data_len, flags, (struct sockaddr *) &addr->addr, (socklen_t *) &addr->len);
   if (num_bytes == -1) {
-    log_err("recvfrom");
+    log_errno("recvfrom");
     return -1;
   }
 
@@ -209,7 +209,7 @@ ssize_t write_domain_data(int sock, char *data, size_t data_len, struct client_a
   errno = 0;
   log_trace("Sending to socket on %.*s", addr->len, addr->addr.sun_path);
   if ((num_bytes = sendto(sock, data, data_len, 0, (struct sockaddr *) &addr->addr, addr->len)) < 0) {
-    log_err("sendto");
+    log_errno("sendto");
     return -1;
   }
 
@@ -250,13 +250,13 @@ int writeread_domain_data_str(char *socket_path, char *write_str, char **reply)
   log_trace("Sending to socket_path=%s", socket_path);
   send_count = write_domain_data_s(sfd, write_str, strlen(write_str), socket_path);
   if (send_count < 0) {
-    log_err("sendto");
+    log_errno("sendto");
     close(sfd);
     return -1;
   }
 
   if ((size_t)send_count != strlen(write_str)) {
-    log_err("write_domain_data_s fail");
+    log_errno("write_domain_data_s fail");
     close(sfd);
     return -1;
   }
@@ -265,14 +265,14 @@ int writeread_domain_data_str(char *socket_path, char *write_str, char **reply)
 
   errno = 0;
   if (select(sfd + 1, &readfds, NULL, NULL, &timeout) < 0) {
-    log_err("select");
+    log_errno("select");
     close(sfd);
     return -1;
   }
 
   if(FD_ISSET(sfd, &readfds)) {
     if (ioctl(sfd, FIONREAD, &bytes_available) == -1) {
-      log_err("ioctl");
+      log_errno("ioctl");
       close(sfd);
       return -1;
     }
@@ -280,7 +280,7 @@ int writeread_domain_data_str(char *socket_path, char *write_str, char **reply)
     log_trace("Socket received bytes available=%u", bytes_available);
     rec_data = os_zalloc(bytes_available + 1);
     if (rec_data == NULL) {
-      log_err("os_zalloc");
+      log_errno("os_zalloc");
       close(sfd);
       return -1;
     }

--- a/src/utils/eloop.c
+++ b/src/utils/eloop.c
@@ -95,7 +95,7 @@ int eloop_init(void)
 	dl_list_init(&eloop.timeout);
 	eloop.epollfd = epoll_create1(0);
 	if (eloop.epollfd < 0) {
-		log_err("epoll_create1 failed");
+		log_errno("epoll_create1 failed");
 		return -1;
 	}
 	eloop.readers.type = EVENT_TYPE_READ;
@@ -127,7 +127,7 @@ static int eloop_sock_queue(int sock, eloop_event_type type)
 	}
 	ev.data.fd = sock;
 	if (epoll_ctl(eloop.epollfd, EPOLL_CTL_ADD, sock, &ev) < 0) {
-		log_err("epoll_ctl(ADD) for fd=%d failed", sock);
+		log_errno("epoll_ctl(ADD) for fd=%d failed", sock);
 		return -1;
 	}
 	return 0;
@@ -168,7 +168,7 @@ static int eloop_sock_table_add_sock(struct eloop_sock_table *table,
 		temp_events = os_realloc_array(eloop.epoll_events, next,
 					       sizeof(struct epoll_event));
 		if (temp_events == NULL) {
-			log_err("os_malloc for epoll failed");
+			log_errno("os_malloc for epoll failed");
 			return -1;
 		}
 
@@ -186,7 +186,7 @@ static int eloop_sock_table_add_sock(struct eloop_sock_table *table,
 	tmp[table->count].eloop_data = eloop_data;
 	tmp[table->count].user_data = user_data;
 	tmp[table->count].handler = handler;
-	
+
 	table->count++;
 	table->table = tmp;
 	eloop.max_sock = new_max_sock;
@@ -226,7 +226,7 @@ static void eloop_sock_table_remove_sock(struct eloop_sock_table *table,
 	table->changed = 1;
 
 	if (epoll_ctl(eloop.epollfd, EPOLL_CTL_DEL, sock, NULL) < 0) {
-		log_err("epoll_ctl(DEL) for fd=%d failed", sock);
+		log_errno("epoll_ctl(DEL) for fd=%d failed", sock);
 		return;
 	}
 	os_memset(&eloop.fd_table[sock], 0, sizeof(struct eloop_sock));
@@ -644,7 +644,7 @@ void eloop_run(void)
 					 eloop.count, timeout_ms);
 		}
 		if (res < 0 && errno != EINTR && errno != 0) {
-			log_err("eloop");
+			log_errno("eloop");
 			goto out;
 		}
 

--- a/src/utils/hashmap.c
+++ b/src/utils/hashmap.c
@@ -19,7 +19,7 @@
 
 /**
  * @file hashmap.c
- * @author Alexandru Mereacre 
+ * @author Alexandru Mereacre
  * @brief File containing the implementation of the hashmap utilities.
  */
 
@@ -79,7 +79,7 @@ bool hmap_str_keychar_put(hmap_str_keychar **hmap, char *keyptr, char *value)
   	if (s == NULL) {
   	  s = (hmap_str_keychar *) os_malloc(sizeof(hmap_str_keychar));
 	  if (s == NULL) {
-		log_err("os_malloc");
+		log_errno("os_malloc");
 		return false;
 	  }
 

--- a/src/utils/iface.c
+++ b/src/utils/iface.c
@@ -86,7 +86,7 @@ struct iface_context* iface_init_context(void *params)
   struct iface_context *ctx = os_zalloc(sizeof(struct iface_context));
 
   if (ctx == NULL) {
-    log_err("os_zalloc");
+    log_errno("os_zalloc");
     return NULL;
   }
 
@@ -126,7 +126,7 @@ UT_array *iface_get(char *ifname)
   netif_info_t nif;
 
   if (getifaddrs(&ifaddr) == -1) {
-    log_err("getifaddrs");
+    log_errno("getifaddrs");
     return NULL;
   }
 
@@ -147,7 +147,7 @@ UT_array *iface_get(char *ifname)
         ipaddr, NI_MAXHOST, NULL, 0, NI_NUMERICHOST);
 
       if (ret != 0) {
-        log_err("getnameinfo");
+        log_errno("getnameinfo");
         utarray_free(interfaces);
         return NULL;
       }

--- a/src/utils/iface_mapper.c
+++ b/src/utils/iface_mapper.c
@@ -63,7 +63,7 @@ int get_if_mapper(hmap_if_conn **hmap, in_addr_t subnet, char *ifname)
 	os_memcpy(ifname, s->value, IFNAMSIZ);
     return 1;
   }
- 
+
   return 0;
 }
 
@@ -86,7 +86,7 @@ bool put_if_mapper(hmap_if_conn **hmap, in_addr_t subnet, char *ifname)
   if (s == NULL) {
     s = (hmap_if_conn *) os_malloc(sizeof(hmap_if_conn));
 	  if (s == NULL) {
-	    log_err("os_malloc");
+	    log_errno("os_malloc");
 	    return false;
 	  }
 
@@ -100,7 +100,7 @@ bool put_if_mapper(hmap_if_conn **hmap, in_addr_t subnet, char *ifname)
     os_memcpy(s->value, ifname, IFNAMSIZ);
   }
 
-  return true;	
+  return true;
 }
 
 void free_if_mapper(hmap_if_conn **hmap)
@@ -131,7 +131,7 @@ int get_vlan_mapper(hmap_vlan_conn **hmap, int vlanid, struct vlan_conn	*conn)
 
     return 1;
   }
- 
+
   return 0;
 }
 
@@ -155,7 +155,7 @@ bool put_vlan_mapper(hmap_vlan_conn **hmap, struct vlan_conn *conn)
     s = (hmap_vlan_conn *) os_malloc(sizeof(hmap_vlan_conn));
 
 	  if (s == NULL) {
-	    log_err("os_malloc");
+	    log_errno("os_malloc");
 	    return false;
 	  }
 
@@ -169,7 +169,7 @@ bool put_vlan_mapper(hmap_vlan_conn **hmap, struct vlan_conn *conn)
     os_memcpy(&s->value, conn, sizeof(struct vlan_conn));
   }
 
-  return true;	
+  return true;
 }
 
 void free_vlan_mapper(hmap_vlan_conn **hmap)
@@ -193,12 +193,12 @@ int find_ifinfo(UT_array *config_ifinfo_array, char *ip, config_ifinfo_t *ifinfo
 	    log_trace("ip_2_nbo fail");
 	    return -1;
 	  }
-  
+
 	  if (ip_2_nbo(ip, p->subnet_mask, &addr_ip) < 0) {
 	    log_trace("ip_2_nbo fail");
 	    return -1;
 	  }
-  
+
 	  if (addr_ip == addr_subnet) {
       os_memcpy(ifinfo, p, sizeof(config_ifinfo_t));
 	    return 0;
@@ -316,12 +316,12 @@ int init_ifbridge_names(UT_array *config_ifinfo_array, char *ifname, char *brnam
 
   while((p = (config_ifinfo_t *) utarray_next(config_ifinfo_array, p)) != NULL) {
     if (snprintf(p->ifname, IFNAMSIZ, "%s%d", ifname, p->vlanid) < 0) {
-      log_err("snprintf");
+      log_errno("snprintf");
       return -1;
     }
 
     if (snprintf(p->brname, IFNAMSIZ, "%s%d", brname, p->vlanid) < 0) {
-      log_err("snprintf");
+      log_errno("snprintf");
       return -1;
     }
   }

--- a/src/utils/ipgen.c
+++ b/src/utils/ipgen.c
@@ -18,7 +18,7 @@
  ****************************************************************************/
 
 /**
- * @file ipgen.h 
+ * @file ipgen.h
  * @author Alexandru Mereacre
  * @brief File containing the definition of the ip generic interface utilities.
  */
@@ -46,7 +46,7 @@ struct ipgenctx* ipgen_init_context(char *path)
   struct ipgenctx *context = os_zalloc(sizeof(struct ipgenctx));
 
   if (context == NULL) {
-    log_err("os_zalloc");
+    log_errno("os_zalloc");
     return NULL;
   }
 
@@ -57,7 +57,7 @@ struct ipgenctx* ipgen_init_context(char *path)
 
 /**
  * @brief Frees the ipgen context
- * 
+ *
  * @param context The ipgen context
  */
 void ipgen_free_context(struct ipgenctx *context)

--- a/src/utils/log.c
+++ b/src/utils/log.c
@@ -21,8 +21,8 @@
  */
 
 /**
- * @file log.h 
- * @authors rxi, Alexandru Mereacre 
+ * @file log.h
+ * @authors rxi, Alexandru Mereacre
  * @brief File containing the implementation of the logging functions.
  */
 
@@ -226,13 +226,13 @@ void print_to(uint8_t level, const char *file, uint32_t line,
 
   if (err > 0 && err <= MAX_ENAME)
     fprintf(stream, "[%s] ", strerror(err));
-  
+
   vfprintf(stream, format, args);
   fprintf(stream, "\n");
-  fflush(stream); 
+  fflush(stream);
 }
 
-void log_msg(uint8_t level, const char *file, uint32_t line, bool flush_std, 
+void log_msg(uint8_t level, const char *file, uint32_t line, bool flush_std,
   bool ignore_level, uint8_t err, const char *format, va_list args)
 {
   (void) flush_std; /* unused */
@@ -271,7 +271,8 @@ void log_levels(uint8_t level, const char *file, uint32_t line, const char *form
   va_end(args);
 }
 
-void log_error(uint8_t level, const char *file, uint32_t line, const char *format, ...)
+/* Display error message including 'errno' diagnostic */
+void log_errno_error(uint8_t level, const char *file, uint32_t line, const char *format, ...)
 {
   uint8_t saved_errno;
   va_list args;

--- a/src/utils/log.h
+++ b/src/utils/log.h
@@ -57,6 +57,11 @@ static inline int snprintf_error(size_t size, int res)
 #define log_info(...)  log_levels(LOGC_INFO,  __FILENAME__, __LINE__, __VA_ARGS__)
 #define log_warn(...)  log_levels(LOGC_WARN,  __FILENAME__, __LINE__, __VA_ARGS__)
 /**
+ * @brief Logs an error message.
+ * Do not use this for if you want to log `errno`, instead use `log_errno` for this.
+ */
+#define log_error(...) log_levels(LOGC_ERROR, __FILENAME__, __LINE__, __VA_ARGS__)
+/**
  * @brief
  * Logs an error message using the value of `errno`.
  * This should be used for errors that set `errno` (e.g. system errors)

--- a/src/utils/log.h
+++ b/src/utils/log.h
@@ -61,7 +61,7 @@ static inline int snprintf_error(size_t size, int res)
  * Logs an error message using the value of `errno`.
  * This should be used for errors that set `errno` (e.g. system errors)
  */
-#define log_errno(...) log_error(LOGC_ERROR, __FILENAME__, __LINE__, __VA_ARGS__)
+#define log_errno(...) log_errno_error(LOGC_ERROR, __FILENAME__, __LINE__, __VA_ARGS__)
 
 #define log_err_ex(...) log_error_exit(LOGC_ERROR, __FILENAME__, __LINE__, __VA_ARGS__)
 #define log_err_exp(...) log_error_exit_proc(LOGC_ERROR, __FILENAME__, __LINE__, __VA_ARGS__)
@@ -76,7 +76,7 @@ int log_open_file(char *path);
 void log_close_file(void);
 
 void log_levels(uint8_t level, const char *file, uint32_t line, const char *format, ...);
-void log_error(uint8_t level, const char *file, uint32_t line, const char *format, ...);
+void log_errno_error(uint8_t level, const char *file, uint32_t line, const char *format, ...);
 void log_error_exit(uint8_t level, const char *file, uint32_t line, const char *format, ...);
 void log_error_exit_proc(uint8_t level, const char *file, uint32_t line, const char *format, ...);
 

--- a/src/utils/log.h
+++ b/src/utils/log.h
@@ -6,8 +6,8 @@
  */
 
 /**
- * @file log.h 
- * @authors rxi, Alexandru Mereacre 
+ * @file log.h
+ * @authors rxi, Alexandru Mereacre
  * @brief File containing the definition of the logging functions.
  */
 
@@ -56,7 +56,12 @@ static inline int snprintf_error(size_t size, int res)
 #define log_debug(...) log_levels(LOGC_DEBUG, __FILENAME__, __LINE__, __VA_ARGS__)
 #define log_info(...)  log_levels(LOGC_INFO,  __FILENAME__, __LINE__, __VA_ARGS__)
 #define log_warn(...)  log_levels(LOGC_WARN,  __FILENAME__, __LINE__, __VA_ARGS__)
-#define log_err(...) log_error(LOGC_ERROR, __FILENAME__, __LINE__, __VA_ARGS__)
+/**
+ * @brief
+ * Logs an error message using the value of `errno`.
+ * This should be used for errors that set `errno` (e.g. system errors)
+ */
+#define log_errno(...) log_error(LOGC_ERROR, __FILENAME__, __LINE__, __VA_ARGS__)
 
 #define log_err_ex(...) log_error_exit(LOGC_ERROR, __FILENAME__, __LINE__, __VA_ARGS__)
 #define log_err_exp(...) log_error_exit_proc(LOGC_ERROR, __FILENAME__, __LINE__, __VA_ARGS__)

--- a/src/utils/net.c
+++ b/src/utils/net.c
@@ -69,7 +69,7 @@ bool validate_ipv4_string(char *ip)
   errno = 0;
   ret = inet_pton(AF_INET, proc_ip, &(sa.sin_addr));
   if (ret == -1) {
-	  log_err("inet_pton");
+	  log_errno("inet_pton");
 	  return false;
   }
 
@@ -121,10 +121,10 @@ int ip4_2_buf(char *ip, uint8_t *buf)
 
   errno = 0;
   if (inet_pton(AF_INET, ip, &addr) < 0) {
-	  log_err("inet_pton");
+	  log_errno("inet_pton");
 	  return -1;
   }
-  
+
   buf[0] = (uint8_t) (addr.s_addr & 0x000000FF);
   buf[1] = (uint8_t) ((addr.s_addr >> 8) & 0x000000FF);
   buf[2] = (uint8_t) ((addr.s_addr >> 16) & 0x000000FF);
@@ -175,7 +175,7 @@ uint8_t get_short_subnet(char *subnet_mask)
 int get_ip_host(char *ip, char *subnet_mask, uint32_t *host)
 {
   uint8_t ipbuf[4], mbuf[4];
-  
+
   if (ip4_2_buf(ip, ipbuf) < 0) {
     log_trace("ip4_2_buf fail");
     return -1;

--- a/src/utils/nl.c
+++ b/src/utils/nl.c
@@ -125,7 +125,7 @@ void free_nlmsg_chain(struct nlmsg_chain *info)
 int ip_link_list(req_filter_fn_t filter_fn, struct nlmsg_chain *linfo)
 {
 	if (rtnl_linkdump_req_filter_fn(&rth, 0, filter_fn) < 0) {
-		log_err("Cannot send dump request");
+		log_errno("Cannot send dump request");
 		return 1;
 	}
 
@@ -151,7 +151,7 @@ static int iplink_filter_req(struct nlmsghdr *nlh, int reqlen)
 static int ipaddr_dump_filter(struct nlmsghdr *nlh, int reqlen)
 {
   (void) reqlen;
-	
+
   struct ifaddrmsg *ifa = NLMSG_DATA(nlh);
 
   ifa->ifa_index = ifindex;
@@ -164,7 +164,7 @@ static int ip_addr_list(struct nlmsg_chain *ainfo, int if_id)
 	ifindex = if_id;
 
 	if (rtnl_addrdump_req(&rth, 0, ipaddr_dump_filter) < 0) {
-		log_err("Cannot send dump request");
+		log_errno("Cannot send dump request");
 		return 1;
 	}
 
@@ -211,7 +211,7 @@ enum IF_STATE get_operstate(__u8 state)
 	if (state >= 7) {
 		return IF_STATE_OTHER;
 	} else {
-		return (enum IF_STATE) state; 
+		return (enum IF_STATE) state;
 	}
 }
 
@@ -244,7 +244,7 @@ int get_addrinfo(struct nlmsghdr *n, netif_info_t *info)
 
 	info->ifa_family = ifa->ifa_family;
 	const char *name = family_name(ifa->ifa_family);
-	
+
 	if (*name != '?') {
 		log_trace("ifindex=%d family=%s", info->ifindex, name);
 	} else {
@@ -327,7 +327,7 @@ int get_linkinfo(struct nlmsghdr *n, netif_info_t *info)
 	if (tb[IFLA_OPERSTATE]) {
 		info->state = get_operstate(rta_getattr_u8(tb[IFLA_OPERSTATE]));
 	} else
-		info->state = IF_STATE_UNKNOWN;	
+		info->state = IF_STATE_UNKNOWN;
 
 	log_trace("ifindex=%d state=%d", ifi->ifi_index, info->state);
 	os_strlcpy(info->link_type, ll_type_n2a(ifi->ifi_type, b1, sizeof(b1)), LINK_TYPE_LEN);
@@ -732,7 +732,7 @@ UT_array *nl_get_interfaces(int if_id)
 		res = get_linkinfo(n, &el);
 		if (res >= 0)
 			get_selected_addrinfo(ifi, ainfo->head, &el);
-		
+
 		utarray_push_back(arr, &el);
 	}
 
@@ -753,7 +753,7 @@ bool nl_new_interface(char *if_name, char *type)
 {
 	int ret;
 	char *argv[4] = {"name", if_name, "type", type};
-	
+
 	log_trace("nl_new_interface for if_name=%s type=%s", if_name, type);
 
 	if (rtnl_open(&rth, 0) < 0) {
@@ -762,7 +762,7 @@ bool nl_new_interface(char *if_name, char *type)
 	}
 
 	rtnl_set_strict_dump(&rth);
-	
+
 	if (iplink_have_newlink()) {
 		ret = iplink_modify(RTM_NEWLINK, NLM_F_CREATE|NLM_F_EXCL, 4, argv);
 		if (ret != 0) {
@@ -794,7 +794,7 @@ bool nl_set_interface_ip(char *ip_addr, char *brd_addr, char *if_name)
 	}
 
 	rtnl_set_strict_dump(&rth);
-	
+
 	int ret;
 	ret = ipaddr_modify(RTM_NEWADDR, NLM_F_CREATE|NLM_F_EXCL, 5, argv);
 	if (ret != 0) {
@@ -814,7 +814,7 @@ bool nl_set_interface_state(char *if_name, bool state)
 {
 	char *if_state = (state) ? "up" : "down";
 	char *argv[3] = {"dev", if_name, if_state};
-	
+
 	log_trace("set_interface_state for if_name=%s if_state=%s", if_name, if_state);
 
 	if (rtnl_open(&rth, 0) < 0) {
@@ -823,7 +823,7 @@ bool nl_set_interface_state(char *if_name, bool state)
 	}
 
 	rtnl_set_strict_dump(&rth);
-	
+
 	int ret;
 
 	if (iplink_have_newlink()) {
@@ -850,7 +850,7 @@ struct nlctx* nl_init_context(void)
   struct nlctx *context = os_zalloc(sizeof(struct nlctx));
 
   if (context == NULL) {
-    log_err("os_zalloc");
+    log_errno("os_zalloc");
     return NULL;
   }
 
@@ -1011,12 +1011,12 @@ static int nl80211_init(struct nl80211_state *state)
 
 	state->nl_sock = nl_socket_alloc();
 	if (!state->nl_sock) {
-		log_err("Failed to allocate netlink socket");
+		log_errno("Failed to allocate netlink socket");
 		return -ENOMEM;
 	}
 
 	if (genl_connect(state->nl_sock)) {
-		log_err("Failed to connect to generic netlink");
+		log_errno("Failed to connect to generic netlink");
 		err = -ENOLINK;
 		goto out_handle_destroy;
 	}
@@ -1030,7 +1030,7 @@ static int nl80211_init(struct nl80211_state *state)
 
 	state->nl80211_id = genl_ctrl_resolve(state->nl_sock, "nl80211");
 	if (state->nl80211_id < 0) {
-		log_err("nl80211 not found");
+		log_errno("nl80211 not found");
 		err = -ENOENT;
 		goto out_handle_destroy;
 	}
@@ -1115,7 +1115,7 @@ static int process_iface_handler(struct nl_msg *msg, void *arg)
 
 static int8_t nl_new(struct nl80211_state *nlstate, struct nl_cb **cb, struct nl_msg **msg, int *err)
 {
-	if (nl80211_init(nlstate)) {		
+	if (nl80211_init(nlstate)) {
 		return -1;
 	}
 

--- a/src/utils/squeue.c
+++ b/src/utils/squeue.c
@@ -19,7 +19,7 @@
 
 /**
  * @file squeue.c
- * @author Alexandru Mereacre 
+ * @author Alexandru Mereacre
  * @brief File containing the implementation of the string queue utilities.
  */
 
@@ -38,7 +38,7 @@ struct string_queue* init_string_queue(ssize_t max_length)
   queue = os_zalloc(sizeof(*queue));
 
   if (queue == NULL) {
-    log_err("os_zalloc");
+    log_errno("os_zalloc");
     return NULL;
   }
 
@@ -166,7 +166,7 @@ char* concat_string_queue(struct string_queue *queue, ssize_t count)
       } else concat_str = os_realloc(concat_str, size);
 
       if (concat_str == NULL) {
-        log_err("os_malloc");
+        log_errno("os_malloc");
         return NULL;
       }
 
@@ -184,7 +184,7 @@ char* concat_string_queue(struct string_queue *queue, ssize_t count)
   //     } else concat_str = os_realloc(concat_str, size);
 
   //     if (concat_str == NULL) {
-  //       log_err("os_malloc");
+  //       log_errno("os_malloc");
   //       return NULL;
   //     }
 

--- a/src/utils/uci_wrt.c
+++ b/src/utils/uci_wrt.c
@@ -92,7 +92,7 @@ char* uci_lookup_section_ref(struct uci_section *s, struct uci_type_list *list, 
 
 	if (ti == NULL) {
 		if ((ti = os_calloc(1, sizeof(struct uci_type_list))) == NULL) {
-      log_err("os_calloc");
+      log_errno("os_calloc");
       return NULL;
     }
 
@@ -105,13 +105,13 @@ char* uci_lookup_section_ref(struct uci_section *s, struct uci_type_list *list, 
 		maxlen = strlen(s->type) + 1 + 2 + 10;
 		if (*typestr == NULL) {
 			if ((*typestr = os_malloc(maxlen)) == NULL) {
-        log_err("os_malloc");
+        log_errno("os_malloc");
         return NULL;
       }
 		} else {
 			void *p = os_realloc(*typestr, maxlen);
 			if (p == NULL) {
-        log_err("os_realloc");
+        log_errno("os_realloc");
 				os_free(*typestr);
 				return NULL;
 			}
@@ -142,7 +142,7 @@ char* uwrt_get_option(struct uci_option *o)
 	switch(o->type) {
 	case UCI_TYPE_STRING:
     if ((vname = os_strdup(o->v.string)) == NULL) {
-      log_err("os_strdup");
+      log_errno("os_strdup");
       return NULL;
     }
     break;
@@ -188,7 +188,7 @@ int uwrt_lookup_option(struct uci_option *o, char *sref, UT_array *kv)
   }
 
   if ((kvstr = os_zalloc(strlen(cname) + strlen(sname) + strlen(oname) + strlen(vname) + 4)) == NULL) {
-    log_err("os_zalloc");
+    log_errno("os_zalloc");
     os_free(vname);
     return -1;
   }
@@ -210,7 +210,7 @@ int uwrt_lookup_section(struct uci_section *s, char *sref, UT_array *kv)
   char *kvstr = NULL;
 
   if ((kvstr = os_zalloc(strlen(cname) + strlen(sname) + strlen(vname) + 3)) == NULL) {
-    log_err("os_zalloc");
+    log_errno("os_zalloc");
     return -1;
   }
 
@@ -434,7 +434,7 @@ struct uctx* uwrt_init_context(char *path)
   struct uctx *context = os_zalloc(sizeof(struct uctx));
 
   if (context == NULL) {
-    log_err("os_zalloc");
+    log_errno("os_zalloc");
     return NULL;
   }
 
@@ -468,9 +468,9 @@ UT_array *uwrt_get_interfaces(struct uctx *context, char *ifname)
 
   while(true) {
     if (ifname == NULL) {
-      snprintf(key, 64, "network.@interface[%d]", idx++); 
+      snprintf(key, 64, "network.@interface[%d]", idx++);
     } else {
-      snprintf(key, 64, "network.%s", ifname); 
+      snprintf(key, 64, "network.%s", ifname);
     }
 
     utarray_new(kv, &ut_str_icd);
@@ -598,7 +598,7 @@ int uwrt_commit_section(struct uctx *context, char *section)
   char *psection = os_strdup(section);
 
   if (psection == NULL) {
-    log_err("os_strdup");
+    log_errno("os_strdup");
     return -1;
   }
 
@@ -840,7 +840,7 @@ int uwrt_gen_hostapd_instance(struct uctx *context, struct hostapd_params *param
 
   if (params->device == NULL) {
     log_trace("device param is NULL");
-    return -1;    
+    return -1;
   }
 
   sprintf(property, "wireless.%s=wifi-device", params->device);

--- a/tests/radius/radius_client.c
+++ b/tests/radius/radius_client.c
@@ -355,7 +355,7 @@ static int radius_client_handle_send_error(struct radius_client_data *radius,
 {
 #ifndef CONFIG_NATIVE_WINDOWS
 	int _errno = errno;
-	log_err("send[RADIUS,s=%d]", s);
+	log_errno("send[RADIUS,s=%d]", s);
 	if (_errno == ENOTCONN || _errno == EDESTADDRREQ || _errno == EINVAL ||
 	    _errno == EBADF || _errno == ENETUNREACH || _errno == EACCES) {
 		log_trace("Send failed - maybe interface status changed - try to connect again");
@@ -825,7 +825,7 @@ static void radius_client_receive(int sock, void *eloop_ctx, void *sock_ctx)
 
 	len = recv(sock, buf, sizeof(buf), MSG_DONTWAIT);
 	if (len < 0) {
-		log_err("recv[RADIUS]");
+		log_errno("recv[RADIUS]");
 		return;
 	}
 	log_trace("Received %d bytes from RADIUS server", len);
@@ -1153,7 +1153,7 @@ radius_change_server(struct radius_client_data *radius,
 		}
 
 		if (bind(sel_sock, cl_addr, claddrlen) < 0) {
-			log_err("bind[radius]");
+			log_errno("bind[radius]");
 			return -1;
 		}
 	}
@@ -1164,7 +1164,7 @@ radius_change_server(struct radius_client_data *radius,
 		log_trace("disconnect[radius]");
 
 	if (connect(sel_sock, addr, addrlen) < 0) {
-		log_err("connect[radius]");
+		log_errno("connect[radius]");
 		return -1;
 	}
 
@@ -1255,7 +1255,7 @@ static int radius_client_disable_pmtu_discovery(int s)
 	r = setsockopt(s, IPPROTO_IP, IP_MTU_DISCOVER, &action,
 		       sizeof(action));
 	if (r == -1)
-		log_err("RADIUS: Failed to set IP_MTU_DISCOVER");
+		log_errno("RADIUS: Failed to set IP_MTU_DISCOVER");
 #endif
 	return r;
 }
@@ -1308,7 +1308,7 @@ static int radius_client_init_auth(struct radius_client_data *radius)
 
 	radius->auth_serv_sock = socket(PF_INET, SOCK_DGRAM, 0);
 	if (radius->auth_serv_sock < 0)
-		log_err("RADIUS: socket[PF_INET,SOCK_DGRAM]");
+		log_errno("RADIUS: socket[PF_INET,SOCK_DGRAM]");
 	else {
 		radius_client_disable_pmtu_discovery(radius->auth_serv_sock);
 		ok++;
@@ -1363,7 +1363,7 @@ static int radius_client_init_acct(struct radius_client_data *radius)
 
 	radius->acct_serv_sock = socket(PF_INET, SOCK_DGRAM, 0);
 	if (radius->acct_serv_sock < 0)
-		log_err("RADIUS: socket[PF_INET,SOCK_DGRAM]");
+		log_errno("RADIUS: socket[PF_INET,SOCK_DGRAM]");
 	else {
 		radius_client_disable_pmtu_discovery(radius->acct_serv_sock);
 		ok++;

--- a/tests/test_engine.c
+++ b/tests/test_engine.c
@@ -46,7 +46,37 @@ static void test_init_context(void **state)
   utarray_free(app_config.config_ifinfo_array);
   free_bridge_list(context.bridge_list);
   free_sqlite_macconn_db(context.macconn_db);
+}
 
+/**
+ * @brief Tests whether the init_context function fails when the config_ifinfo_array
+ * param is invalid.
+ * This should also log an error message (not a debug/info message)
+ * (run test manually to see whether this appears in your console)
+ */
+static void test_init_context_failure(void **state) {
+  (void) state; /* unused */
+  struct supervisor_context context;
+  struct app_config app_config = {0, .quarantine_vlanid = -1, .default_open_vlanid = -1};
+
+  // Load the bin paths array
+  const char * paths[] = {
+    "/bin", "/usr/bin", "/usr/sbin"
+  };
+  utarray_new(app_config.bin_path_array, &ut_str_icd);
+  for (size_t idx = 0; idx < sizeof(paths) / sizeof(paths[0]); idx++) {
+    utarray_push_back(app_config.bin_path_array, &(paths[idx]));
+  }
+
+  int context_error = init_context(&app_config, &context);
+  // should log an error about invalid config_ifinfo_array
+  assert_int_equal(context_error, -1);
+
+  if (context_error == 0) { // automatically frees on error
+    utarray_free(app_config.bin_path_array);
+  }
+  free_bridge_list(context.bridge_list);
+  free_sqlite_macconn_db(context.macconn_db);
 }
 
 int main(int argc, char *argv[])
@@ -57,7 +87,8 @@ int main(int argc, char *argv[])
   log_set_quiet(false);
 
   const struct CMUnitTest tests[] = {
-    cmocka_unit_test(test_init_context)
+    cmocka_unit_test(test_init_context),
+    cmocka_unit_test(test_init_context_failure)
   };
 
   return cmocka_run_group_tests(tests, NULL, NULL);

--- a/tests/utils/test_log_err.c
+++ b/tests/utils/test_log_err.c
@@ -8,6 +8,6 @@
 #include "utils/log.h"
 
 int main(int argc, char *argv[]) {
-    log_err("Hello %s", "world");
+    log_errno("Hello %s", "world");
     exit(0);
 }


### PR DESCRIPTION
Things changed:
  - `log_err()` is now called `log_errno()`. This is to better describe how this macro should only be used to log `errno` errors.
  - The function `log_error()` is now called `log_errno_error()`. This is to better describe that this function should only be used to log `errno` errors.
  - [Add log_error() macro for logging program errors](https://github.com/nqminds/EDGESec/commit/95f057e1349e3f4f4c0f3ec11e91f2f25400bf19)
    - This macro will be used to log custom EDGESec errors **without** using `errno`.
      **This is how the original `log.c` library works, see** https://github.com/rxi/log.c/blob/f9ea34994bd58ed342d2245cd4110bb5c6790153/src/log.h#L37
  - [Change hostap log_trace to log_errno()](https://github.com/nqminds/EDGESec/commit/a1e3c9c5d341564747fa5a62995040a64b2e30bf)
    - According to original HostApd radius_server.c source-code,
      this should be logging the errno value, as it checks why `bind()` failed (system call).
      See https://w1.fi/cgit/hostap/tree/src/radius/radius_server.c#n1950
  - [Handle NULL config_ifinfo_array in engine()](https://github.com/nqminds/EDGESec/commit/67e9e53a712109763362c0361546614bc138e36d)
    Previously, this would throw a segmentation fault.
    Now this logs an error instead using `log_error()` (so **not** using `errno`)
    See discussion in https://github.com/nqminds/EDGESec/pull/106#discussion_r847079847 and https://github.com/nqminds/EDGESec/pull/106#discussion_r847171055
