### PR TITLE
style: Remove EOL whitespace

### DIFF
--- a/src/ap/ap_config.h
+++ b/src/ap/ap_config.h
@@ -18,11 +18,11 @@
  ****************************************************************************/
 
 /**
- * @file ap_config.h 
- * @author Alexandru Mereacre 
+ * @file ap_config.h
+ * @author Alexandru Mereacre
  * @brief File containing the definition of AP config structures.
- * 
- * Defines the access point (AP) configuration structure used to configure the 
+ *
+ * Defines the access point (AP) configuration structure used to configure the
  * AP service.
  */
 
@@ -46,7 +46,7 @@
 
 /**
  * @brief The AP conection status
- * 
+ *
  * Defines the connection state for a station connected to the AP.
  */
 enum AP_CONNECTION_STATUS {
@@ -57,7 +57,7 @@ enum AP_CONNECTION_STATUS {
 
 /**
  * @brief The hostapd configuration structure
- * 
+ *
  */
 struct apconf {
   char ap_bin_path[MAX_OS_PATH_LEN];             /**< The AP binary path string */

--- a/src/ap/ap_service.c
+++ b/src/ap/ap_service.c
@@ -18,11 +18,11 @@
  ****************************************************************************/
 
 /**
- * @file hostapd_service.c 
- * @author Alexandru Mereacre 
+ * @file hostapd_service.c
+ * @author Alexandru Mereacre
  * @brief File containing the implementation of the hostapd service.
- * 
- * Defines the functions to start and stop the acces point service (AP). It also 
+ *
+ * Defines the functions to start and stop the acces point service (AP). It also
  * defines auxiliary commands to manage the acces control list for stations
  * connected to the AP.
  */

--- a/src/ap/ap_service.h
+++ b/src/ap/ap_service.h
@@ -18,11 +18,11 @@
  ****************************************************************************/
 
 /**
- * @file ap_service.h 
- * @author Alexandru Mereacre 
+ * @file ap_service.h
+ * @author Alexandru Mereacre
  * @brief File containing the definition of the ap service.
- * 
- * Defines the functions to start and stop the acces point service (AP). It also 
+ *
+ * Defines the functions to start and stop the acces point service (AP). It also
  * defines auxiliary commands to manage the acces control list for stations
  * connected to the AP.
  */
@@ -53,7 +53,7 @@
 
 /**
  * @brief Runs the AP service
- * 
+ *
  * @param context The supervisor context structure
  * @param exec_ap Flag to execute/signal the AP process
  * @param generate_ssid Flag to generate the SSID for AP
@@ -65,15 +65,15 @@ int run_ap(struct supervisor_context *context, bool exec_ap, bool generate_ssid,
 
 /**
  * @brief Closes (terminates) AP process
- * 
+ *
  * @param context The supervisor context structure
  * @return true success, false otherwise
  */
 bool close_ap(struct supervisor_context *context);
 
 /**
- * @brief Deny ACL ADD AP command 
- * 
+ * @brief Deny ACL ADD AP command
+ *
  * @param hconf AP config structure
  * @param mac_addr The mac address to add to deny list
  * @return int 0 on success, -1 on failure
@@ -81,8 +81,8 @@ bool close_ap(struct supervisor_context *context);
 int denyacl_add_ap_command(struct apconf *hconf, char *mac_addr);
 
 /**
- * @brief Deny ACL DEL AP command 
- * 
+ * @brief Deny ACL DEL AP command
+ *
  * @param hconf AP config structure
  * @param mac_addr The mac address to remove from deny list
  * @return int 0 on success, -1 on failure
@@ -91,7 +91,7 @@ int denyacl_del_ap_command(struct apconf *hconf, char *mac_addr);
 
 /**
  * @brief Disconnect and reconnect a MAC device from the AP
- * 
+ *
  * @param hconf AP config structure
  * @param mac_addr The mac address to disconnect
  * @return int 0 on success, -1 on failure
@@ -100,7 +100,7 @@ int disconnect_ap_command(struct apconf *hconf, char *mac_addr);
 
 /**
  * @brief Check if a station is registered on the AP
- * 
+ *
  * @param hconf AP config structure
  * @param mac_addr The mac address of the station
  * @return int 0 on success, -1 on failure

--- a/src/ap/hostapd.c
+++ b/src/ap/hostapd.c
@@ -19,9 +19,9 @@
 
 /**
  * @file hostapd.c
- * @author Alexandru Mereacre 
+ * @author Alexandru Mereacre
  * @brief File containing the implementation of hostapd config generation utilities.
- * 
+ *
  * Defines function that generate the hostapd daemon configuration file and
  * manages (execute, kill and signal) the hostapd process.
  */

--- a/src/ap/hostapd.h
+++ b/src/ap/hostapd.h
@@ -18,10 +18,10 @@
  ****************************************************************************/
 
 /**
- * @file hostapd.h 
- * @author Alexandru Mereacre 
+ * @file hostapd.h
+ * @author Alexandru Mereacre
  * @brief File containing the definition of hostapd config generation utilities.
- * 
+ *
  * Defines function that generate the hostapd daemon configuration file and
  * manages (execute, kill and signal) the hostapd process.
  */
@@ -39,7 +39,7 @@
 
 /**
  * @brief Generates and saves the hostapd configuration files
- * 
+ *
  * @param hconf The hostapd configuration structure
  * @param rconf The radius configuration structure
  * @return 0 if config file saved, -1 otherwise
@@ -48,7 +48,7 @@ int generate_hostapd_conf(struct apconf *hconf, struct radius_conf *rconf);
 
 /**
  * @brief Generates and save the VLAN configuration file
- * 
+ *
  * @param vlan_file The VLAN configuration file path
  * @param interface The WiFi AP interface name
  * @return 0 if VLAN config file saved, -1 otherwise
@@ -57,7 +57,7 @@ int generate_vlan_conf(char *vlan_file, char *interface);
 
 /**
  * @brief Executes the hostapd process
- * 
+ *
  * @param hconf The hostapd process config structure
  * @return int 0 on success, -1 on failure
  */
@@ -65,7 +65,7 @@ int run_ap_process(struct apconf *hconf);
 
 /**
  * @brief Signal the AP process to reload the config
- * 
+ *
  * @param hconf The hostapd process config structure
  * @return int 0 on success, -1 on failure
  */
@@ -73,8 +73,8 @@ int signal_ap_process(struct apconf *hconf);
 
 /**
  * @brief Terminate the AP service
- * 
- * @return bool true on success, false otherwise 
+ *
+ * @return bool true on success, false otherwise
  */
 bool kill_ap_process(void);
 

--- a/src/capsrv.c
+++ b/src/capsrv.c
@@ -18,8 +18,8 @@
  ****************************************************************************/
 
 /**
- * @file capsrv.c 
- * @author Alexandru Mereacre 
+ * @file capsrv.c
+ * @author Alexandru Mereacre
  * @brief File containing the implementation of the capture service.
  */
 
@@ -126,7 +126,7 @@ int process_app_options(int argc, char *argv[], uint8_t *verbosity,
       return log_cmdline_error("Missing argument for -%c\n", optopt);
     case '?':
       return log_cmdline_error("Unrecognized option -%c\n", optopt);
-    default: 
+    default:
       ret = capture_opt2config(opt, optarg, config);
       if (ret < 0) {
         return log_cmdline_error("Wrong argument value for -%c\n", optopt);

--- a/src/capture/capture_cleaner.c
+++ b/src/capture/capture_cleaner.c
@@ -18,12 +18,12 @@
  ****************************************************************************/
 
 /**
- * @file capture_cleaner.c 
- * @author Alexandru Mereacre 
+ * @file capture_cleaner.c
+ * @author Alexandru Mereacre
  * @brief File containing the implementation of the capture cleaner service structures.
- * 
+ *
  * Defines the start function for the capturte cleaner service, which
- * removes the capture files from the database folder when it 
+ * removes the capture files from the database folder when it
  * reaches a given size specified in the capture_conf structure. The
  * store size is give by the parameter capture_store_size in Kb.
  */
@@ -55,9 +55,9 @@ int clean_capture(struct cleaner_context *context)
   struct pcap_file_meta *p = NULL;
   UT_array *pcap_meta_arr = NULL;
   uint64_t timestamp = context->low_timestamp, lt;
-  char *path; 
+  char *path;
   utarray_new(pcap_meta_arr, &pcap_file_meta_icd);
-  
+
   while(timestamp <= context->next_timestamp) {
     lt = timestamp;
     if (get_pcap_meta_array(context->pcap_db, timestamp, CLEANER_GROUP_INTERVAL, pcap_meta_arr) < 0) {
@@ -90,7 +90,7 @@ int clean_capture(struct cleaner_context *context)
     if (delete_pcap_entries(context->pcap_db, lt, timestamp) < 0) {
       log_trace("delete_pcap_entries fail");
       utarray_free(pcap_meta_arr);
-      return -1;    
+      return -1;
     }
   }
 
@@ -119,7 +119,7 @@ void eloop_cleaner_handler(void *eloop_ctx, void *user_ctx)
     context->low_timestamp = lt;
     context->store_sum = caplen;
   }
-  
+
   ht = lt;
 
   if (lt) {
@@ -188,7 +188,7 @@ int start_capture_cleaner(struct capture_conf *config)
   if (open_sqlite_pcap_db(pcap_db_path, (sqlite3**)&context.pcap_db) < 0) {
     log_trace("open_sqlite_pcap_db fail");
     os_free(pcap_db_path);
-    return -1;  
+    return -1;
   }
   os_free(pcap_db_path);
 

--- a/src/capture/capture_cleaner.h
+++ b/src/capture/capture_cleaner.h
@@ -18,12 +18,12 @@
  ****************************************************************************/
 
 /**
- * @file capture_cleaner.h 
- * @author Alexandru Mereacre 
+ * @file capture_cleaner.h
+ * @author Alexandru Mereacre
  * @brief File containing the definition of the capture cleaner service structures.
- * 
+ *
  * Defines the start function for the capturte cleaner service, which
- * removes the capture files from the database folder when it 
+ * removes the capture files from the database folder when it
  * reaches a given size specified in the capture_conf structure. The
  * store size is give by the parameter capture_store_size in Kb.
  */
@@ -35,7 +35,7 @@
 
 /**
  * @brief Executes the capture cleaner service
- * 
+ *
  * @param config The capture service config structure
  * @return int 0 on success, -1 on error
  */

--- a/src/capture/capture_config.c
+++ b/src/capture/capture_config.c
@@ -19,11 +19,11 @@
 
 /**
  * @file capture_config.c
- * @author Alexandru Mereacre 
+ * @author Alexandru Mereacre
  * @brief File containing the implementation of the capture config structures.
- * 
- * Defines the function to generate the config parameters for the capture 
- * service. It also defines all the metadata and database schema for the 
+ *
+ * Defines the function to generate the config parameters for the capture
+ * service. It also defines all the metadata and database schema for the
  * captured packets.
  */
 
@@ -58,7 +58,7 @@ long get_opt_num(char *num)
 {
   if (!is_number(num))
     return -1;
-  
+
   return strtol(num, NULL, 10);
 }
 
@@ -276,7 +276,7 @@ char** capture_config2opt(struct capture_conf *config)
 
     opt_str[idx] = os_malloc(MAX_ANALYSER_NAME_SIZE);
     os_strlcpy(opt_str[idx], config->analyser, MAX_ANALYSER_NAME_SIZE);
-    idx ++; 
+    idx ++;
   }
 
   //immediate, -e

--- a/src/capture/capture_config.h
+++ b/src/capture/capture_config.h
@@ -18,12 +18,12 @@
  ****************************************************************************/
 
 /**
- * @file capture_config.h 
- * @author Alexandru Mereacre 
+ * @file capture_config.h
+ * @author Alexandru Mereacre
  * @brief File containing the definition of the capture config structures.
- * 
- * Defines the function to generate the config parameters for the capture 
- * service. It also defines all the metadata and database schema for the 
+ *
+ * Defines the function to generate the config parameters for the capture
+ * service. It also defines all the metadata and database schema for the
  * captured packets.
  */
 
@@ -67,7 +67,7 @@
 #define MAX_QUERY_LEN 	            MAX_OS_PATH_LEN
 
 #define CAPTURE_MAX_OPT       26
-                              
+
 #define CAPTURE_OPT_STRING    ":c:i:q:f:t:n:p:y:x:z:r:b:dvhmewu"   // gjlkoas
 #define CAPTURE_USAGE_STRING  "\t%s [-c config] [-d] [-h] [-v] [(-y engine [-w] [-u]) | (-b size)] [-i interface] [-q domain]" \
                               "[-f filter] [-m] [-t timeout] [-n interval] " \
@@ -117,7 +117,7 @@ typedef enum packet_types {
 
 /**
  * @brief The capture configuration structure
- * 
+ *
  */
 struct capture_conf {
   char capture_bin_path[MAX_OS_PATH_LEN];                     /**< The capture binary path string */
@@ -128,11 +128,11 @@ struct capture_conf {
   bool promiscuous;                                           /**< Specifies whether the interface is to be put into promiscuous mode. If promiscuous param is non-zero, promiscuous mode will be set, otherwise it will not be set */
   bool immediate;                                             /**< Sets whether immediate mode should be set on a capture handle when the handle is activated. If immediate param is non-zero, immediate mode will be set, otherwise it will not be set. */
   uint32_t buffer_timeout;                                    /**< Specifies the packet buffer timeout, as a non-negative value, in milliseconds. (See pcap(3PCAP) for an explanation of the packet buffer timeout.) */
-  uint32_t process_interval;                                  /**< Specifies the packet process interval, in milliseconds. */ 
-  char analyser[MAX_ANALYSER_NAME_SIZE];                      /**< Specifies the packet analyser engine. */ 
+  uint32_t process_interval;                                  /**< Specifies the packet process interval, in milliseconds. */
+  char analyser[MAX_ANALYSER_NAME_SIZE];                      /**< Specifies the packet analyser engine. */
   bool file_write;                                            /**< Specifies wether the packets should be saved to file(s). */
   bool db_write;                                              /**< Specifies wether the packets should be saved in a sqlite db. */
-  char db_path[MAX_OS_PATH_LEN];                              /**< Specifies the path to the sqlite3 dbs */ 
+  char db_path[MAX_OS_PATH_LEN];                              /**< Specifies the path to the sqlite3 dbs */
   char filter[MAX_FILTER_SIZE];                               /**< Specifies the filter expression or pcap lib */
   ssize_t sync_store_size;                                    /**< Specifies the sync store size */
   ssize_t sync_send_size;                                     /**< Specifies the sync send size */
@@ -146,7 +146,7 @@ struct tuple_packet {
 
 /**
  * @brief Ethernet protocol schema definition
- * 
+ *
  */
 struct eth_schema {
   uint32_t hash;                                    /**< Packet hash */
@@ -163,7 +163,7 @@ struct eth_schema {
 
 /**
  * @brief ARP protocol schema definition
- * 
+ *
  */
 struct arp_schema {
   uint32_t hash;                                    /**< Packet hash */
@@ -183,7 +183,7 @@ struct arp_schema {
 
 /**
  * @brief IP4 protocol schema definition
- * 
+ *
  */
 struct ip4_schema {
   uint32_t hash;                                    /**< Packet hash */
@@ -206,7 +206,7 @@ struct ip4_schema {
 
 /**
  * @brief IP6 protocol schema definition
- * 
+ *
  */
 struct ip6_schema {
   uint32_t hash;                                    /**< Packet hash */
@@ -224,7 +224,7 @@ struct ip6_schema {
 
 /**
  * @brief TCP protocol schema definition
- * 
+ *
  */
 struct tcp_schema {
   uint32_t hash;                                    /**< Packet hash */
@@ -250,7 +250,7 @@ struct tcp_schema {
 
 /**
  * @brief UDP protocol schema definition
- * 
+ *
  */
 struct udp_schema {
   uint32_t hash;                                    /**< Packet hash */
@@ -265,7 +265,7 @@ struct udp_schema {
 
 /**
  * @brief ICMP4 protocol schema definition
- * 
+ *
  */
 struct icmp4_schema {
   uint32_t hash;                                    /**< Packet hash */
@@ -280,7 +280,7 @@ struct icmp4_schema {
 
 /**
  * @brief ICMP6 protocol schema definition
- * 
+ *
  */
 struct icmp6_schema {
   uint32_t hash;                                    /**< Packet hash */
@@ -295,7 +295,7 @@ struct icmp6_schema {
 
 /**
  * @brief DNS protocol schema definition
- * 
+ *
  */
 struct dns_schema {
   uint32_t hash;                                    /**< Packet hash */
@@ -313,7 +313,7 @@ struct dns_schema {
 
 /**
  * @brief mDNS protocol schema definition
- * 
+ *
  */
 struct mdns_schema {
   uint32_t hash;                                    /**< Packet hash */
@@ -331,7 +331,7 @@ struct mdns_schema {
 
 /**
  * @brief DHCP protocol schema definition
- * 
+ *
  */
 struct dhcp_schema {
   uint32_t hash;                                    /**< Packet hash */
@@ -353,7 +353,7 @@ struct dhcp_schema {
 
 /**
  * @brief DNS header definition
- * 
+ *
  */
 struct dns_header {
 	uint16_t tid;		                      /**< Transaction ID */
@@ -366,7 +366,7 @@ struct dns_header {
 
 /**
  * @brief mDNS header definition
- * 
+ *
  */
 struct mdns_header {
 	uint16_t tid;		                      /**< Transaction ID */
@@ -379,7 +379,7 @@ struct mdns_header {
 
 /**
  * @brief mDNS query meta definition
- * 
+ *
  */
 struct mdns_query_meta {
   uint16_t qtype;                         /**< The type of the query, i.e. the type of RR which should be returned in response */
@@ -389,7 +389,7 @@ struct mdns_query_meta {
 
 /**
  * @brief mDNS response meta definition
- * 
+ *
  */
 struct mdns_answer_meta {
   uint16_t rrtype;                        /**< The type of the Resource Record */
@@ -401,7 +401,7 @@ struct mdns_answer_meta {
 
 /**
  * @brief DHCP header definition (truncated)
- * 
+ *
  */
 struct dhcp_header {
   uint8_t  op;                          /**< packet type */
@@ -419,7 +419,7 @@ struct dhcp_header {
 
 /**
  * @brief Capture structure definition
- * 
+ *
  */
 struct capture_packet {
   struct ether_header *ethh;           /**< Ethernet header.  */
@@ -475,7 +475,7 @@ struct alert_meta {
 
 /**
  * @brief Translate a capture process option to a config structure value
- * 
+ *
  * @param key Capture process option key
  * @param opt Capture process option value
  * @param config The config structure
@@ -485,7 +485,7 @@ int capture_opt2config(char key, char *value, struct capture_conf *config);
 
 /**
  * @brief Transforms a config structure to opt string array
- * 
+ *
  * @param config The config structure
  * @return char** the opt string array, NULL on failure
  */
@@ -493,7 +493,7 @@ int capture_opt2config(char key, char *value, struct capture_conf *config);
 char** capture_config2opt(struct capture_conf *config);
 /**
  * @brief Free opt string array
- * 
+ *
  * @param opt_str Opt string array
  */
 void capture_freeopt(char **opt_str);

--- a/src/capture/capture_service.c
+++ b/src/capture/capture_service.c
@@ -19,7 +19,7 @@
 
 /**
  * @file capture_service.c
- * @author Alexandru Mereacre 
+ * @author Alexandru Mereacre
  * @brief File containing the implementation of the capture service.
  */
 #include <errno.h>

--- a/src/capture/capture_service.h
+++ b/src/capture/capture_service.h
@@ -18,8 +18,8 @@
  ****************************************************************************/
 
 /**
- * @file capture_service.h 
- * @author Alexandru Mereacre 
+ * @file capture_service.h
+ * @author Alexandru Mereacre
  * @brief File containing the definition of the capture service structures.
  */
 
@@ -31,7 +31,7 @@
 
 /**
  * @brief Executes the capture service
- * 
+ *
  * @param config The capture service config structure
  * @return int 0 on success, -1 on error
  */

--- a/src/capture/default_analyser.c
+++ b/src/capture/default_analyser.c
@@ -18,7 +18,7 @@
  ****************************************************************************/
 /**
  * @file default_analyser.c
- * @author Alexandru Mereacre 
+ * @author Alexandru Mereacre
  * @brief File containing the implementation of the default analyser service.
  */
 
@@ -299,7 +299,7 @@ int start_default_analyser(struct capture_conf *config)
     os_free(header_db_path);
     return -1;
   }
-  
+
   if ((context.domain_client = create_domain_client(NULL)) < 0) {
     log_trace("create_domain_client fail");
     os_free(header_db_path);

--- a/src/capture/default_analyser.h
+++ b/src/capture/default_analyser.h
@@ -18,8 +18,8 @@
  ****************************************************************************/
 
 /**
- * @file default_analyser.h 
- * @author Alexandru Mereacre 
+ * @file default_analyser.h
+ * @author Alexandru Mereacre
  * @brief File containing the definition of the default analyser service.
  */
 
@@ -60,7 +60,7 @@ struct capture_context {
 
 /**
  * @brief Callback for pcap packet module
- * 
+ *
  * @param ctx The capture context
  * @param ctx The pcap context
  * @param ltype The link type
@@ -72,7 +72,7 @@ void pcap_callback(const void *ctx, const void *pcap_ctx,
 
 /**
  * @brief Starts the default analyser engine
- * 
+ *
  * @param config The capture config structure
  * @return int 0 on success, -1 on failure
  */

--- a/src/capture/dns_decoder.c
+++ b/src/capture/dns_decoder.c
@@ -18,8 +18,8 @@
  ****************************************************************************/
 
 /**
- * @file dns_decoder.c 
- * @author Alexandru Mereacre 
+ * @file dns_decoder.c
+ * @author Alexandru Mereacre
  * @brief File containing the implementation of the dns packet decoder utilities.
  */
 
@@ -96,7 +96,7 @@ bool decode_dns_packet(struct capture_packet *cpac)
     if (cpac->dnss.nqueries)
         decode_dns_questions((uint8_t *)payload, cpac);
   }
-  
+
   // log_trace("DNS id=%d flags=0x%x nqueries=%d nanswers=%d nauth=%d nother=%d qname=%s",
   //   cpac->dnss.tid, cpac->dnss.flags, cpac->dnss.nqueries, cpac->dnss.nanswers,
   //   cpac->dnss.nauth, cpac->dnss.nother, cpac->dnss.qname);

--- a/src/capture/dns_decoder.h
+++ b/src/capture/dns_decoder.h
@@ -18,8 +18,8 @@
  ****************************************************************************/
 
 /**
- * @file dns_decoder.h 
- * @author Alexandru Mereacre 
+ * @file dns_decoder.h
+ * @author Alexandru Mereacre
  * @brief File containing the definition of the dns packet decoder utilities.
  */
 
@@ -31,7 +31,7 @@
 
 /**
  * @brief Decode dns packet
- * 
+ *
  * @param cpac The captyure packet structure
  * @return true Success, false otherwise
  */

--- a/src/capture/mdns_decoder.c
+++ b/src/capture/mdns_decoder.c
@@ -18,8 +18,8 @@
  ****************************************************************************/
 
 /**
- * @file mdns_decoder.c 
- * @author Alexandru Mereacre 
+ * @file mdns_decoder.c
+ * @author Alexandru Mereacre
  * @brief File containing the implementation of the mdns packet decoder utilities.
  */
 
@@ -271,7 +271,7 @@ bool decode_mdns_packet(struct capture_packet *cpac)
   //     os_free(qname);
   //   }
   // }
-  
+
   log_trace("mDNS id=%d flags=0x%x nqueries=%d nanswers=%d nauth=%d nother=%d qname=%s",
     cpac->mdnss.tid, cpac->mdnss.flags, cpac->mdnss.nqueries, cpac->mdnss.nanswers,
     cpac->mdnss.nauth, cpac->mdnss.nother, cpac->mdnss.qname);

--- a/src/capture/mdns_decoder.h
+++ b/src/capture/mdns_decoder.h
@@ -18,8 +18,8 @@
  ****************************************************************************/
 
 /**
- * @file mdns_decoder.h 
- * @author Alexandru Mereacre 
+ * @file mdns_decoder.h
+ * @author Alexandru Mereacre
  * @brief File containing the definition of the mdns packet decoder utilities.
  */
 
@@ -45,7 +45,7 @@ struct mdns_answer_entry {
 
 /**
  * @brief Decodes the mdns queries
- * 
+ *
  * @param payload The mdns payload
  * @param len The mdns payload length
  * @param first The starting index to the queries field
@@ -57,7 +57,7 @@ int decode_mdns_queries(uint8_t *payload, size_t len, size_t *first, uint16_t nq
 
 /**
  * @brief Decodes the mdns answers
- * 
+ *
  * @param payload The mdns payload
  * @param len The mdns payload length
  * @param first The starting index to the answers field
@@ -69,7 +69,7 @@ int decode_mdns_answers(uint8_t *payload, size_t len, size_t *first, uint16_t na
 
 /**
  * @brief Decodes the mdns header
- * 
+ *
  * @param packet The mdns packet
  * @param out The output mdns decoded header
  * @return 0 Success, -1 on failure
@@ -78,7 +78,7 @@ int decode_mdns_header(uint8_t *packet, struct mdns_header *out);
 
 /**
  * @brief Decode mdns packet
- * 
+ *
  * @param cpac The capture packet structure
  * @return true Success, false otherwise
  */

--- a/src/capture/packet_decoder.c
+++ b/src/capture/packet_decoder.c
@@ -19,7 +19,7 @@
 
 /**
  * @file packet_decoder.c
- * @author Alexandru Mereacre 
+ * @author Alexandru Mereacre
  * @brief File containing the implementation of the packet decoder utilities.
  */
 

--- a/src/capture/packet_decoder.h
+++ b/src/capture/packet_decoder.h
@@ -18,8 +18,8 @@
  ****************************************************************************/
 
 /**
- * @file packet_decoder.h 
- * @author Alexandru Mereacre 
+ * @file packet_decoder.h
+ * @author Alexandru Mereacre
  * @brief File containing the definition of the packet decoder utilities.
  */
 
@@ -36,7 +36,7 @@
 
 /**
  * @brief Extract packets from pcap packet data
- * 
+ *
  * @param ltype The link type
  * @param header The packet header as per pcap
  * @param packet The packet data

--- a/src/capture/packet_queue.c
+++ b/src/capture/packet_queue.c
@@ -19,7 +19,7 @@
 
 /**
  * @file packet_queue.c
- * @author Alexandru Mereacre 
+ * @author Alexandru Mereacre
  * @brief File containing the implementation of the packet queue utilities.
  */
 
@@ -56,7 +56,7 @@ struct packet_queue* push_packet_queue(struct packet_queue* queue, struct tuple_
     log_debug("queue param is NULL");
     return NULL;
   }
-  
+
   if ((el = init_packet_queue()) == NULL) {
     log_debug("init_packet_queue fail");
     return NULL;

--- a/src/capture/packet_queue.h
+++ b/src/capture/packet_queue.h
@@ -18,8 +18,8 @@
  ****************************************************************************/
 
 /**
- * @file packet_queue.h 
- * @author Alexandru Mereacre 
+ * @file packet_queue.h
+ * @author Alexandru Mereacre
  * @brief File containing the definition of the packet queue utilities.
  */
 
@@ -35,7 +35,7 @@
 
 /**
  * @brief Packet queueu structure definition
- * 
+ *
  */
 struct packet_queue {
   struct tuple_packet tp;       /**< Packet address and metadata */
@@ -44,14 +44,14 @@ struct packet_queue {
 
 /**
  * @brief Initialises and empty packet queue
- * 
+ *
  * @return struct packet_queue* Returned initialised empty packet queue
  */
 struct packet_queue* init_packet_queue(void);
 
 /**
  * @brief Pushes a packet in the packet queue
- * 
+ *
  * @param queue The packet queue
  * @param tp The packet tuple
  * @return struct packet_queue* Returned the packet queue element
@@ -60,7 +60,7 @@ struct packet_queue* push_packet_queue(struct packet_queue* queue, struct tuple_
 
 /**
  * @brief Extract the first packet from the packet queueu
- * 
+ *
  * @param queue The packet queue
  * @return struct packet_queue* The returned packet (NULL if queue is empty)
  */
@@ -68,21 +68,21 @@ struct packet_queue* pop_packet_queue(struct packet_queue* queue);
 
 /**
  * @brief Frees an allocated packet tuple
- * 
+ *
  * @param tp The pointer to the packet tuple
  */
 void free_packet_tuple(struct tuple_packet *tp);
 
 /**
  * @brief Delete a packet entry
- * 
+ *
  * @param el The packet queue entry
  */
 void free_packet_queue_el(struct packet_queue* el);
 
 /**
  * @brief Returns the packet queue length
- * 
+ *
  * @param el The pointer to the packet queue
  * @return ssize_t The packet queue length
  */
@@ -90,14 +90,14 @@ ssize_t get_packet_queue_length(struct packet_queue* queue);
 
 /**
  * @brief Frees the packet queue
- * 
+ *
  * @param queue The pointer to the packet queue
  */
 void free_packet_queue(struct packet_queue* queue);
 
 /**
  * @brief Checks if packet queue is empty
- * 
+ *
  * @param queue The pointer to the packet queue
  * @return 1, is empty, 0 otherwise, -1 for error
  */

--- a/src/capture/pcap_queue.c
+++ b/src/capture/pcap_queue.c
@@ -19,7 +19,7 @@
 
 /**
  * @file pcap_queue.c
- * @author Alexandru Mereacre 
+ * @author Alexandru Mereacre
  * @brief File containing the implementation of the pcap queue utilities.
  */
 

--- a/src/capture/pcap_queue.h
+++ b/src/capture/pcap_queue.h
@@ -18,8 +18,8 @@
  ****************************************************************************/
 
 /**
- * @file pcap_queue.h 
- * @author Alexandru Mereacre 
+ * @file pcap_queue.h
+ * @author Alexandru Mereacre
  * @brief File containing the definition of the pcap queue utilities.
  */
 
@@ -36,7 +36,7 @@
 
 /**
  * @brief pcap queueu structure definition
- * 
+ *
  */
 struct pcap_queue {
   struct pcap_pkthdr header;            /**< pcap header */
@@ -46,14 +46,14 @@ struct pcap_queue {
 
 /**
  * @brief Initialises and empty pcap queue
- * 
+ *
  * @return struct pcap_queue* Returned initialised empty pcap queue
  */
 struct pcap_queue* init_pcap_queue(void);
 
 /**
  * @brief Pushes a packet in the pcap queue
- * 
+ *
  * @param queue The pcap queue
  * @param header The pcap header
  * @param packet The pcap packet
@@ -63,7 +63,7 @@ struct pcap_queue* push_pcap_queue(struct pcap_queue* queue, struct pcap_pkthdr 
 
 /**
  * @brief Extract the first pcap element from the pcap queueu
- * 
+ *
  * @param queue The pcap queue
  * @return struct pcap_queue* The returned pcap (NULL if queue is empty)
  */
@@ -71,14 +71,14 @@ struct pcap_queue* pop_pcap_queue(struct pcap_queue* queue);
 
 /**
  * @brief Delete a pcap entry
- * 
+ *
  * @param el The pcap queue entry
  */
 void free_pcap_queue_el(struct pcap_queue* el);
 
 /**
  * @brief Returns the pcap queue length
- * 
+ *
  * @param el The pointer to the pcap queue
  * @return ssize_t The pcap queue length
  */
@@ -86,14 +86,14 @@ ssize_t get_pcap_queue_length(struct pcap_queue* queue);
 
 /**
  * @brief Frees the pcap queue
- * 
+ *
  * @param queue The pointer to the pcap queue
  */
 void free_pcap_queue(struct pcap_queue* queue);
 
 /**
  * @brief Checks if pcap queue is empty
- * 
+ *
  * @param queue The pointer to the packet queue
  * @return 1, is empty, 0 otherwise, -1 for error
  */

--- a/src/capture/pcap_service.c
+++ b/src/capture/pcap_service.c
@@ -19,7 +19,7 @@
 
 /**
  * @file pcap_service.c
- * @author Alexandru Mereacre 
+ * @author Alexandru Mereacre
  * @brief File containing the implementation of the pcap service utilities.
  */
 #include <linux/if.h>
@@ -49,7 +49,7 @@ bool find_device(char *ifname, bpf_u_int32 *net, bpf_u_int32 *mask)
 
   if(pcap_findalldevs(&ifs, err) == -1) {
     log_trace("pcap_findalldevs fail with error %s", err);
-    return false;   
+    return false;
   }
 
   for(temp = ifs; temp; temp = temp->next) {
@@ -71,7 +71,7 @@ bool find_device(char *ifname, bpf_u_int32 *net, bpf_u_int32 *mask)
 
 void receive_pcap_packet(u_char *args, const struct pcap_pkthdr *header, const u_char *packet)
 {
-  
+
   struct pcap_context *ctx = (struct pcap_context *) args;
   char *ltype = (char *) pcap_datalink_val_to_name(pcap_datalink(ctx->pd));
 
@@ -142,7 +142,7 @@ int run_pcap(char *interface, bool immediate, bool promiscuous,
   bit32_2_ip((uint32_t) net, ip_str);
   bit32_2_ip((uint32_t) mask, mask_str);
   log_debug("Found device=%s IP=" IPSTR " netmask=" IPSTR, interface, IP2STR(ip_str), IP2STR(mask_str));
-  
+
   ctx = os_zalloc(sizeof(struct pcap_context));
   *pctx = ctx;
 

--- a/src/capture/pcap_service.h
+++ b/src/capture/pcap_service.h
@@ -18,8 +18,8 @@
  ****************************************************************************/
 
 /**
- * @file pcap_service.h 
- * @author Alexandru Mereacre 
+ * @file pcap_service.h
+ * @author Alexandru Mereacre
  * @brief File containing the definition of the pcap service utilities.
  */
 
@@ -38,7 +38,7 @@ typedef void (*capture_callback_fn)(const void *ctx, const void *pcap_ctx,
 
 /**
  * @brief Pcap context structure definition
- * 
+ *
  */
 struct pcap_context {
   int pcap_fd;                  /**< The pcap selectable fd */
@@ -50,7 +50,7 @@ struct pcap_context {
 
 /**
  * @brief Starts the blocking pcap loop
- * 
+ *
  * @param ctx The pcap context
  * @return int 0 on success, -1 on error, -2 if the loop terminated
  */
@@ -58,14 +58,14 @@ int capture_pcap_start(struct pcap_context *ctx);
 
 /**
  * @brief Stops the blocking pcap loop
- * 
+ *
  * @param ctx The pcap context
  */
 void capture_pcap_stop(struct pcap_context *ctx);
 
 /**
  * @brief Get the pcap config datalink value
- * 
+ *
  * @param ctx The pcap context
  * @return int the config value
  */
@@ -73,7 +73,7 @@ int get_pcap_datalink(struct pcap_context *ctx);
 
 /**
  * @brief Executes the libpcap service
- * 
+ *
  * @param interface The capture interface
  * @param immediate The immediate mode flag
  * @param promiscuous The promiscuous mode flag
@@ -91,7 +91,7 @@ int run_pcap(char *interface, bool immediate, bool promiscuous,
 
 /**
  * @brief Captures a pcap packet
- * 
+ *
  * @param ctx The pcap context structure
  * @return int 0 on success, -1 otherwise
  */
@@ -99,7 +99,7 @@ int capture_pcap_packet(struct pcap_context *ctx);
 
 /**
  * @brief Saves a packet packet into file
- * 
+ *
  * @param ctx The pcap context
  * @param file_path The file path to save the packet
  * @param header The packet header
@@ -110,21 +110,21 @@ int dump_file_pcap(struct pcap_context *ctx, char *file_path, struct pcap_pkthdr
 
 /**
  * @brief Closes the pcap service
- * 
+ *
  * @param ctx The pcap context
  */
 void close_pcap(struct pcap_context *ctx);
 
 /**
  * @brief Frees a pcap list
- * 
+ *
  * @param ctx_list The pcap list
  */
 void free_pcap_list(UT_array *ctx_list);
 
 /**
  * @brief Creates a pcap list
- * 
+ *
  * @return UT_array* The pcap list, NULL on failure
  */
 UT_array * create_pcap_list(void);

--- a/src/capture/sqlite_header_writer.c
+++ b/src/capture/sqlite_header_writer.c
@@ -19,7 +19,7 @@
 
 /**
  * @file sqlite_header_writer.c
- * @author Alexandru Mereacre 
+ * @author Alexandru Mereacre
  * @brief File containing the implementation of the sqlite header writer utilities.
  */
 
@@ -106,7 +106,7 @@ int extract_arp_statement(struct sqlite_header_context *ctx, struct arp_schema *
 {
   int column_idx, rc;
   sqlite3_stmt *res = NULL;
-  
+
   rc = sqlite3_prepare_v2(ctx->db, ARP_INSERT_INTO, -1, &res, 0);
 
   if (rc == SQLITE_OK) {
@@ -230,7 +230,7 @@ int extract_ip6_statement(struct sqlite_header_context *ctx, struct ip6_schema *
 {
   int column_idx, rc;
   sqlite3_stmt *res = NULL;
-  
+
   rc = sqlite3_prepare_v2(ctx->db, IP6_INSERT_INTO, -1, &res, 0);
 
   if (rc == SQLITE_OK) {
@@ -283,7 +283,7 @@ int extract_tcp_statement(struct sqlite_header_context *ctx, struct tcp_schema *
 {
   int column_idx, rc;
   sqlite3_stmt *res = NULL;
-  
+
   rc = sqlite3_prepare_v2(ctx->db, TCP_INSERT_INTO, -1, &res, 0);
 
   if (rc == SQLITE_OK) {
@@ -359,7 +359,7 @@ int extract_udp_statement(struct sqlite_header_context *ctx, struct udp_schema *
 {
   int column_idx, rc;
   sqlite3_stmt *res = NULL;
-  
+
   rc = sqlite3_prepare_v2(ctx->db, UDP_INSERT_INTO, -1, &res, 0);
 
   if (rc == SQLITE_OK) {
@@ -402,7 +402,7 @@ int extract_icmp4_statement(struct sqlite_header_context *ctx, struct icmp4_sche
 {
   int column_idx, rc;
   sqlite3_stmt *res = NULL;
-  
+
   rc = sqlite3_prepare_v2(ctx->db, ICMP4_INSERT_INTO, -1, &res, 0);
 
   if (rc == SQLITE_OK) {
@@ -445,7 +445,7 @@ int extract_icmp6_statement(struct sqlite_header_context *ctx, struct icmp6_sche
 {
   int column_idx, rc;
   sqlite3_stmt *res = NULL;
-  
+
   rc = sqlite3_prepare_v2(ctx->db, ICMP6_INSERT_INTO, -1, &res, 0);
 
   if (rc == SQLITE_OK) {
@@ -488,7 +488,7 @@ int extract_dns_statement(struct sqlite_header_context *ctx, struct dns_schema *
 {
   int column_idx, rc;
   sqlite3_stmt *res = NULL;
-  
+
   rc = sqlite3_prepare_v2(ctx->db, DNS_INSERT_INTO, -1, &res, 0);
 
   if (rc == SQLITE_OK) {
@@ -593,7 +593,7 @@ int extract_dhcp_statement(struct sqlite_header_context *ctx, struct dhcp_schema
 {
   int column_idx, rc;
   sqlite3_stmt *res = NULL;
-  
+
   rc = sqlite3_prepare_v2(ctx->db, DHCP_INSERT_INTO, -1, &res, 0);
 
   if (rc == SQLITE_OK) {
@@ -717,7 +717,7 @@ int sqlite_trace_callback(unsigned int uMask, void* ctx, void* stm, void* X)
   if (sql_ctx->trace_fn != NULL) {
     sqlite_str = sqlite3_expanded_sql(statement);
     sql_ctx->trace_fn(sqlite_str, sql_ctx->trace_ctx);
-    sqlite3_free(sqlite_str);  
+    sqlite3_free(sqlite_str);
   }
 
   return 0;
@@ -726,7 +726,7 @@ int sqlite_trace_callback(unsigned int uMask, void* ctx, void* stm, void* X)
 int open_sqlite_header_db(char *db_path, trace_callback_fn fn,
                                void *trace_ctx, struct sqlite_header_context **ctx)
 {
-  
+
   sqlite3 *db;
   struct sqlite_header_context *context = NULL;
 

--- a/src/capture/sqlite_header_writer.h
+++ b/src/capture/sqlite_header_writer.h
@@ -18,8 +18,8 @@
  ****************************************************************************/
 
 /**
- * @file sqlite_header_writer.h 
- * @author Alexandru Mereacre 
+ * @file sqlite_header_writer.h
+ * @author Alexandru Mereacre
  * @brief File containing the definition of the sqlite header writer utilities.
  */
 
@@ -121,7 +121,7 @@ extern "C" {
 
 /**
  * @brief Save packets to sqlite db
- * 
+ *
  * @param ctx The sqlite db context
  * @param tp The packet tuple structure
  * @return int 0 on success, -1 o failure
@@ -130,7 +130,7 @@ int save_packet_statement(struct sqlite_header_context *ctx, struct tuple_packet
 
 /**
  * @brief Opens the sqlite3 header database
- * 
+ *
  * @param db_path The path to sqlite3 db
  * @param trace_fn The callback to the trace callback function
  * @param trace_ctx The context for trace callback
@@ -142,7 +142,7 @@ int open_sqlite_header_db(char *db_path, trace_callback_fn fn,
 
 /**
  * @brief Closes the sqlite db
- * 
+ *
  * @param ctx The sqlite db context
  */
 void free_sqlite_header_db(struct sqlite_header_context *ctx);

--- a/src/capture/sqlite_pcap_writer.c
+++ b/src/capture/sqlite_pcap_writer.c
@@ -19,7 +19,7 @@
 
 /**
  * @file sqlite_pcap_writer.c
- * @author Alexandru Mereacre 
+ * @author Alexandru Mereacre
  * @brief File containing the implementation of the sqlite pcap writer utilities.
  */
 
@@ -48,7 +48,7 @@ int open_sqlite_pcap_db(char *db_path, sqlite3** sql)
   sqlite3 *db = NULL;
   int rc;
 
-  if ((rc = sqlite3_open(db_path, &db)) != SQLITE_OK) {     
+  if ((rc = sqlite3_open(db_path, &db)) != SQLITE_OK) {
     log_debug("Cannot open database: %s %s", sqlite3_errmsg(db), db_path);
     sqlite3_close(db);
     return -1;

--- a/src/capture/sqlite_pcap_writer.h
+++ b/src/capture/sqlite_pcap_writer.h
@@ -18,8 +18,8 @@
  ****************************************************************************/
 
 /**
- * @file sqlite_pcap_writer.h 
- * @author Alexandru Mereacre 
+ * @file sqlite_pcap_writer.h
+ * @author Alexandru Mereacre
  * @brief File containing the definition of the sqlite pcap writer utilities.
  */
 
@@ -49,7 +49,7 @@ struct pcap_file_meta {
 
 /**
  * @brief Opens the sqlite pcap db
- * 
+ *
  * @param db_path The sqlite db path
  * @param sql The returned sqlite db structure pointer
  * @return 0 on success, -1 on failure
@@ -58,14 +58,14 @@ int open_sqlite_pcap_db(char *db_path, sqlite3** sql);
 
 /**
  * @brief Closes the sqlite db
- * 
+ *
  * @param ctx The sqlite db structure pointer
  */
 void free_sqlite_pcap_db(sqlite3 *db);
 
 /**
  * @brief Save a pcap entry into the sqlite db
- * 
+ *
  * @param db The sqlite db structure pointer
  * @param name The pcap file name
  * @param timestamp The timestamp value
@@ -81,7 +81,7 @@ int save_sqlite_pcap_entry(sqlite3 *db, char *name, uint64_t timestamp,
 
 /**
  * @brief Returns the first pcap entry timestamp
- * 
+ *
  * @param db The sqlite db structure pointer
  * @param timestamp The returned timestamp value
  * @param caplen The returned caplen value
@@ -91,7 +91,7 @@ int get_first_pcap_entry(sqlite3 *db, uint64_t *timestamp, uint64_t *caplen);
 
 /**
  * @brief Returns the pcap meta array
- * 
+ *
  * @param db The sqlite db structure pointer
  * @param lt The lower timestamp
  * @param lim The limit number of rows
@@ -102,7 +102,7 @@ int get_pcap_meta_array(sqlite3 *db, uint64_t lt, uint32_t lim, UT_array *pcap_m
 
 /**
  * @brief Removes a set of entries
- * 
+ *
  * @param db The sqlite db structure pointer
  * @param lt The lower timestamp
  * @param ht The higher timestamp
@@ -112,7 +112,7 @@ int delete_pcap_entries(sqlite3 *db, uint64_t lt, uint64_t ht);
 
 /**
  * @brief Calculates the sum of the group of a pcap
- * 
+ *
  * @param db The sqlite db structure pointer
  * @param lt The lower bound timestamp
  * @param lim The limit number of rows

--- a/src/config.c
+++ b/src/config.c
@@ -18,8 +18,8 @@
  ****************************************************************************/
 
 /**
- * @file config.c 
- * @author Alexandru Mereacre 
+ * @file config.c
+ * @author Alexandru Mereacre
  * @brief File containing the implementation of the app configuration utilities.
  */
 
@@ -393,7 +393,7 @@ bool load_ap_conf(const char *filename, struct app_config *config)
   ini_gets("ap", "rsnPairwise", "CCMP", value, INI_BUFFERSIZE, filename);
   os_strlcpy(config->hconfig.rsn_pairwise, value, AP_RSN_PAIRWISE_LEN);
   os_free(value);
-  
+
   // Load ap ctrlInterface
   value = os_malloc(INI_BUFFERSIZE);
   ini_gets("ap", "ctrlInterface", "/var/run/hostapd", value, INI_BUFFERSIZE, filename);
@@ -913,7 +913,7 @@ void free_app_config(struct app_config *config)
   if (config->dhcp_config.config_dhcpinfo_array != NULL) {
     utarray_free(config->dhcp_config.config_dhcpinfo_array);
   }
-  
+
   if (config->dns_config.server_array != NULL) {
     utarray_free(config->dns_config.server_array);
   }

--- a/src/config.h
+++ b/src/config.h
@@ -18,8 +18,8 @@
  ****************************************************************************/
 
 /**
- * @file config.h 
- * @author Alexandru Mereacre 
+ * @file config.h
+ * @author Alexandru Mereacre
  * @brief File containing the definition of the app configuration utilities.
  */
 #ifndef CONFIG_H
@@ -41,7 +41,7 @@
 
 /**
  * @brief The App configuration structures. Used for configuring the networking services.
- * 
+ *
  */
 struct app_config {
   UT_array            *bin_path_array;                      /**< The array including the paths of systems binaries. */
@@ -66,9 +66,9 @@ struct app_config {
   UT_array            *config_ifinfo_array;                 /**< Interface list mapping bridge interface name and IP address range. */
   char                domain_server_path[MAX_OS_PATH_LEN];  /**< Path to the control server. */
   char                db_path[MAX_OS_PATH_LEN];             /**< Specifies the path to the sqlite3 dbs */
-  char                crypt_db_path[MAX_OS_PATH_LEN];       /**< Specifies the crypt db path to the sqlite3 db */ 
-  char                crypt_key_id[MAX_KEY_ID_SIZE];        /**< Specifies the crypt key id */ 
-  char                crypt_secret[MAX_USER_SECRET];        /**< Specifies the crypt user master secret */ 
+  char                crypt_db_path[MAX_OS_PATH_LEN];       /**< Specifies the crypt db path to the sqlite3 db */
+  char                crypt_key_id[MAX_KEY_ID_SIZE];        /**< Specifies the crypt key id */
+  char                crypt_secret[MAX_USER_SECRET];        /**< Specifies the crypt user master secret */
   char                domain_delim;                         /**< Control server command delimiter. */
   bool                allow_all_connections;                /**< Flag to allow all connections. */
   bool                allow_all_nat;                        /**< Flag to allow all nat connections. */
@@ -87,7 +87,7 @@ struct app_config {
 
 /**
  * @brief Load the app configuration
- * 
+ *
  * @param filename The app configuration file
  * @param config The configuration structure
  * @return true on success, false otherwise
@@ -97,7 +97,7 @@ bool load_app_config(const char *filename, struct app_config *config);
 
 /**
  * @brief Frees the app configuration
- * 
+ *
  * @param config The app configuration structure
  * @return true on success, false otherwise
  */
@@ -105,7 +105,7 @@ void free_app_config(struct app_config *config);
 
 /**
  * @brief Loads the capture config
- * 
+ *
  * @param filename The app configuration file
  * @param config The capture configuration structure
  * @return true on success, false otherwise
@@ -114,7 +114,7 @@ bool load_capture_config(const char *filename, struct capture_conf *config);
 
 /**
  * @brief Loads the system config
- * 
+ *
  * @param filename The app configuration file
  * @param config The app configuration structure
  * @return true on success, false otherwise
@@ -123,7 +123,7 @@ bool load_system_config(const char *filename, struct app_config *config);
 
 /**
  * @brief Loads the supervisor config
- * 
+ *
  * @param filename The app configuration file
  * @param config The app configuration structure
  * @return true on success, false otherwise
@@ -132,7 +132,7 @@ bool load_supervisor_config(const char *filename, struct app_config *config);
 
 /**
  * @brief Loads the mDNS config
- * 
+ *
  * @param filename The app configuration file
  * @param config The app configuration structure
  * @return true on success, false otherwise
@@ -141,7 +141,7 @@ bool load_mdns_conf(const char *filename, struct app_config *config);
 
 /**
  * @brief Loads the list of interfaces
- * 
+ *
  * @param filename The app configuration file
  * @param config The app configuration structure
  * @return true on success, false otherwise
@@ -150,7 +150,7 @@ bool load_interface_list(const char *filename, struct app_config *config);
 
 /**
  * @brief Loads the AP config
- * 
+ *
  * @param filename The app configuration file
  * @param config The app configuration structure
  * @return true on success, false otherwise

--- a/src/crypt/crypt_config.h
+++ b/src/crypt/crypt_config.h
@@ -19,7 +19,7 @@
 
 /**
  * @file crypt_config.h
- * @author Alexandru Mereacre 
+ * @author Alexandru Mereacre
  * @brief File containing the definition of crypt configuration structure.
  */
 #ifndef CRYPT_CONFIG_H
@@ -35,7 +35,7 @@
 
 /**
  * @brief crypt context structure definition
- * 
+ *
  */
 struct crypt_context {
   struct hsm_context *hcontext;                       /**< The HSM context. */

--- a/src/crypt/crypt_service.c
+++ b/src/crypt/crypt_service.c
@@ -19,7 +19,7 @@
 
 /**
  * @file crypt_service.c
- * @author Alexandru Mereacre 
+ * @author Alexandru Mereacre
  * @brief File containing the implementation of crypt service configuration utilities.
  */
 
@@ -89,7 +89,7 @@ int extract_secret_entry(struct secrets_row* row, uint8_t *key, int *key_size,
 {
   size_t out_len;
   char *buf;
-  
+
   if (row->value == NULL && key_size != NULL) {
     *key_size = 0;
   } else if (row->value != NULL && key != NULL && key_size != NULL) {
@@ -193,7 +193,7 @@ struct secrets_row * generate_user_crypto_key_entry(char *key_id, uint8_t *user_
   int enc_crypto_key_size;
   if (!crypto_gensalt(user_key_salt, SALT_SIZE)) {
     log_trace("crypto_gensalt fail");
-    return NULL;        
+    return NULL;
   }
 
   // Generate the enc/dec key using the user supplied key
@@ -268,7 +268,7 @@ struct crypt_context* load_crypt_service(char *crypt_db_path, char *key_id,
       }
 
       log_debug("Using user supplied secret");
-      
+
       if ((row_secret = generate_user_crypto_key_entry(key_id, user_secret, user_secret_size,
                                                     context->crypto_key)) == NULL)
       {
@@ -374,7 +374,7 @@ struct crypt_context* load_crypt_service(char *crypt_db_path, char *key_id,
       os_free(crypto_buf);
     }
   }
-  
+
   free_sqlite_secrets_row(row_secret);
   return context;
 }

--- a/src/crypt/crypt_service.h
+++ b/src/crypt/crypt_service.h
@@ -19,7 +19,7 @@
 
 /**
  * @file crypt_service.h
- * @author Alexandru Mereacre 
+ * @author Alexandru Mereacre
  * @brief File containing the definition of crypt service configuration utilities.
  */
 #ifndef CRYPT_SERVICE_H
@@ -35,7 +35,7 @@
 
 /**
  * @brief crypt context structure definition
- * 
+ *
  */
 struct crypt_pair {
   char *key;              /**< The crypt key string. */
@@ -49,7 +49,7 @@ extern "C" {
 
 /**
  * @brief Load the crypt service
- * 
+ *
  * @param crypt_db_path The crypt db path
  * @param key_id The crypt secrets key id
  * @param user_secret The user secret
@@ -61,14 +61,14 @@ struct crypt_context* load_crypt_service(char *crypt_db_path, char *key_id,
 
 /**
  * @brief Frees the crypt context
- * 
+ *
  * @param ctx The crypt context
  */
 void free_crypt_service(struct crypt_context *ctx);
 
 /**
  * @brief Retrieves a key/value pair from the crypt
- * 
+ *
  * @param ctx The crypt context
  * @param key The key string
  * @return struct crypt_pair* The returned pair, NULL on failure
@@ -77,7 +77,7 @@ struct crypt_pair* get_crypt_pair(struct crypt_context *ctx, char *key);
 
 /**
  * @brief Inserts a key/value pair into the crypt
- * 
+ *
  * @param ctx The crypt context
  * @param pair The key/value pair
  * @return 0 on success, -1 on failure
@@ -86,7 +86,7 @@ int put_crypt_pair(struct crypt_context *ctx, struct crypt_pair *pair);
 
 /**
  * @brief Frees the crypt pair
- * 
+ *
  * @param pair The crypt pair
  */
 void free_crypt_pair(struct crypt_pair *pair);

--- a/src/crypt/generic_hsm_driver.c
+++ b/src/crypt/generic_hsm_driver.c
@@ -19,7 +19,7 @@
 
 /**
  * @file generic_hsm_driver.c
- * @author Alexandru Mereacre 
+ * @author Alexandru Mereacre
  * @brief File containing the implementation of generic HSM driver configuration utilities.
  */
 #include <sys/types.h>

--- a/src/crypt/generic_hsm_driver.h
+++ b/src/crypt/generic_hsm_driver.h
@@ -19,7 +19,7 @@
 
 /**
  * @file generic_hsm_driver.h
- * @author Alexandru Mereacre 
+ * @author Alexandru Mereacre
  * @brief File containing the definition of generic HSM driver configuration utilities.
  */
 #ifndef GENERIC_HSM_DRIVER_H
@@ -36,14 +36,14 @@ struct hsm_context {
 
 /**
  * @brief Initialises an HSM context
- * 
+ *
  * @return struct hsm_context* The returned context, NULL on error
  */
 struct hsm_context* init_hsm(void);
 
 /**
  * @brief Closes the HSM context
- * 
+ *
  * @param context Tje HSM context
  * @return int 0 on success, -1 on failure
  */
@@ -51,7 +51,7 @@ int close_hsm(struct hsm_context *context);
 
 /**
  * @brief Generate an HSM key
- * 
+ *
  * @param context The HSM context
  * @param key The returned key
  * @param key_size The key size
@@ -61,7 +61,7 @@ int generate_hsm_key(struct hsm_context *context, uint8_t *key, size_t key_size)
 
 /**
  * @brief Encrypt a byte array wiht the HSM
- * 
+ *
  * @param context The HSM context
  * @param in The input array
  * @param in_size The input array size
@@ -73,7 +73,7 @@ int encrypt_hsm_blob(struct hsm_context *context, uint8_t *in, size_t in_size, u
 
 /**
  * @brief Decrypt a byte array wiht the HSM
- * 
+ *
  * @param context The HSM context
  * @param in The input array
  * @param in_size The input array size

--- a/src/crypt/sqlite_crypt_writer.c
+++ b/src/crypt/sqlite_crypt_writer.c
@@ -19,7 +19,7 @@
 
 /**
  * @file sqlite_crypt_writer.c
- * @author Alexandru Mereacre 
+ * @author Alexandru Mereacre
  * @brief File containing the implementation of the sqlite crypt writer utilities.
  */
 
@@ -37,8 +37,8 @@ int open_sqlite_crypt_db(char *db_path, sqlite3** sql)
 {
   sqlite3 *db = NULL;
   int rc;
-  
-  if ((rc = sqlite3_open(db_path, &db)) != SQLITE_OK) {     
+
+  if ((rc = sqlite3_open(db_path, &db)) != SQLITE_OK) {
     log_debug("Cannot open database: %s", sqlite3_errmsg(db));
     sqlite3_close(db);
     return -1;
@@ -218,7 +218,7 @@ struct store_row* get_sqlite_store_row(sqlite3 *db, char *key)
   struct store_row *row;
   sqlite3_stmt *res;
   int rc;
-  
+
   if (key == NULL) {
     log_trace("key param is NULL");
     return NULL;
@@ -343,6 +343,6 @@ struct secrets_row* get_sqlite_secrets_row(sqlite3 *db, char *id)
 
 
   sqlite3_finalize(res);
-  free_sqlite_secrets_row(row);  
+  free_sqlite_secrets_row(row);
   return NULL;
 }

--- a/src/crypt/sqlite_crypt_writer.h
+++ b/src/crypt/sqlite_crypt_writer.h
@@ -18,8 +18,8 @@
  ****************************************************************************/
 
 /**
- * @file sqlite_crypt_writer.h 
- * @author Alexandru Mereacre 
+ * @file sqlite_crypt_writer.h
+ * @author Alexandru Mereacre
  * @brief File containing the definition of the sqlite crypt writer utilities.
  */
 
@@ -48,7 +48,7 @@
 
 /**
  * @brief The store row structure definition
- * 
+ *
  */
 struct store_row {
   char *key;      /**< The key */
@@ -60,7 +60,7 @@ struct store_row {
 
 /**
  * @brief The secrets row structure definition
- * 
+ *
  */
 struct secrets_row {
   char *id;       /**< The key ID */
@@ -71,7 +71,7 @@ struct secrets_row {
 
 /**
  * @brief Opens the sqlite crypt db
- * 
+ *
  * @param db_path The sqlite db path
  * @param sql The returned sqlite db structure pointer
  * @return 0 on success, -1 on failure
@@ -80,14 +80,14 @@ int open_sqlite_crypt_db(char *db_path, sqlite3** sql);
 
 /**
  * @brief Closes the sqlite db
- * 
+ *
  * @param ctx The sqlite db structure pointer
  */
 void free_sqlite_crypt_db(sqlite3 *db);
 
 /**
  * @brief Save a store entry into the sqlite db
- * 
+ *
  * @param db The sqlite db structure pointer
  * @param row The store row structure
  * @return int 0 on success, -1 on failure
@@ -96,7 +96,7 @@ int save_sqlite_store_entry(sqlite3 *db, struct store_row *row);
 
 /**
  * @brief Save a secrets entry into the sqlite db
- * 
+ *
  * @param db The sqlite db structure pointer
  * @param row The secrets row structure
  * @return int 0 on success, -1 on failure
@@ -105,7 +105,7 @@ int save_sqlite_secrets_entry(sqlite3 *db, struct secrets_row *row);
 
 /**
  * @brief Get the sqlite store entry object
- * 
+ *
  * @param db The sqlite db structure pointer
  * @param key The store column key
  * @return struct store_row* row value, NULL on failure
@@ -114,14 +114,14 @@ struct store_row* get_sqlite_store_row(sqlite3 *db, char *key);
 
 /**
  * @brief Frees a store row entry
- * 
+ *
  * @param column The store row value
  */
 void free_sqlite_store_row(struct store_row *row);
 
 /**
  * @brief Get the sqlite secrets entry object
- * 
+ *
  * @param db The sqlite db structure pointer
  * @param id The secrets column id
  * @return struct secrets_row* row value, NULL on failure
@@ -130,7 +130,7 @@ struct secrets_row* get_sqlite_secrets_row(sqlite3 *db, char *id);
 
 /**
  * @brief Frees a secrets row entry
- * 
+ *
  * @param column The secrets row value
  */
 void free_sqlite_secrets_row(struct secrets_row *row);

--- a/src/crypt/zymkey4_driver.c
+++ b/src/crypt/zymkey4_driver.c
@@ -19,7 +19,7 @@
 
 /**
  * @file zymkey4_driver.c
- * @author Alexandru Mereacre 
+ * @author Alexandru Mereacre
  * @brief File containing the implementation of zymkey4 driver configuration utilities.
  */
 
@@ -66,7 +66,7 @@ int generate_zymkey4_key(zkCTX *ctx, uint8_t *key, size_t key_size)
     log_trace("zkGetRandBytes fail");
     return -1;
   }
-  
+
   if (rdata == NULL) {
     log_trace("zkGetRandBytes fail");
     return -1;

--- a/src/crypt/zymkey4_driver.h
+++ b/src/crypt/zymkey4_driver.h
@@ -19,7 +19,7 @@
 
 /**
  * @file zymkey4_driver.h
- * @author Alexandru Mereacre 
+ * @author Alexandru Mereacre
  * @brief File containing the definition of zymkey4 driver configuration utilities.
  */
 #ifndef ZYMKEY4_DRIVER_H
@@ -29,14 +29,14 @@
 
 /**
  * @brief Initialises an HSM context
- * 
+ *
  * @return zkCTX* The returned Zymkey4 context, NULL on error
  */
 zkCTX* init_zymkey4(void);
 
 /**
  * @brief Closes the zymkey4 context
- * 
+ *
  * @param ctx The Zymkey4 context
  * @return int 0 on success, -1 on failure
  */
@@ -44,7 +44,7 @@ int close_zymkey4(zkCTX *ctx);
 
 /**
  * @brief Generate a random Zymkey4 key
- * 
+ *
  * @param ctx The Zymkey4 context
  * @param key The returned key
  * @param key_size The key size
@@ -54,7 +54,7 @@ int generate_zymkey4_key(zkCTX *ctx, uint8_t *key, size_t key_size);
 
 /**
  * @brief Encrypt a byte array wiht the Zymkey4 HSM
- * 
+ *
  * @param ctx The Zymkey4 context
  * @param in The input array
  * @param in_size The input array size
@@ -66,7 +66,7 @@ int encrypt_zymkey4_blob(zkCTX *ctx, uint8_t *in, size_t in_size, uint8_t **out,
 
 /**
  * @brief Decrypt a byte array wiht the Zymkey4 HSM
- * 
+ *
  * @param ctx The Zymkey4 context
  * @param in The input array
  * @param in_size The input array size

--- a/src/dhcp/dhcp_config.h
+++ b/src/dhcp/dhcp_config.h
@@ -19,7 +19,7 @@
 
 /**
  * @file dhcp_config.h
- * @author Alexandru Mereacre 
+ * @author Alexandru Mereacre
  * @brief File containing the definition of dhcp configuration structures.
  */
 #ifndef DHCP_CONFIG_H
@@ -35,7 +35,7 @@
 
 /**
  * @brief The dhcp mapping structure
- * 
+ *
  */
 typedef struct config_dhcpinfo_t {
 	int       			        vlanid;                             /**< Interface VLAN ID */
@@ -47,7 +47,7 @@ typedef struct config_dhcpinfo_t {
 
 /**
  * @brief The dhcp configuration structures.
- * 
+ *
  */
 struct dhcp_conf {
   char dhcp_bin_path[MAX_OS_PATH_LEN];                  /**< The dhcp bin path string */

--- a/src/dhcp/dhcp_service.c
+++ b/src/dhcp/dhcp_service.c
@@ -19,7 +19,7 @@
 
 /**
  * @file dhcp_service.c
- * @author Alexandru Mereacre 
+ * @author Alexandru Mereacre
  * @brief File containing the implementation of dhcp service configuration utilities.
  */
 #include "dnsmasq.h"
@@ -37,7 +37,7 @@ int run_dhcp(struct dhcp_conf *dconf, UT_array *dns_server_array, char *domain_s
     log_trace("generate_dnsmasq_conf fail");
     return -1;
   }
-  
+
   if (generate_dnsmasq_script(dconf->dhcp_script_path, domain_server_path) < 0) {
     log_trace("generate_dnsmasq_script fail");
     return -1;

--- a/src/dhcp/dhcp_service.h
+++ b/src/dhcp/dhcp_service.h
@@ -19,7 +19,7 @@
 
 /**
  * @file dhcp_service.h
- * @author Alexandru Mereacre 
+ * @author Alexandru Mereacre
  * @brief File containing the definition of dhcp service configuration utilities.
  */
 #ifndef DHCP_SERVICE_H
@@ -33,7 +33,7 @@
 
 /**
  * @brief Run the DHCP server
- * 
+ *
  * @param dconf The dhcp configuration structures.
  * @param dns_server_array The array including the DNS servers IP addresses.
  * @param domain_server_path The UNIX domain server path.
@@ -45,14 +45,14 @@ int run_dhcp(struct dhcp_conf *dconf, UT_array *dns_server_array,
 
 /**
  * @brief Closes (terminates) dhcp process
- * 
+ *
  * @return true success, false otherwise
  */
 bool close_dhcp(void);
 
 /**
  * @brief Clear the DHCP lease for a MAC addrress
- * 
+ *
  * @param mac_addr The MAC address string
  * @param dconf The dhcp configuration structures
  * @return int 0 on success, -1 on failure

--- a/src/dhcp/dnsmasq.c
+++ b/src/dhcp/dnsmasq.c
@@ -19,7 +19,7 @@
 
 /**
  * @file dnsmasq.c
- * @author Alexandru Mereacre 
+ * @author Alexandru Mereacre
  * @brief File containing the implementation of dnsmasq service configuration utilities.
  */
 

--- a/src/dns/command_mapper.c
+++ b/src/dns/command_mapper.c
@@ -18,8 +18,8 @@
  ****************************************************************************/
 
 /**
- * @file command_mapper.c 
- * @author Alexandru Mereacre 
+ * @file command_mapper.c
+ * @author Alexandru Mereacre
  * @brief File containing the implementation of the command mapper.
  */
 
@@ -93,6 +93,6 @@ int check_command_mapper(hmap_command_conn **hmap, char *command)
   hash_key = md_hash(command, strlen(command));
 
   HASH_FIND(hh, *hmap, &hash_key, sizeof(uint32_t), s);
-    
+
   return (s != NULL);
 }

--- a/src/dns/command_mapper.h
+++ b/src/dns/command_mapper.h
@@ -18,8 +18,8 @@
  ****************************************************************************/
 
 /**
- * @file command_mapper.h 
- * @author Alexandru Mereacre 
+ * @file command_mapper.h
+ * @author Alexandru Mereacre
  * @brief File containing the definition of the command mapper.
  */
 
@@ -37,24 +37,24 @@
 
 /**
  * @brief Command mapper connection structure
- * 
+ *
  */
 typedef struct hashmap_command_conn {           /**< hashmap key */
-    uint32_t key;               
+    uint32_t key;
     int value;                                  /**< Command info TBD */
     UT_hash_handle hh;         		            /**< hashmap handle */
 } hmap_command_conn;
 
 /**
  * @brief Frees the command mapper connection object
- * 
+ *
  * @param hmap Command mapper connection object
  */
 void free_command_mapper(hmap_command_conn **hmap);
 
 /**
  * @brief Insert a command into the command mapper connection object
- * 
+ *
  * @param hmap Command mapper object
  * @param command The command string
  * @return 0 on success, -1 on failure
@@ -63,7 +63,7 @@ int put_command_mapper(hmap_command_conn **hmap, char *command);
 
 /**
  * @brief Check if a command is in the command mapper connection object
- * 
+ *
  * @param hmap Command mapper object
  * @param command The command string
  * @return 1 if command is in hmap, 0 otherwise, -1 on failure

--- a/src/dns/dns_config.h
+++ b/src/dns/dns_config.h
@@ -18,8 +18,8 @@
  ****************************************************************************/
 
 /**
- * @file dns_config.h 
- * @author Alexandru Mereacre 
+ * @file dns_config.h
+ * @author Alexandru Mereacre
  * @brief File containing the definition of dns service configuration utilities.
  */
 #ifndef DNS_CONFIG_H
@@ -48,7 +48,7 @@
 
 /**
  * @brief The dns configuration structures.
- * 
+ *
  */
 struct dns_conf {
   UT_array *server_array;                      /**< The array including the DNS servers IP addresses. */
@@ -56,7 +56,7 @@ struct dns_conf {
 
 /**
  * @brief The mDNS configuration structures.
- * 
+ *
  */
 struct mdns_conf {
   char mdns_bin_path[MAX_OS_PATH_LEN];                        /**< Path to the mDNS binary */

--- a/src/dns/mcast.c
+++ b/src/dns/mcast.c
@@ -19,7 +19,7 @@
 
 /**
  * @file mcast.c
- * @author Alexandru Mereacre 
+ * @author Alexandru Mereacre
  * @brief File containing the implementation of mDNS utils.
  */
 

--- a/src/dns/mcast.h
+++ b/src/dns/mcast.h
@@ -19,7 +19,7 @@
 
 /**
  * @file mcast.h
- * @author Alexandru Mereacre 
+ * @author Alexandru Mereacre
  * @brief File containing the definition of mDNS utils.
  */
 
@@ -31,7 +31,7 @@
 
 /**
  * @brief Join a multicast socket
- * 
+ *
  * @param fd The socket descriptor
  * @param sa The socket address
  * @param sa_len The socket address length
@@ -42,7 +42,7 @@ int join_mcast(int fd, const struct sockaddr_storage *sa, socklen_t sa_len, uint
 
 /**
  * @brief Create a receive multicast socket
- * 
+ *
  * @param sa The socket address
  * @param sa_len The socket address length
  * @param ifindex The interface index
@@ -52,7 +52,7 @@ int create_recv_mcast(const struct sockaddr_storage *sa, socklen_t sa_len, uint3
 
 /**
  * @brief Create a send multicast socket
- * 
+ *
  * @param sa The socket address
  * @param sa_len The socket address length
  * @param ifindex The interface index

--- a/src/dns/mdns_list.c
+++ b/src/dns/mdns_list.c
@@ -19,7 +19,7 @@
 
 /**
  * @file mdns_list.c
- * @author Alexandru Mereacre 
+ * @author Alexandru Mereacre
  * @brief File containing the implementation of mdns list utils.
  */
 

--- a/src/dns/mdns_list.h
+++ b/src/dns/mdns_list.h
@@ -41,7 +41,7 @@ enum MDNS_REQUEST_TYPE {
 
 /**
  * @brief MDNS info list
- * 
+ *
  */
 struct mdns_list_info {
   enum MDNS_REQUEST_TYPE request;       /**< MDNS request type */
@@ -53,7 +53,7 @@ struct mdns_list_info {
 
 /**
  * @brief MDNS info list
- * 
+ *
  */
 struct mdns_list {
   struct mdns_list_info info;   /**< MDNS info structure */
@@ -78,21 +78,21 @@ int push_mdns_list(struct mdns_list* mlist, struct mdns_list_info *info);
 
 /**
  * @brief Delete a mdns list entry
- * 
+ *
  * @param el The mdns list entry
  */
 void free_mdns_list_el(struct mdns_list* el);
 
 /**
  * @brief Frees the mdns list
- * 
+ *
  * @param mlist The pointer to the mdns list
  */
 void free_mdns_list(struct mdns_list* mlist);
 
 /**
  * @brief Checks if MDNS list has an element with a given request type
- * 
+ *
  * @param mlist The pointer to the mdns list
  * @param request The request type
  * @return 1 request present, 0 otherwise and -1 on failure

--- a/src/dns/mdns_mapper.c
+++ b/src/dns/mdns_mapper.c
@@ -19,7 +19,7 @@
 
 /**
  * @file mdns_mapper.c
- * @author Alexandru Mereacre 
+ * @author Alexandru Mereacre
  * @brief File containing the implementation of the mdns mapper utils.
  */
 
@@ -91,7 +91,7 @@ int put_mdns_query_mapper(hmap_mdns_conn **imap, uint8_t *ip, struct mdns_query_
   info.name = query->qname;
   info.qtype = query->qtype;
   info.request = MDNS_REQUEST_QUERY;
-  
+
   if (put_mdns_info(imap, ip, &info) < 0) {
     log_trace("put_mdns_info fail");
     return -1;
@@ -123,7 +123,7 @@ int put_mdns_answer_mapper(hmap_mdns_conn **imap, uint8_t *ip, struct mdns_answe
   info.rrtype = answer->rrtype;
   info.ttl = answer->ttl;
   info.request = MDNS_REQUEST_ANSWER;
-  
+
   if (put_mdns_info(imap, ip, &info) < 0) {
     log_trace("put_mdns_info fail");
     return -1;
@@ -157,7 +157,7 @@ int check_mdns_mapper_req(hmap_mdns_conn **imap, uint8_t *ip, enum MDNS_REQUEST_
     log_trace("ip param is NULL");
     return -1;
   }
-  
+
   HASH_FIND(hh, *imap, ip, IP_ALEN, s);     /* IP already in the hash? */
 
   if (s == NULL) {

--- a/src/dns/mdns_mapper.h
+++ b/src/dns/mdns_mapper.h
@@ -19,7 +19,7 @@
 
 /**
  * @file mdns_mapper.h
- * @author Alexandru Mereacre 
+ * @author Alexandru Mereacre
  * @brief File containing the definition of mdns mapper utils.
  */
 
@@ -35,10 +35,10 @@
 
 /**
  * @brief MDNS connection structure
- * 
+ *
  */
 typedef struct hashmap_mdns_conn {            /**< hashmap key */
-    uint8_t key[IP_ALEN];               
+    uint8_t key[IP_ALEN];
     struct mdns_list* value;                /**< mDNS list structure */
     UT_hash_handle hh;         		        /**< hashmap handle */
 } hmap_mdns_conn;
@@ -65,14 +65,14 @@ int put_mdns_answer_mapper(hmap_mdns_conn **imap, uint8_t *ip, struct mdns_answe
 
 /**
  * @brief Frees the mDNS mapper connection object
- * 
+ *
  * @param hmap mDNS mapper connection object
  */
 void free_mdns_mapper(hmap_mdns_conn **imap);
 
 /**
  * @brief Checks if mDNS mapper has an element with a given request type
- * 
+ *
  * @param imap mDNS mapper object
  * @param ip The IP
  * @param request The request type

--- a/src/dns/mdns_service.c
+++ b/src/dns/mdns_service.c
@@ -19,7 +19,7 @@
 
 /**
  * @file mdns_service.c
- * @author Alexandru Mereacre 
+ * @author Alexandru Mereacre
  * @brief File containing the implementation of mDNS service structures.
  */
 
@@ -218,7 +218,7 @@ void eloop_reflector_handler(int sock, void *eloop_ctx, void *sock_ctx)
     if(ip4_2_buf(peer_addr_str, qip) < 0) {
       log_trace("Wrong IP4 mDNS address");
       os_free(buf);
-      return;      
+      return;
     }
   }
 
@@ -383,7 +383,7 @@ int register_reflector_if4(struct mdns_context *context)
       return -1;
     }
   }
-  
+
   return 0;
 }
 
@@ -537,12 +537,12 @@ int send_bridge_command(struct mdns_context *context, struct tuple_packet *tp)
     log_trace("check_mdns_mapper_req fail");
     return -1;
   }
-  
+
   if ((retd = check_mdns_mapper_req(&context->imap, dip, MDNS_REQUEST_ANSWER)) < 0) {
     log_trace("check_mdns_mapper_req fail");
     return -1;
   }
-  
+
   if (!ret && !retd) {
     log_trace("Not found mDNS answer request for src ip=%s or dst ip=%s", sch->ip_src, sch->ip_dst);
     return -1;
@@ -553,7 +553,7 @@ int send_bridge_command(struct mdns_context *context, struct tuple_packet *tp)
   {
     log_trace("create_domain_command fail");
     return -1;
-  }  
+  }
 
   log_trace("%s", domain);
 
@@ -619,7 +619,7 @@ int run_capture(struct mdns_context *context)
 {
   UT_array *interfaces = NULL;
   char **ifname = NULL;
-  struct pcap_context *pctx = NULL; 
+  struct pcap_context *pctx = NULL;
   utarray_new(interfaces, &ut_str_icd);
 
   if (split_string_array(context->ifname, ',', interfaces) < 0) {
@@ -631,10 +631,10 @@ int run_capture(struct mdns_context *context)
   if ((context->pctx_list = create_pcap_list()) == NULL) {
     log_trace("create_pcap_context_list fail");
     utarray_free(interfaces);
-    return -1;  
+    return -1;
   }
 
-  while((ifname = (char**) utarray_next(interfaces, ifname)) != NULL) { 
+  while((ifname = (char**) utarray_next(interfaces, ifname)) != NULL) {
     if (!strlen(*ifname)) {
       continue;
     }
@@ -661,7 +661,7 @@ int run_capture(struct mdns_context *context)
 }
 
 int run_mdns(struct mdns_context *context)
-{ 
+{
   if (init_reflections(&context->vlan_mapper, context) < 0) {
     log_trace("init_reflections fail");
     return -1;

--- a/src/dns/mdns_service.h
+++ b/src/dns/mdns_service.h
@@ -19,7 +19,7 @@
 
 /**
  * @file mdns_service.h
- * @author Alexandru Mereacre 
+ * @author Alexandru Mereacre
  * @brief File containing the definition of mDNS service structures.
  */
 
@@ -34,7 +34,7 @@
 
 /**
  * @brief The mDNS context.
- * 
+ *
  */
 struct mdns_context {
   struct reflection_list *rif4;                 /**< IP4 reflection list. */
@@ -44,18 +44,18 @@ struct mdns_context {
   hmap_command_conn *command_mapper;            /**< The command mapper */
   UT_array *pctx_list;                          /**< The list of pcap context */
   struct mdns_conf config;                      /**< mDNS config. */
-  char *ifname;                                 /**< Specifies the interface for pcap lib. */      
+  char *ifname;                                 /**< Specifies the interface for pcap lib. */
   char filter[MAX_FILTER_SIZE];                 /**< Specifies the filter expression for pcap lib */
   char cap_id[MAX_RANDOM_UUID_LEN];             /**< Auto generated capture ID */
   char hostname[OS_HOST_NAME_MAX];              /**< The capture hostname */
   char domain_server_path[MAX_OS_PATH_LEN];     /**< Specifies the path to the UNIX domain socket server */
   char domain_delim;                            /**< Specifies the UNIX domain command delimiter */
-  int sfd;                                      /**< Domain client file descriptor */  
+  int sfd;                                      /**< Domain client file descriptor */
 };
 
 /**
  * @brief Runs the mDNS forwarder service
- * 
+ *
  * @param config The mDNS config structure
  * @return int 0 on success, -1 on failure
  */
@@ -63,7 +63,7 @@ int run_mdns(struct mdns_context *context);
 
 /**
  * @brief Closes mDNS service
- * 
+ *
  * @param context The mDNS context structure
  * @return 0 on success, -1 on failure
  */

--- a/src/dns/reflection_list.c
+++ b/src/dns/reflection_list.c
@@ -19,7 +19,7 @@
 
 /**
  * @file reflection_list.c
- * @author Alexandru Mereacre 
+ * @author Alexandru Mereacre
  * @brief File containing the implementation of reflection list structures.
  */
 
@@ -42,7 +42,7 @@ void setup_reflection_if_el(struct reflection_list *el, unsigned int ifindex, co
   if (ifname == NULL) {
     os_memset(el->ifname, 0, IFNAMSIZ);
   } else {
-    snprintf(el->ifname, IFNAMSIZ, "%s", ifname);   
+    snprintf(el->ifname, IFNAMSIZ, "%s", ifname);
   }
 }
 
@@ -68,7 +68,7 @@ struct reflection_list* push_reflection_list(struct reflection_list *rif, unsign
     log_debug("rif param is NULL");
     return NULL;
   }
-  
+
   if ((el = init_reflection_list()) == NULL) {
     log_debug("init_reflection_list fail");
     return NULL;
@@ -105,5 +105,5 @@ void free_reflection_list(struct reflection_list *rif)
     free_reflection_list_el(el);
   }
 
-  free_reflection_list_el(rif);  
+  free_reflection_list_el(rif);
 }

--- a/src/dns/reflection_list.h
+++ b/src/dns/reflection_list.h
@@ -19,7 +19,7 @@
 
 /**
  * @file reflection_list.h
- * @author Alexandru Mereacre 
+ * @author Alexandru Mereacre
  * @brief File containing the definition of reflection list structures.
  */
 
@@ -43,14 +43,14 @@ struct reflection_list {
 
 /**
  * @brief Initialises the reflection list
- * 
+ *
  * @return struct reflection_list * The reflection list or %NULL on failure
  */
 struct reflection_list * init_reflection_list(void);
 
 /**
  * @brief Pushes an interface element to the reflection list
- * 
+ *
  * @param rif The reflection list
  * @param ifindex The interface index
  * @param ifname The interface name
@@ -60,7 +60,7 @@ struct reflection_list* push_reflection_list(struct reflection_list *rif, unsign
 
 /**
  * @brief Frees the reflection list
- * 
+ *
  * @param rif The reflection list
  */
 void free_reflection_list(struct reflection_list *rif);

--- a/src/edgesec.c
+++ b/src/edgesec.c
@@ -18,8 +18,8 @@
  ****************************************************************************/
 
 /**
- * @file edgesec.c 
- * @author Alexandru Mereacre 
+ * @file edgesec.c
+ * @author Alexandru Mereacre
  * @brief File containing the edgesec tool implementations.
  */
 
@@ -182,7 +182,7 @@ int main(int argc, char *argv[])
   uint8_t level = 0;
   char *config_filename = NULL, *log_filename = NULL;
   struct app_config config;
-  
+
   // Init the app config struct
   memset(&config, 0, sizeof(struct app_config));
 
@@ -195,7 +195,7 @@ int main(int argc, char *argv[])
   } else {
     level = MAX_LOG_LEVELS - verbosity;
   }
-  
+
   // Set the log level
   log_set_level(level);
 

--- a/src/engine.c
+++ b/src/engine.c
@@ -18,8 +18,8 @@
  ****************************************************************************/
 
 /**
- * @file engine.c 
- * @author Alexandru Mereacre 
+ * @file engine.c
+ * @author Alexandru Mereacre
  * @brief File containing the implementation of the app configuration structure.
  */
 
@@ -75,11 +75,11 @@ void copy_ifinfo(UT_array *in, UT_array *out)
 
 /**
  * @brief Check if the system binaries are present and return their absolute paths
- * 
+ *
  * @param commands Array of system binaries name strings
  * @param bin_path_arr Array of system binaries default fodler paths
  * @param hmap_bin_hashes Map of systems binaries to hashes
- * @return hmap_str_keychar* Map for binary to path 
+ * @return hmap_str_keychar* Map for binary to path
  */
 hmap_str_keychar *check_systems_commands(char *commands[], UT_array *bin_path_arr, hmap_str_keychar *hmap_bin_hashes)
 {
@@ -91,7 +91,7 @@ hmap_str_keychar *check_systems_commands(char *commands[], UT_array *bin_path_ar
   }
 
   hmap_str_keychar *hmap_bin_paths = hmap_str_keychar_new();
-  
+
   for(uint8_t idx = 0; commands[idx] != NULL; idx ++) {
     log_debug("Checking %s command...", commands[idx]);
     char *path = get_secure_path(bin_path_arr, commands[idx], false);
@@ -157,7 +157,7 @@ bool create_mac_mapper(struct supervisor_context *ctx)
     utarray_free(mac_conn_arr);
     return false;
   }
-  
+
   if (mac_conn_arr != NULL) {
     while((p = (struct mac_conn *) utarray_next(mac_conn_arr, p)) != NULL) {
       log_trace("Adding mac=" MACSTR " with id=%s vlanid=%d ifname=%s nat=%d allow=%d label=%s status=%d",
@@ -307,7 +307,7 @@ int init_context(struct app_config *app_config, struct supervisor_context *ctx)
   ctx->risk_score = app_config->risk_score;
   ctx->wpa_passphrase_len = os_strnlen_s(app_config->hconfig.wpa_passphrase, AP_SECRET_LEN);
   os_memcpy(ctx->wpa_passphrase, app_config->hconfig.wpa_passphrase, ctx->wpa_passphrase_len);
-  
+
   os_memcpy(ctx->nat_bridge, app_config->nat_bridge, IFNAMSIZ);
   os_memcpy(ctx->nat_interface, app_config->nat_interface, IFNAMSIZ);
   os_memcpy(ctx->db_path, app_config->db_path, MAX_OS_PATH_LEN);
@@ -374,7 +374,7 @@ int init_context(struct app_config *app_config, struct supervisor_context *ctx)
        return -1;
      }
   }
-  
+
   return 0;
 }
 

--- a/src/engine.h
+++ b/src/engine.h
@@ -18,8 +18,8 @@
  ****************************************************************************/
 
 /**
- * @file engine.h 
- * @author Alexandru Mereacre 
+ * @file engine.h
+ * @author Alexandru Mereacre
  * @brief File containing the definition of the app configuration structure.
  */
 #ifndef ENGINE_H
@@ -34,7 +34,7 @@
 
 /**
  * @brief Initialises the app context structure
- * 
+ *
  * @param app_config The app config structure
  * @param ctx The app context structure
  * @return 0 on success, -1 otherwise
@@ -43,7 +43,7 @@ int init_context(struct app_config *app_config, struct supervisor_context *ctx);
 
 /**
  * @brief Executes the edgesec WiFi networking engine. Creates subnets and starts the supervisor, radius servers and hostapd service.
- * 
+ *
  * @param app_config The app configuration structures, setting WiFi network config params.
  * @return @c true if succes, @c false if a service fails to start.
  */

--- a/src/firewall/firewall_config.h
+++ b/src/firewall/firewall_config.h
@@ -18,8 +18,8 @@
  ****************************************************************************/
 
 /**
- * @file firewall_service.h 
- * @author Alexandru Mereacre 
+ * @file firewall_service.h
+ * @author Alexandru Mereacre
  * @brief File containing the definition of the firewall structures.
  */
 

--- a/src/firewall/firewall_service.c
+++ b/src/firewall/firewall_service.c
@@ -18,8 +18,8 @@
  ****************************************************************************/
 
 /**
- * @file firewall_service.c 
- * @author Alexandru Mereacre 
+ * @file firewall_service.c
+ * @author Alexandru Mereacre
  * @brief File containing the implementation of the firewall service commands.
  */
 
@@ -401,5 +401,5 @@ int fw_set_ip_forward(void)
     }
   }
   close(fd);
-  return 0; 
+  return 0;
 }

--- a/src/firewall/firewall_service.h
+++ b/src/firewall/firewall_service.h
@@ -18,8 +18,8 @@
  ****************************************************************************/
 
 /**
- * @file firewall_service.h 
- * @author Alexandru Mereacre 
+ * @file firewall_service.h
+ * @author Alexandru Mereacre
  * @brief File containing the definition of the firewall service commands.
  */
 
@@ -38,7 +38,7 @@
 
 /**
  * @brief Initialises the firewall service context
- * 
+ *
  * @param if_mapper The WiFi subnet to interface mapper
  * @param vlan_mapper The WiFi VLAN to interface mapper
  * @param hmap_bin_paths The Mapper for paths to systems binaries
@@ -60,14 +60,14 @@ struct fwctx* fw_init_context(hmap_if_conn *if_mapper,
 
 /**
  * @brief Frees the firewall service context
- * 
+ *
  * @param context The firewall context
  */
 void fw_free_context(struct fwctx* context);
 
 /**
  * @brief Adds NAT rule to an IP
- * 
+ *
  * @param context The firewall context
  * @param ip_addr The IP address string
  * @return 0 on sucess, -1 on failure
@@ -76,7 +76,7 @@ int fw_add_nat(struct fwctx* context, char *ip_addr);
 
 /**
  * @brief Removes NAT rule to an IP
- * 
+ *
  * @param context The firewall context
  * @param ip_addr The IP address string
  * @return 0 on sucess, -1 on failure
@@ -85,7 +85,7 @@ int fw_remove_nat(struct fwctx* context, char *ip_addr);
 
 /**
  * @brief Adds bridge rule for two IPs
- * 
+ *
  * @param context The firewall context
  * @param ip_addr_left The IP address string left
  * @param ip_addr_right The IP address string right
@@ -95,7 +95,7 @@ int fw_add_bridge(struct fwctx* context, char *ip_addr_left, char *ip_addr_right
 
 /**
  * @brief Removes bridge rule for two IPs
- * 
+ *
  * @param context The firewall context
  * @param ip_addr_left The IP address string left
  * @param ip_addr_right The IP address string right
@@ -105,7 +105,7 @@ int fw_remove_bridge(struct fwctx* context, char *ip_addr_left, char *ip_addr_ri
 
 /**
  * @brief Set the ip forward os system param
- * 
+ *
  * @return int 0 on success, -1 on failure
  */
 

--- a/src/mdnsf.c
+++ b/src/mdnsf.c
@@ -18,8 +18,8 @@
  ****************************************************************************/
 
 /**
- * @file mdnsf.c 
- * @author Alexandru Mereacre 
+ * @file mdnsf.c
+ * @author Alexandru Mereacre
  * @brief File containing the implementation of the mdns forwarder.
  */
 
@@ -127,7 +127,7 @@ int process_app_options(int argc, char *argv[], uint8_t *verbosity, const char *
       return log_cmdline_error("Missing argument for -%c\n", optopt);
     case '?':
       return log_cmdline_error("Unrecognized option -%c\n", optopt);
-    default: 
+    default:
       return show_app_help(argv[0]);
     }
   }

--- a/src/radius/md5.h
+++ b/src/radius/md5.h
@@ -7,7 +7,7 @@
  */
 
 /**
- * @file md5.h 
+ * @file md5.h
  * @author Jouni Malinen
  * @brief MD5 hash implementation and interface functions.
  */

--- a/src/radius/md5_internal.c
+++ b/src/radius/md5_internal.c
@@ -7,7 +7,7 @@
  */
 
 /**
- * @file md5_internal.c 
+ * @file md5_internal.c
  * @author Jouni Malinen
  * @brief MD5 hash implementation and interface functions.
  */

--- a/src/radius/md5_internal.h
+++ b/src/radius/md5_internal.h
@@ -7,7 +7,7 @@
  */
 
 /**
- * @file md5_internal.h 
+ * @file md5_internal.h
  * @author Jouni Malinen
  * @brief MD5 internal definitions.
  */

--- a/src/radius/radius_server.c
+++ b/src/radius/radius_server.c
@@ -7,7 +7,7 @@
  */
 
 /**
- * @file radius_server.h 
+ * @file radius_server.h
  * @authors Jouni Malinen, Alexandru Mereacre
  * @brief RADIUS authentication server.
  */
@@ -147,7 +147,7 @@ struct hostapd_radius_attr * get_password_attribute(const uint8_t *req_authentic
 struct hostapd_radius_attr * get_vlan_attribute(uint16_t vlan_id)
 {
 	char id_str[5];
-	struct hostapd_radius_attr *attr, 
+	struct hostapd_radius_attr *attr,
 		*attr_medium_type, *attr_id;
 
 #define RADIUS_ATTR_TUNNEL_VALUE 		13

--- a/src/radius/radius_server.h
+++ b/src/radius/radius_server.h
@@ -7,7 +7,7 @@
  */
 
 /**
- * @file radius_server.h 
+ * @file radius_server.h
  * @authors Jouni Malinen, Alexandru Mereacre
  * @brief RADIUS authentication server.
  */
@@ -135,7 +135,7 @@ struct radius_server_data {
 
 /**
  * @brief Radius configuration structure
- * 
+ *
  */
 struct radius_conf {
   	int                 radius_port;							/**< Radius port */

--- a/src/radius/radius_service.c
+++ b/src/radius/radius_service.c
@@ -18,8 +18,8 @@
  ****************************************************************************/
 
 /**
- * @file radius_service.h 
- * @author Alexandru Mereacre 
+ * @file radius_service.h
+ * @author Alexandru Mereacre
  * @brief File containing the implementation of the radius service.
  */
 

--- a/src/radius/radius_service.h
+++ b/src/radius/radius_service.h
@@ -18,8 +18,8 @@
  ****************************************************************************/
 
 /**
- * @file radius_service.h 
- * @author Alexandru Mereacre 
+ * @file radius_service.h
+ * @author Alexandru Mereacre
  * @brief File containing the definition of the radius service.
  */
 
@@ -31,7 +31,7 @@
 
 /**
  * @brief Runs the radius service
- * 
+ *
  * @param rconf The radius config
  * @param radius_callback_fn The radius callback function
  * @param radius_callback_args The Radius callback arguments
@@ -42,7 +42,7 @@ struct radius_server_data *run_radius(struct radius_conf *rconf,
 
 /**
  * @brief Closes the radius service
- * 
+ *
  * @param srv Pointer to private RADIUS server context
  */
 void close_radius(struct radius_server_data *srv);

--- a/src/supervisor/bridge_list.c
+++ b/src/supervisor/bridge_list.c
@@ -18,8 +18,8 @@
  ****************************************************************************/
 
 /**
- * @file bridge_list.c 
- * @author Alexandru Mereacre 
+ * @file bridge_list.c
+ * @author Alexandru Mereacre
  * @brief File containing the implementation of the bridge creation functions.
  */
 
@@ -155,7 +155,7 @@ int add_bridge_mac(struct bridge_mac_list *ml, const uint8_t *mac_addr_left, con
   // Existing edge
 	if(ret.left_edge && ret.right_edge)
     return 0;
-  
+
 	src_el = os_zalloc(sizeof(*src_el));
 	if (src_el == NULL) {
     log_err("os_zalloc");
@@ -200,10 +200,10 @@ int remove_bridge_mac(struct bridge_mac_list *ml, const uint8_t *mac_addr_left, 
 	if (e.left_edge == NULL || e.right_edge == NULL) {
     log_trace("Missing edge");
   }
-  
+
   bridge_mac_list_free(e.left_edge);
   bridge_mac_list_free(e.right_edge);
-  
+
   return 0;
 }
 

--- a/src/supervisor/bridge_list.h
+++ b/src/supervisor/bridge_list.h
@@ -18,8 +18,8 @@
  ****************************************************************************/
 
 /**
- * @file bridge_list.h 
- * @author Alexandru Mereacre 
+ * @file bridge_list.h
+ * @author Alexandru Mereacre
  * @brief File containing the definition of the bridge creation functions.
  */
 
@@ -34,7 +34,7 @@
 
 /**
  * @brief The bridge MAc tuple definition
- * 
+ *
  */
 struct bridge_mac_tuple {
   uint8_t src_addr[ETH_ALEN];            /**< MAC address in byte format for source node*/
@@ -42,7 +42,7 @@ struct bridge_mac_tuple {
 };
 /**
  * @brief The MAC bridge address store list
- * 
+ *
  */
 struct bridge_mac_list {
   struct bridge_mac_tuple mac_tuple;          /**< The MAC address tuple */
@@ -51,7 +51,7 @@ struct bridge_mac_list {
 
 /**
  * @brief The structure for edge definition
- * 
+ *
  */
 struct bridge_mac_list_tuple {
   struct bridge_mac_list *left_edge;
@@ -60,21 +60,21 @@ struct bridge_mac_list_tuple {
 
 /**
  * @brief Init the MAC brideg address list for bridge assignment
- * 
+ *
  * @return struct bridge_mac_list* The initialised list
  */
 struct bridge_mac_list *init_bridge_list(void);
 
 /**
  * @brief Free MAC bridge address list
- * 
+ *
  * @param ml The MAC bridge address list
  */
 void free_bridge_list(struct bridge_mac_list *ml);
 
 /**
  * @brief Add bridge connection to the MAC bridge address list
- * 
+ *
  * @param ml The MAC bridge address list
  * @param mac_addr_left The MAC address in byte format for left node
  * @param mac_addr_right The MAC address in byte format for right node
@@ -84,7 +84,7 @@ int add_bridge_mac(struct bridge_mac_list *ml, const uint8_t *mac_addr_left, con
 
 /**
  * @brief Removes a bridge connection from the MAC address list
- * 
+ *
  * @param ml The MAC bridge address list
  * @param mac_addr_left The MAC address in byte format for left node
  * @param mac_addr_right The MAC address in byte format for right node
@@ -94,7 +94,7 @@ int remove_bridge_mac(struct bridge_mac_list *ml, const uint8_t *mac_addr_left, 
 
 /**
  * @brief Get the bridge mac object from a bridge connection
- * 
+ *
  * @param ml The MAC bridge address list
  * @param mac_addr_left The MAC address in byte format for left node
  * @param mac_addr_right The MAC address in byte format for rigth node
@@ -104,7 +104,7 @@ struct bridge_mac_list_tuple get_bridge_mac(struct bridge_mac_list *ml, const ui
 
 /**
  * @brief Get the MAC address dst list array for a src MAC address
- * 
+ *
  * @param ml The MAC bridge address list
  * @param src_addr The source MAC address in byte format
  * @param mac_list_arr The returned array of MAC addresses
@@ -114,7 +114,7 @@ int get_src_mac_list(struct bridge_mac_list *ml, const uint8_t *src_addr, UT_arr
 
 /**
  * @brief Get the all the bridge edges as tuple list array
- * 
+ *
  * @param ml The MAC bridge address list
  * @param tuple_list_arr The returned array of tuples
  * @return int The total number of tuples, -1 on error
@@ -123,7 +123,7 @@ int get_all_bridge_edges(struct bridge_mac_list *ml, UT_array **tuple_list_arr);
 
 /**
  * @brief Check if a bridge exist
- * 
+ *
  * @param ml The MAC bridge address list
  * @param mac_addr_left The MAC address in byte format for left node
  * @param mac_addr_right The MAC address in byte format for rigth node

--- a/src/supervisor/cmd_processor.c
+++ b/src/supervisor/cmd_processor.c
@@ -19,7 +19,7 @@
 
 /**
  * @file cmd_processor.c
- * @author Alexandru Mereacre 
+ * @author Alexandru Mereacre
  * @brief File containing the implementation of the command processor functions.
  */
 
@@ -125,7 +125,7 @@ ssize_t process_accept_mac_cmd(int sock, struct client_address *client_addr,
           return write_domain_data(sock, OK_REPLY, strlen(OK_REPLY), client_addr);
         }
       }
-    } 
+    }
   }
 
   return write_domain_data(sock, FAIL_REPLY, strlen(FAIL_REPLY), client_addr);
@@ -147,7 +147,7 @@ ssize_t process_deny_mac_cmd(int sock, struct client_address *client_addr,
       }
 
       return write_domain_data(sock, OK_REPLY, strlen(OK_REPLY), client_addr);
-    } 
+    }
   }
 
   return write_domain_data(sock, FAIL_REPLY, strlen(FAIL_REPLY), client_addr);
@@ -169,7 +169,7 @@ ssize_t process_add_nat_cmd(int sock, struct client_address *client_addr,
       }
 
       return write_domain_data(sock, OK_REPLY, strlen(OK_REPLY), client_addr);
-    } 
+    }
   }
 
   return write_domain_data(sock, FAIL_REPLY, strlen(FAIL_REPLY), client_addr);
@@ -191,7 +191,7 @@ ssize_t process_remove_nat_cmd(int sock, struct client_address *client_addr,
       }
 
       return write_domain_data(sock, OK_REPLY, strlen(OK_REPLY), client_addr);
-    } 
+    }
   }
 
   return write_domain_data(sock, FAIL_REPLY, strlen(FAIL_REPLY), client_addr);
@@ -221,7 +221,7 @@ ssize_t process_assign_psk_cmd(int sock, struct client_address *client_addr,
           return write_domain_data(sock, OK_REPLY, strlen(OK_REPLY), client_addr);
         }
       }
-    } 
+    }
   }
 
   return write_domain_data(sock, FAIL_REPLY, strlen(FAIL_REPLY), client_addr);
@@ -253,7 +253,7 @@ ssize_t process_get_map_cmd(int sock, struct client_address *client_addr,
       } else if (!ret) {
         return write_domain_data(sock, OK_REPLY, strlen(OK_REPLY), client_addr);
       }
-    } 
+    }
   }
 
   return write_domain_data(sock, FAIL_REPLY, strlen(FAIL_REPLY), client_addr);
@@ -264,7 +264,7 @@ ssize_t process_get_all_cmd(int sock, struct client_address *client_addr,
 {
   (void) cmd_arr; /* unused */
 
-  char temp[255], *reply_buf = NULL; 
+  char temp[255], *reply_buf = NULL;
   struct mac_conn *mac_list = NULL;
   int mac_list_len = get_mac_list(&context->mac_mapper, &mac_list);
   int total = 0;
@@ -335,7 +335,7 @@ ssize_t process_set_ip_cmd(int sock, struct client_address *client_addr,
         if (validate_ipv4_string(*ptr)) {
           if (set_ip_cmd(context, addr, *ptr, ip_type) < 0) {
             log_trace("set_ip_cmd fail");
-            return write_domain_data(sock, FAIL_REPLY, strlen(FAIL_REPLY), client_addr);  
+            return write_domain_data(sock, FAIL_REPLY, strlen(FAIL_REPLY), client_addr);
           }
 
           return write_domain_data(sock, OK_REPLY, strlen(OK_REPLY), client_addr);
@@ -448,7 +448,7 @@ ssize_t process_get_bridges_cmd(int sock, struct client_address *client_addr,
 {
   (void) cmd_arr; /* unused */
 
-  char temp[255], *reply_buf = NULL; 
+  char temp[255], *reply_buf = NULL;
   UT_array *tuple_list_arr;
   int total = 0;
   struct bridge_mac_tuple *p = NULL;
@@ -497,7 +497,7 @@ ssize_t process_set_fingerprint_cmd(int sock, struct client_address *client_addr
   ptr = (char**) utarray_next(cmd_arr, ptr);
   if (ptr != NULL && *ptr != NULL) {
     os_strlcpy(src_mac_addr, *ptr, MACSTR_LEN);
-    
+
     if (hwaddr_aton2(src_mac_addr, addr) == -1) {
       return write_domain_data(sock, FAIL_REPLY, strlen(FAIL_REPLY), client_addr);
     }
@@ -584,7 +584,7 @@ ssize_t process_set_alert_cmd(int sock, struct client_address *client_addr,
       os_free(info);
     }
 
-    return write_domain_data(sock, OK_REPLY, strlen(OK_REPLY), client_addr);  
+    return write_domain_data(sock, OK_REPLY, strlen(OK_REPLY), client_addr);
   }
 
   return write_domain_data(sock, FAIL_REPLY, strlen(FAIL_REPLY), client_addr);
@@ -842,7 +842,7 @@ ssize_t process_gen_pubkey_cmd(int sock, struct client_address *client_addr, str
   char **ptr = (char**) utarray_next(cmd_arr, NULL);
   char *pubid = NULL;
 
-  // public key id  
+  // public key id
   ptr = (char**) utarray_next(cmd_arr, ptr);
   if (ptr != NULL && *ptr != NULL) {
     if ((pubid = os_strdup(*ptr)) == NULL) {

--- a/src/supervisor/cmd_processor.h
+++ b/src/supervisor/cmd_processor.h
@@ -18,8 +18,8 @@
  ****************************************************************************/
 
 /**
- * @file cmd_processor.h 
- * @author Alexandru Mereacre 
+ * @file cmd_processor.h
+ * @author Alexandru Mereacre
  * @brief File containing the definition of the command processor functions.
  */
 
@@ -80,7 +80,7 @@ typedef ssize_t (*process_cmd_fn)(int sock, struct client_address *client_addr, 
 
 /**
  * @brief Processes the domain command string
- * 
+ *
  * @param domain_buffer The domain command string
  * @param domain_buffer_len The domain command string length
  * @param cmd_arr The processed command array
@@ -91,7 +91,7 @@ bool process_domain_buffer(char *domain_buffer, size_t domain_buffer_len, UT_arr
 
 /**
  * @brief Processes the PING command
- * 
+ *
  * @param sock The domain server socket
  * @param client_addr The client address for replies
  * @param context The supervisor structure instance
@@ -102,7 +102,7 @@ ssize_t process_ping_cmd(int sock, struct client_address *client_addr, struct su
 
 /**
  * @brief Processes the SUBSCRIBE_EVENTS command
- * 
+ *
  * @param sock The domain server socket
  * @param client_addr The client address for replies
  * @param context The supervisor structure instance
@@ -113,7 +113,7 @@ ssize_t process_subscribe_events_cmd(int sock, struct client_address *client_add
 
 /**
  * @brief Processes the ACCEPT_MAC command
- * 
+ *
  * @param sock The domain server socket
  * @param client_addr The client address for replies
  * @param context The supervisor structure instance
@@ -124,7 +124,7 @@ ssize_t process_accept_mac_cmd(int sock, struct client_address *client_addr, str
 
 /**
  * @brief Processes the DENY_MAC command
- * 
+ *
  * @param sock The domain server socket
  * @param client_addr The client address for replies
  * @param context The supervisor structure instance
@@ -135,7 +135,7 @@ ssize_t process_deny_mac_cmd(int sock, struct client_address *client_addr, struc
 
 /**
  * @brief Processes the ADD_NAT command
- * 
+ *
  * @param sock The domain server socket
  * @param client_addr The client address for replies
  * @param context The supervisor structure instance
@@ -146,7 +146,7 @@ ssize_t process_add_nat_cmd(int sock, struct client_address *client_addr, struct
 
 /**
  * @brief Processes the REMOVE_NAT command
- * 
+ *
  * @param sock The domain server socket
  * @param client_addr The client address for replies
  * @param context The supervisor structure instance
@@ -157,7 +157,7 @@ ssize_t process_remove_nat_cmd(int sock, struct client_address *client_addr, str
 
 /**
  * @brief Processes the ASSIGN_PSK command
- * 
+ *
  * @param sock The domain server socket
  * @param client_addr The client address for replies
  * @param context The supervisor structure instance
@@ -168,7 +168,7 @@ ssize_t process_assign_psk_cmd(int sock, struct client_address *client_addr, str
 
 /**
  * @brief Processes the GET_MAP command
- * 
+ *
  * @param sock The domain server socket
  * @param client_addr The client address for replies
  * @param context The supervisor structure instance
@@ -179,7 +179,7 @@ ssize_t process_get_map_cmd(int sock, struct client_address *client_addr, struct
 
 /**
  * @brief Processes the GET_ALL command
- * 
+ *
  * @param sock The domain server socket
  * @param client_addr The client address for replies
  * @param context The supervisor structure instance
@@ -190,7 +190,7 @@ ssize_t process_get_all_cmd(int sock, struct client_address *client_addr, struct
 
 /**
  * @brief Processes the SET_IP command
- * 
+ *
  * @param sock The domain server socket
  * @param client_addr The client address for replies
  * @param context The supervisor structure instance
@@ -201,7 +201,7 @@ ssize_t process_set_ip_cmd(int sock, struct client_address *client_addr, struct 
 
 /**
  * @brief Processes the ADD_BRIDGE command
- * 
+ *
  * @param sock The domain server socket
  * @param client_addr The client address for replies
  * @param context The supervisor structure instance
@@ -212,7 +212,7 @@ ssize_t process_add_bridge_cmd(int sock, struct client_address *client_addr, str
 
 /**
  * @brief Processes the REMOVE_BRIDGE command
- * 
+ *
  * @param sock The domain server socket
  * @param client_addr The client address for replies
  * @param context The supervisor structure instance
@@ -223,7 +223,7 @@ ssize_t process_remove_bridge_cmd(int sock, struct client_address *client_addr, 
 
 /**
  * @brief Processes the CLEAR_BRIDGES command
- * 
+ *
  * @param sock The domain server socket
  * @param client_addr The client address for replies
  * @param context The supervisor structure instance
@@ -234,7 +234,7 @@ ssize_t process_clear_bridges_cmd(int sock, struct client_address *client_addr, 
 
 /**
  * @brief Processes the GET_BRIDGES command
- * 
+ *
  * @param sock The domain server socket
  * @param client_addr The client address for replies
  * @param context The supervisor structure instance
@@ -245,7 +245,7 @@ ssize_t process_get_bridges_cmd(int sock, struct client_address *client_addr, st
 
 /**
  * @brief Processes the SET_FINGERPRINT command
- * 
+ *
  * @param sock The domain server socket
  * @param client_addr The client address for replies
  * @param context The supervisor structure instance
@@ -256,7 +256,7 @@ ssize_t process_set_fingerprint_cmd(int sock, struct client_address *client_addr
 
 /**
  * @brief Processes the QUERY_FINGERPRINT command
- * 
+ *
  * @param sock The domain server socket
  * @param client_addr The client address for replies
  * @param context The supervisor structure instance
@@ -267,7 +267,7 @@ ssize_t process_query_fingerprint_cmd(int sock, struct client_address *client_ad
 
 /**
  * @brief Processes the REGISTER_TICKET command
- * 
+ *
  * @param sock The domain server socket
  * @param client_addr The client address for replies
  * @param context The supervisor structure instance
@@ -278,7 +278,7 @@ ssize_t process_register_ticket_cmd(int sock, struct client_address *client_addr
 
 /**
  * @brief Processes the CLEAR_PSK command
- * 
+ *
  * @param sock The domain server socket
  * @param client_addr The client address for replies
  * @param context The supervisor structure instance
@@ -289,7 +289,7 @@ ssize_t process_clear_psk_cmd(int sock, struct client_address *client_addr, stru
 
 /**
  * @brief Processes the PUT_CRYPT command
- * 
+ *
  * @param sock The domain server socket
  * @param client_addr The client address for replies
  * @param context The supervisor structure instance
@@ -300,7 +300,7 @@ ssize_t process_put_crypt_cmd(int sock, struct client_address *client_addr, stru
 
 /**
  * @brief Processes the GET_CRYPT command
- * 
+ *
  * @param sock The domain server socket
  * @param client_addr The client address for replies
  * @param context The supervisor structure instance
@@ -311,7 +311,7 @@ ssize_t process_get_crypt_cmd(int sock, struct client_address *client_addr, stru
 
 /**
  * @brief Processes the GEN_RANDKEY command
- * 
+ *
  * @param sock The domain server socket
  * @param client_addr The client address for replies
  * @param context The supervisor structure instance
@@ -322,7 +322,7 @@ ssize_t process_gen_randkey_cmd(int sock, struct client_address *client_addr, st
 
 /**
  * @brief Processes the GEN_PRIVKEY command
- * 
+ *
  * @param sock The domain server socket
  * @param client_addr The client address for replies
  * @param context The supervisor structure instance
@@ -333,7 +333,7 @@ ssize_t process_gen_privkey_cmd(int sock, struct client_address *client_addr, st
 
 /**
  * @brief Processes the GEN_PUBKEY command
- * 
+ *
  * @param sock The domain server socket
  * @param client_addr The client address for replies
  * @param context The supervisor structure instance
@@ -344,7 +344,7 @@ ssize_t process_gen_pubkey_cmd(int sock, struct client_address *client_addr, str
 
 /**
  * @brief Processes the GEN_CERT command
- * 
+ *
  * @param sock The domain server socket
  * @param client_addr The client address for replies
  * @param context The supervisor structure instance
@@ -355,7 +355,7 @@ ssize_t process_gen_cert_cmd(int sock, struct client_address *client_addr, struc
 
 /**
  * @brief Processes the ENCRYPT_BLOB command
- * 
+ *
  * @param sock The domain server socket
  * @param client_addr The client address for replies
  * @param context The supervisor structure instance
@@ -366,7 +366,7 @@ ssize_t process_encrypt_blob_cmd(int sock, struct client_address *client_addr, s
 
 /**
  * @brief Processes the DECRYPT_BLOB command
- * 
+ *
  * @param sock The domain server socket
  * @param client_addr The client address for replies
  * @param context The supervisor structure instance
@@ -377,7 +377,7 @@ ssize_t process_decrypt_blob_cmd(int sock, struct client_address *client_addr, s
 
 /**
  * @brief Processes the SIGN_BLOB command
- * 
+ *
  * @param sock The domain server socket
  * @param client_addr The client address for replies
  * @param context The supervisor structure instance
@@ -388,7 +388,7 @@ ssize_t process_sign_blob_cmd(int sock, struct client_address *client_addr, stru
 
 /**
  * @brief Get the command function pointer
- * 
+ *
  * @param cmd The command string
  * @return process_cmd_fn The returned function pointer
  */

--- a/src/supervisor/crypt_commands.c
+++ b/src/supervisor/crypt_commands.c
@@ -19,7 +19,7 @@
 
 /**
  * @file crypt_commands.c
- * @author Alexandru Mereacre 
+ * @author Alexandru Mereacre
  * @brief File containing the implementation of the crypt commands.
  */
 
@@ -222,7 +222,7 @@ char* encrypt_blob_cmd(struct supervisor_context *context, char *keyid, char *iv
   if (keypair->value == NULL) {
     log_trace("value is empty");
     free_crypt_pair(keypair);
-    return NULL;  
+    return NULL;
   }
 
   if ((ivpair = get_crypt_pair(context->crypt_ctx, ivid)) == NULL) {
@@ -235,7 +235,7 @@ char* encrypt_blob_cmd(struct supervisor_context *context, char *keyid, char *iv
     log_trace("value is empty");
     free_crypt_pair(keypair);
     free_crypt_pair(ivpair);
-    return NULL;  
+    return NULL;
   }
 
   if ((blob_data = (uint8_t *) base64_url_decode((unsigned char *)blob, strlen(blob), &blob_data_size)) == NULL) {
@@ -292,7 +292,7 @@ char* decrypt_blob_cmd(struct supervisor_context *context, char *keyid, char *iv
   if (keypair->value == NULL) {
     log_trace("value is empty");
     free_crypt_pair(keypair);
-    return NULL;  
+    return NULL;
   }
 
   if ((ivpair = get_crypt_pair(context->crypt_ctx, ivid)) == NULL) {
@@ -305,7 +305,7 @@ char* decrypt_blob_cmd(struct supervisor_context *context, char *keyid, char *iv
     log_trace("value is empty");
     free_crypt_pair(keypair);
     free_crypt_pair(ivpair);
-    return NULL;  
+    return NULL;
   }
 
   if ((blob_data = (uint8_t *) base64_url_decode((unsigned char *)blob, strlen(blob), &blob_data_size)) == NULL) {
@@ -362,7 +362,7 @@ char* sign_blob_cmd(struct supervisor_context *context, char *keyid, char *blob)
   if (pair->value == NULL) {
     log_trace("value is empty");
     free_crypt_pair(pair);
-    return NULL;  
+    return NULL;
   }
 
   if ((blob_data = (uint8_t *) base64_url_decode((unsigned char *)blob, strlen(blob), &blob_data_size)) == NULL) {

--- a/src/supervisor/crypt_commands.h
+++ b/src/supervisor/crypt_commands.h
@@ -18,8 +18,8 @@
  ****************************************************************************/
 
 /**
- * @file crypt_commands.h 
- * @author Alexandru Mereacre 
+ * @file crypt_commands.h
+ * @author Alexandru Mereacre
  * @brief File containing the definition of the crypt commands.
  */
 
@@ -31,7 +31,7 @@
 
 /**
  * @brief PUT_CRYPT command
- * 
+ *
  * @param context The supervisor structure instance
  * @param key The crypt key
  * @param value The crypt value
@@ -41,7 +41,7 @@ int put_crypt_cmd(struct supervisor_context *context, char *key, char *value);
 
 /**
  * @brief GET_CRYPT command
- * 
+ *
  * @param context The supervisor structure instance
  * @param key The crypt key
  * @param value The crypt output value
@@ -51,7 +51,7 @@ int get_crypt_cmd(struct supervisor_context *context, char *key, char **value);
 
 /**
  * @brief GEN_RANDKEY command
- * 
+ *
  * @param context The supervisor structure instance
  * @param keyid The key id
  * @param size The key size in bytes
@@ -61,7 +61,7 @@ int gen_randkey_cmd(struct supervisor_context *context, char *keyid, uint8_t siz
 
 /**
  * @brief GEN_PRIVKEY command
- * 
+ *
  * @param context The supervisor structure instance
  * @param keyid The key id
  * @param size The key size in bytes
@@ -71,7 +71,7 @@ int gen_privkey_cmd(struct supervisor_context *context, char *keyid, uint8_t siz
 
 /**
  * @brief GEN_PUBKEY command
- * 
+ *
  * @param context The supervisor structure instance
  * @param certid The public id
  * @param keyid The private key id
@@ -81,7 +81,7 @@ int gen_pubkey_cmd(struct supervisor_context *context, char *pubid, char *keyid)
 
 /**
  * @brief GEN_CERT command
- * 
+ *
  * @param context The supervisor structure instance
  * @param certid The certificate id
  * @param keyid The private key id
@@ -93,7 +93,7 @@ int gen_cert_cmd(struct supervisor_context *context, char *certid, char *keyid,
 
 /**
  * @brief ENCRYPT_BLOB command
- * 
+ *
  * @param context The supervisor structure instance
  * @param keyid The private key id
  * @param ivid The iv id
@@ -104,7 +104,7 @@ char* encrypt_blob_cmd(struct supervisor_context *context, char *keyid, char *iv
 
 /**
  * @brief DECRYPT_BLOB command
- * 
+ *
  * @param context The supervisor structure instance
  * @param keyid The private key id
  * @param ivid The iv id
@@ -115,7 +115,7 @@ char* decrypt_blob_cmd(struct supervisor_context *context, char *keyid, char *iv
 
 /**
  * @brief SIGN_BLOB command
- * 
+ *
  * @param context The supervisor structure instance
  * @param keyid The private key id
  * @param blob The blob base64 string to sign

--- a/src/supervisor/mac_mapper.c
+++ b/src/supervisor/mac_mapper.c
@@ -19,7 +19,7 @@
 
 /**
  * @file mac_mapper.c
- * @author Alexandru Mereacre 
+ * @author Alexandru Mereacre
  * @brief File containing the implementation of the mac mapper.
  */
 #include <stdbool.h>
@@ -59,7 +59,7 @@ int get_mac_mapper(hmap_mac_conn **hmap, uint8_t mac_addr[ETH_ALEN], struct mac_
 		*info = s->value;
     return 1;
   }
- 
+
   return 0;
 }
 

--- a/src/supervisor/mac_mapper.h
+++ b/src/supervisor/mac_mapper.h
@@ -18,8 +18,8 @@
  ****************************************************************************/
 
 /**
- * @file mac_mapper.h 
- * @author Alexandru Mereacre 
+ * @file mac_mapper.h
+ * @author Alexandru Mereacre
  * @brief File containing the definition of the mac mapper.
  */
 
@@ -43,14 +43,14 @@
 
 /**
  * @brief MAC connection info structure
- * 
+ *
  * MAC device = Device with a given MAC address
  */
 struct mac_conn_info {
   enum AP_CONNECTION_STATUS       status;   /**< The MAC Connection status */
   int       vlanid;                         /**< VLAN ID assigned to the MAC device */
   bool      nat;                            /**< Flag if set assigns NAT to the MAC device*/
-  bool      allow_connection;               /**< If set allows the MAC device to connect ot the network */ 
+  bool      allow_connection;               /**< If set allows the MAC device to connect ot the network */
 	uint8_t 	pass[AP_SECRET_LEN];            /**< WiFi password assigned to the MAC devices */
 	ssize_t		pass_len;                       /**< WiFi password length assigned to the MAC devices */
   char      ip_addr[IP_LEN];                /**< IP address assigned to the MAC device */
@@ -63,7 +63,7 @@ struct mac_conn_info {
 
 /**
  * @brief MAC connection structure
- * 
+ *
  */
 struct mac_conn {
   uint8_t mac_addr[ETH_ALEN];               /**< MAC address in byte format */
@@ -72,17 +72,17 @@ struct mac_conn {
 
 /**
  * @brief MAC mapper connection structure
- * 
+ *
  */
 typedef struct hashmap_mac_conn {           /**< hashmap key */
-    char key[ETH_ALEN];               
+    char key[ETH_ALEN];
     struct mac_conn_info value;             /**< MAC connection structure */
     UT_hash_handle hh;         		          /**< hashmap handle */
 } hmap_mac_conn;
 
 /**
  * @brief Get the MAC connection info structure for a given MAC address
- * 
+ *
  * @param hmap MAC mapper object
  * @param mac_addr MAC address in byte format
  * @param info Output MAC connection info structure
@@ -92,7 +92,7 @@ int get_mac_mapper(hmap_mac_conn **hmap, uint8_t mac_addr[ETH_ALEN], struct mac_
 
 /**
  * @brief Insert a MAC into the MAC mapper connection object
- * 
+ *
  * @param hmap MAC mapper object
  * @param conn MAC connection structure
  * @return true on success, false otherwise
@@ -101,14 +101,14 @@ bool put_mac_mapper(hmap_mac_conn **hmap, struct mac_conn conn);
 
 /**
  * @brief Frees the MAC mapper connection object
- * 
+ *
  * @param hmap MAC mapper connection object
  */
 void free_mac_mapper(hmap_mac_conn **hmap);
 
 /**
  * @brief Get the MAC list from the MAC mapper connection object
- * 
+ *
  * @param hmap MAC mapper connection object
  * @param list Output MAC list
  * @return int
@@ -117,7 +117,7 @@ int get_mac_list(hmap_mac_conn **hmap, struct mac_conn **list);
 
 /**
  * @brief Generate a default mac info configuration
- * 
+ *
  * @param info The input mac info structure
  * @param default_open_vlanid The default VLAN ID
  * @param allow_all_nat The NAT flag
@@ -127,7 +127,7 @@ void init_default_mac_info(struct mac_conn_info *info, int default_open_vlanid,
 
 /**
  * @brief Get the MAC address for a given IP address
- * 
+ *
  * @param hmap MAC mapper object
  * @param ip The AP address
  * @param mac_addr Output MAC address

--- a/src/supervisor/monitor_commands.c
+++ b/src/supervisor/monitor_commands.c
@@ -18,8 +18,8 @@
  ****************************************************************************/
 
 /**
- * @file monitor_commands.c 
- * @author Alexandru Mereacre 
+ * @file monitor_commands.c
+ * @author Alexandru Mereacre
  * @brief File containing the implementation of the monitor commands.
  */
 #include <libgen.h>

--- a/src/supervisor/monitor_commands.h
+++ b/src/supervisor/monitor_commands.h
@@ -18,8 +18,8 @@
  ****************************************************************************/
 
 /**
- * @file monitor_commands.h 
- * @author Alexandru Mereacre 
+ * @file monitor_commands.h
+ * @author Alexandru Mereacre
  * @brief File containing the definition of the monitor commands.
  */
 
@@ -33,7 +33,7 @@
 
 /**
  * @brief SET_ALERT command
- * 
+ *
  * @param context The supervisor structure instance
  * @param meta The alert meta structure
  * @param info The info buffer
@@ -45,7 +45,7 @@ int set_alert_cmd(struct supervisor_context *context, struct alert_meta *meta,
 
 /**
  * @brief SET_FINGERPRINT command
- * 
+ *
  * @param context The supervisor structure instance
  * @param src_mac_addr The source MAC address string
  * @param dst_mac_addr The destination MAC address string
@@ -61,7 +61,7 @@ int set_fingerprint_cmd(struct supervisor_context *context, char *src_mac_addr,
 
 /**
  * @brief QUERY_FINGERPRINT command
- * 
+ *
  * @param context The supervisor structure instance
  * @param mac_addr The MAC address string
  * @param timestamp The timestamp 64 bit value

--- a/src/supervisor/network_commands.c
+++ b/src/supervisor/network_commands.c
@@ -18,8 +18,8 @@
  ****************************************************************************/
 
 /**
- * @file network_commands.c 
- * @author Alexandru Mereacre 
+ * @file network_commands.c
+ * @author Alexandru Mereacre
  * @brief File containing the implementation of the network commands.
  */
 #include <libgen.h>
@@ -469,7 +469,7 @@ uint8_t* register_ticket_cmd(struct supervisor_context *context, uint8_t *mac_ad
 }
 
 int clear_psk_cmd(struct supervisor_context *context, uint8_t *mac_addr)
-{  
+{
   struct mac_conn conn;
   struct mac_conn_info info;
 

--- a/src/supervisor/network_commands.h
+++ b/src/supervisor/network_commands.h
@@ -18,8 +18,8 @@
  ****************************************************************************/
 
 /**
- * @file network_commands.h 
- * @author Alexandru Mereacre 
+ * @file network_commands.h
+ * @author Alexandru Mereacre
  * @brief File containing the definition of the network commands.
  */
 
@@ -37,24 +37,24 @@
 
 /**
  * @brief Save a MAC entry into the mapper
- * 
+ *
  * @param The supervisor context
  * @param The MAc connection structure
- * 
+ *
  * @return true on success, false on failure
  */
 bool save_mac_mapper(struct supervisor_context *context, struct mac_conn conn);
 
 /**
  * @brief Frees an allocated ticket
- * 
+ *
  * @param The supervisor context
  */
 void free_ticket(struct supervisor_context *context);
 
 /**
  * @brief ACCEPT_MAC command
- * 
+ *
  * @param context The supervisor structure instance
  * @param mac_addr The MAC address
  * @param vlanid The VLAN ID
@@ -64,7 +64,7 @@ int accept_mac_cmd(struct supervisor_context *context, uint8_t *mac_addr, int vl
 
 /**
  * @brief DENY_MAC command
- * 
+ *
  * @param context The supervisor structure instance
  * @param mac_addr The MAC address
  * @return int 0 on success, -1 on failure
@@ -73,7 +73,7 @@ int deny_mac_cmd(struct supervisor_context *context, uint8_t *mac_addr);
 
 /**
  * @brief ADD_NAT command
- * 
+ *
  * @param context The supervisor structure instance
  * @param mac_addr The MAC address
  * @return int 0 on success, -1 on failure
@@ -82,7 +82,7 @@ int add_nat_cmd(struct supervisor_context *context, uint8_t *mac_addr);
 
 /**
  * @brief REMOVE_NAT command
- * 
+ *
  * @param context The supervisor structure instance
  * @param mac_addr The MAC address
  * @return int 0 on success, -1 on failure
@@ -91,7 +91,7 @@ int remove_nat_cmd(struct supervisor_context *context, uint8_t *mac_addr);
 
 /**
  * @brief ASSIGN_PSK command
- * 
+ *
  * @param context The supervisor structure instance
  * @param mac_addr The MAC address
  * @param pass The password
@@ -103,7 +103,7 @@ int assign_psk_cmd(struct supervisor_context *context, uint8_t *mac_addr,
 
 /**
  * @brief ADD_BRIDGE command (MAC address input)
- * 
+ *
  * @param context The supervisor structure instance
  * @param left_mac_addr The left MAC address
  * @param right_mac_addr The right MAC address
@@ -113,7 +113,7 @@ int add_bridge_mac_cmd(struct supervisor_context *context, uint8_t *left_mac_add
 
 /**
  * @brief ADD_BRIDGE command (IP address input)
- * 
+ *
  * @param context The supervisor structure instance
  * @param left_ip_addr The left IP address
  * @param right_ip_addr The right IP address
@@ -123,7 +123,7 @@ int add_bridge_ip_cmd(struct supervisor_context *context, char *left_ip_addr, ch
 
 /**
  * @brief REMOVE_BRIDGE command
- * 
+ *
  * @param context The supervisor structure instance
  * @param left_mac_addr The left MAC address
  * @param right_mac_addr The right MAC address
@@ -133,7 +133,7 @@ int remove_bridge_cmd(struct supervisor_context *context, uint8_t *left_mac_addr
 
 /**
  * @brief CLEAR_BRIDGES command
- * 
+ *
  * @param context The supervisor structure instance
  * @param mac_addr The MAC address
  * @return int 0 on success, -1 on failure
@@ -142,7 +142,7 @@ int clear_bridges_cmd(struct supervisor_context *context, uint8_t *left_mac_addr
 
 /**
  * @brief REGISTER_TICKET command
- * 
+ *
  * @param context The supervisor structure instance
  * @param mac_addr The MAC address string
  * @param label The label string
@@ -154,7 +154,7 @@ uint8_t* register_ticket_cmd(struct supervisor_context *context, uint8_t *mac_ad
 
 /**
  * @brief CLEAR_PSK command
- * 
+ *
  * @param context The supervisor structure instance
  * @param mac_addr The MAC address string
  * @return 0 on success, -1 on failure
@@ -163,7 +163,7 @@ int clear_psk_cmd(struct supervisor_context *context, uint8_t *mac_addr);
 
 /**
  * @brief Add an IP to NAT
- * 
+ *
  * @param context The supervisor structure instance
  * @param ip_addr The IP address string
  * @return 0 on success, -1 on failure
@@ -172,7 +172,7 @@ int add_nat_ip(struct supervisor_context *context, char *ip_addr);
 
 /**
  * @brief Remove an IP to NAT
- * 
+ *
  * @param context The supervisor structure instance
  * @param ip_addr The IP address string
  * @return 0 on success, -1 on failure
@@ -181,7 +181,7 @@ int remove_nat_ip(struct supervisor_context *context, char *ip_addr);
 
 /**
  * @brief Add an IP bridge
- * 
+ *
  * @param context The supervisor structure instance
  * @param ip_addr_left The left IP address string
  * @param ip_addr_right The right IP address string
@@ -191,7 +191,7 @@ int add_bridge_ip(struct supervisor_context *context, char *ip_addr_left, char *
 
 /**
  * @brief Deletes an IP bridge
- * 
+ *
  * @param context The supervisor structure instance
  * @param ip_addr_left The left IP address string
  * @param ip_addr_right The right IP address string

--- a/src/supervisor/sqlite_alert_writer.c
+++ b/src/supervisor/sqlite_alert_writer.c
@@ -19,7 +19,7 @@
 
 /**
  * @file sqlite_alert_writer.c
- * @author Alexandru Mereacre 
+ * @author Alexandru Mereacre
  * @brief File containing the implementation of the sqlite alert writer utilities.
  */
 
@@ -47,8 +47,8 @@ int open_sqlite_alert_db(char *db_path, sqlite3** sql)
 {
   sqlite3 *db = NULL;
   int rc;
-  
-  if ((rc = sqlite3_open(db_path, &db)) != SQLITE_OK) {     
+
+  if ((rc = sqlite3_open(db_path, &db)) != SQLITE_OK) {
     log_debug("Cannot open database: %s", sqlite3_errmsg(db));
     sqlite3_close(db);
     return -1;

--- a/src/supervisor/sqlite_alert_writer.h
+++ b/src/supervisor/sqlite_alert_writer.h
@@ -18,8 +18,8 @@
  ****************************************************************************/
 
 /**
- * @file sqlite_alert_writer.h 
- * @author Alexandru Mereacre 
+ * @file sqlite_alert_writer.h
+ * @author Alexandru Mereacre
  * @brief File containing the definition of the sqlite alert writer utilities.
  */
 
@@ -40,7 +40,7 @@
 
 /**
  * @brief The alert row definition
- * 
+ *
  */
 struct alert_row {
   char *hostname;               /**< The machine hostname */
@@ -55,7 +55,7 @@ struct alert_row {
 
 /**
  * @brief Opens the sqlite alert db
- * 
+ *
  * @param db_path The sqlite db path
  * @param sql The returned sqlite db structure pointer
  * @return 0 on success, -1 on failure
@@ -64,21 +64,21 @@ int open_sqlite_alert_db(char *db_path, sqlite3** sql);
 
 /**
  * @brief Closes the sqlite db
- * 
+ *
  * @param ctx The sqlite db structure pointer
  */
 void free_sqlite_alert_db(sqlite3 *db);
 
 /**
  * @brief Frees a row element
- * 
+ *
  * @param row The row structure
  */
 void free_sqlite_alert_row(struct alert_row *row);
 
 /**
  * @brief Save an alert row into the sqlite db
- * 
+ *
  * @param db The sqlite db structure pointer
  * @param row The entry row
  * @return int 0 on success, -1 on failure

--- a/src/supervisor/sqlite_fingerprint_writer.c
+++ b/src/supervisor/sqlite_fingerprint_writer.c
@@ -19,7 +19,7 @@
 
 /**
  * @file sqlite_fingerprint_writer.c
- * @author Alexandru Mereacre 
+ * @author Alexandru Mereacre
  * @brief File containing the implementation of the sqlite fingerprint writer utilities.
  */
 
@@ -47,8 +47,8 @@ int open_sqlite_fingerprint_db(char *db_path, sqlite3** sql)
 {
   sqlite3 *db = NULL;
   int rc;
-  
-  if ((rc = sqlite3_open(db_path, &db)) != SQLITE_OK) {     
+
+  if ((rc = sqlite3_open(db_path, &db)) != SQLITE_OK) {
     log_debug("Cannot open database: %s", sqlite3_errmsg(db));
     sqlite3_close(db);
     return -1;

--- a/src/supervisor/sqlite_fingerprint_writer.h
+++ b/src/supervisor/sqlite_fingerprint_writer.h
@@ -18,8 +18,8 @@
  ****************************************************************************/
 
 /**
- * @file sqlite_fingerprint_writer.h 
- * @author Alexandru Mereacre 
+ * @file sqlite_fingerprint_writer.h
+ * @author Alexandru Mereacre
  * @brief File containing the definition of the sqlite fingerprint writer utilities.
  */
 
@@ -44,7 +44,7 @@
 
 /**
  * @brief The fingerprint row definition
- * 
+ *
  */
 struct fingerprint_row {
   char *mac;                /**< The MAC */
@@ -56,7 +56,7 @@ struct fingerprint_row {
 
 /**
  * @brief Opens the sqlite fingerprint db
- * 
+ *
  * @param db_path The sqlite db path
  * @param sql The returned sqlite db structure pointer
  * @return 0 on success, -1 on failure
@@ -65,14 +65,14 @@ int open_sqlite_fingerprint_db(char *db_path, sqlite3** sql);
 
 /**
  * @brief Closes the sqlite db
- * 
+ *
  * @param ctx The sqlite db structure pointer
  */
 void free_sqlite_fingerprint_db(sqlite3 *db);
 
 /**
  * @brief Save a fingerprint row into the sqlite db
- * 
+ *
  * @param db The sqlite db structure pointer
  * @param row The entry row
  * @return int 0 on success, -1 on failure
@@ -82,7 +82,7 @@ int save_sqlite_fingerprint_row(sqlite3 *db, struct fingerprint_row *row);
 
 /**
  * @brief Retrieves all the fingerprint rows satifying a query
- * 
+ *
  * @param db The sqlite db structure pointer
  * @param mac The MAC value for
  * @param timestamp The timestamp value
@@ -96,7 +96,7 @@ int get_sqlite_fingerprint_rows(sqlite3 *db, char *mac, uint64_t timestamp, char
 
 /**
  * @brief Frees all the rows an an array of rows
- * 
+ *
  * @param rows The array of rows
  */
 void free_sqlite_fingerprint_rows(UT_array *rows);

--- a/src/supervisor/sqlite_macconn_writer.c
+++ b/src/supervisor/sqlite_macconn_writer.c
@@ -19,7 +19,7 @@
 
 /**
  * @file sqlite_macconn_writer.c
- * @author Alexandru Mereacre 
+ * @author Alexandru Mereacre
  * @brief File containing the implementation of the sqlite macconn writer utilities.
  */
 
@@ -48,8 +48,8 @@ int open_sqlite_macconn_db(char *db_path, sqlite3** sql)
 {
   sqlite3 *db = NULL;
   int rc;
-  
-  if ((rc = sqlite3_open(db_path, &db)) != SQLITE_OK) {     
+
+  if ((rc = sqlite3_open(db_path, &db)) != SQLITE_OK) {
     log_debug("Cannot open database: %s", sqlite3_errmsg(db));
     sqlite3_close(db);
     return -1;

--- a/src/supervisor/sqlite_macconn_writer.h
+++ b/src/supervisor/sqlite_macconn_writer.h
@@ -18,8 +18,8 @@
  ****************************************************************************/
 
 /**
- * @file sqlite_macconn_writer.h 
- * @author Alexandru Mereacre 
+ * @file sqlite_macconn_writer.h
+ * @author Alexandru Mereacre
  * @brief File containing the definition of the sqlite macconn writer utilities.
  */
 
@@ -45,7 +45,7 @@
 
 /**
  * @brief Opens the sqlite macconn db
- * 
+ *
  * @param db_path The sqlite db path
  * @param sql The returned sqlite db structure pointer
  * @return 0 on success, -1 on failure
@@ -54,14 +54,14 @@ int open_sqlite_macconn_db(char *db_path, sqlite3** sql);
 
 /**
  * @brief Closes the sqlite db
- * 
+ *
  * @param ctx The sqlite db structure pointer
  */
 void free_sqlite_macconn_db(sqlite3 *db);
 
 /**
  * @brief Saves a macconn entry in the sqlite db
- * 
+ *
  * @param db The sqlite db structure pointer
  * @param conn The MAC connection structure
  * @return int 0 on success, -1 on failure
@@ -70,7 +70,7 @@ int save_sqlite_macconn_entry(sqlite3 *db, struct mac_conn *conn);
 
 /**
  * @brief Saves a macconn entries in the sqlite db
- * 
+ *
  * @param db The sqlite db structure pointer
  * @param entries The macconn entries
  * @return int 0 on success, -1 on failure

--- a/src/supervisor/subscriber_events.c
+++ b/src/supervisor/subscriber_events.c
@@ -19,7 +19,7 @@
 
 /**
  * @file subscriber_events.c
- * @author Alexandru Mereacre 
+ * @author Alexandru Mereacre
  * @brief File containing the implementation of the subscriber events structure.
  */
 
@@ -52,7 +52,7 @@ int add_events_subscriber(struct supervisor_context *context, struct client_addr
   p = utarray_find(context->subscribers_array, addr, sort_subscribers_arrray);
   if (p != NULL) {
     log_trace("Client already subscribed with size=%d", p->len);
-    return 0;    
+    return 0;
   }
 
   utarray_push_back(context->subscribers_array, addr);

--- a/src/supervisor/subscriber_events.h
+++ b/src/supervisor/subscriber_events.h
@@ -19,7 +19,7 @@
 
 /**
  * @file subscriber_events.c
- * @author Alexandru Mereacre 
+ * @author Alexandru Mereacre
  * @brief File containing the definition of the subscriber events structure.
  */
 
@@ -48,7 +48,7 @@ enum SUBSCRIBER_EVENT {
 
 /**
  * @brief Add a subscriber to the subscriber events array
- * 
+ *
  * @param context The supervisor context
  * @param addr The subscriber address
  * @return 0 on success, -1 on failure
@@ -57,7 +57,7 @@ int add_events_subscriber(struct supervisor_context *context, struct client_addr
 
 /**
  * @brief Send an event to the subscribers array
- * 
+ *
  * @param context The supervisor context
  * @param type The event type
  * @param format The event text

--- a/src/supervisor/supervisor.c
+++ b/src/supervisor/supervisor.c
@@ -19,7 +19,7 @@
 
 /**
  * @file supervisor.c
- * @author Alexandru Mereacre 
+ * @author Alexandru Mereacre
  * @brief File containing the implementation of the supervisor service.
  */
 
@@ -131,7 +131,7 @@ int allocate_vlan(struct supervisor_context *context)
   int vlanid, idx = 0, len;
   config_ifinfo_t *p = NULL;
   UT_array *config_ifinfo_array = context->config_ifinfo_array;
-  
+
   if (!context->allocate_vlans) {
     return context->default_open_vlanid;
   }
@@ -262,7 +262,7 @@ struct mac_conn_info get_mac_conn_cmd(uint8_t mac_addr[], void *mac_conn_arg)
 
     return info;
   }
-  
+
   log_trace("REJECTING mac=" MACSTR, MAC2STR(mac_addr));
   info.vlanid = -1;
   return info;
@@ -317,7 +317,7 @@ void eloop_read_sock_handler(int sock, void *eloop_ctx, void *sock_ctx)
 
   if ((num_bytes = read_domain_data(sock, buf, bytes_available, &claddr, 0)) == -1) {
     log_trace("read_domain_data fail");
-    goto end;  
+    goto end;
   }
 
   log_trace("Supervisor received %ld bytes from socket length=%d", (long) num_bytes, claddr.len);

--- a/src/supervisor/supervisor.h
+++ b/src/supervisor/supervisor.h
@@ -19,7 +19,7 @@
 
 /**
  * @file supervisor.c
- * @author Alexandru Mereacre 
+ * @author Alexandru Mereacre
  * @brief File containing the definition of the supervisor service.
  */
 
@@ -30,16 +30,16 @@
 
 /**
  * @brief Return a mac_conn_info for a given MAC address
- * 
+ *
  * @param mac_addr The input MAC adderss
  * @param mac_conn_arg The supervisor_context pointer
- * @return struct mac_conn_info 
+ * @return struct mac_conn_info
  */
 struct mac_conn_info get_mac_conn_cmd(uint8_t mac_addr[], void *mac_conn_arg);
 
 /**
  * @brief The AP service callback
- * 
+ *
  * @param context The supervisor context
  * @param mac_addr The STA mac address
  * @param status The STA connection status
@@ -49,7 +49,7 @@ void ap_service_callback(struct supervisor_context *context, uint8_t mac_addr[],
 
 /**
  * @brief Executes the supervisor service
- * 
+ *
  * @param server_path The domain socket path
  * @param context The supervisor structure
  * @return int The domain socket
@@ -58,7 +58,7 @@ int run_supervisor(char *server_path, struct supervisor_context *context);
 
 /**
  * @brief Closes the supervisor service
- * 
+ *
  * @param context The supervisor structure
  * @return true on success, false otherwise
  */

--- a/src/supervisor/supervisor_config.h
+++ b/src/supervisor/supervisor_config.h
@@ -19,7 +19,7 @@
 
 /**
  * @file supervisor_config.c
- * @author Alexandru Mereacre 
+ * @author Alexandru Mereacre
  * @brief File containing the definition of the supervisor service structure.
  */
 
@@ -42,7 +42,7 @@
 
 /**
  * @brief Authentication ticket structure definition
- * 
+ *
  */
 struct auth_ticket {
   uint8_t         passphrase[AP_SECRET_LEN];              /**< the ticket passphrase */
@@ -54,7 +54,7 @@ struct auth_ticket {
 
 /**
  * @brief Supervisor structure definition
- * 
+ *
  */
 struct supervisor_context {
   hmap_mac_conn   *mac_mapper;                                /**< MAC mapper connection structure */
@@ -63,7 +63,7 @@ struct supervisor_context {
   hmap_str_keychar *hmap_bin_paths;                           /**< Mapper for paths to systems binaries */
   bool            allow_all_connections;                      /**< @c allow_all_connections Flag from @c struct app_config */
   bool            allow_all_nat;                              /**< @c allow_all_nat Flag from @c struct app_config */
-  bool            exec_capture;                               /**< @c execute_capture from @c struct app_config */  
+  bool            exec_capture;                               /**< @c execute_capture from @c struct app_config */
   uint8_t         wpa_passphrase[AP_SECRET_LEN];              /**< @c wpa_passphrase from @c struct hostapd_conf */
   ssize_t         wpa_passphrase_len;                         /**< the length of @c wpa_passphrase*/
   char            nat_bridge[IFNAMSIZ];                       /**< @c nat_bridge param from @c struct app_config */
@@ -93,7 +93,7 @@ struct supervisor_context {
   struct fwctx* fw_ctx;                                       /**< The firewall context. */
   struct crypt_context *crypt_ctx;                            /**< The crypt context. */
   struct iface_context *iface_ctx;                            /**< The interface context. */
-  struct auth_ticket *ticket;                                 /**< The authentication ticket. */  
+  struct auth_ticket *ticket;                                 /**< The authentication ticket. */
   int              ap_sock;                                   /**< The AP notifier socket. */
 };
 

--- a/src/supervisor/system_commands.c
+++ b/src/supervisor/system_commands.c
@@ -19,7 +19,7 @@
 
 /**
  * @file system_commands.c
- * @author Alexandru Mereacre 
+ * @author Alexandru Mereacre
  * @brief File containing the implementation of the system commands.
  */
 #include <sys/un.h>

--- a/src/supervisor/system_commands.h
+++ b/src/supervisor/system_commands.h
@@ -18,8 +18,8 @@
  ****************************************************************************/
 
 /**
- * @file system_commands.h 
- * @author Alexandru Mereacre 
+ * @file system_commands.h
+ * @author Alexandru Mereacre
  * @brief File containing the definition of the system commands.
  */
 
@@ -42,7 +42,7 @@ enum DHCP_IP_TYPE {
 
 /**
  * @brief SET_IP command
- * 
+ *
  * @param context The supervisor structure instance
  * @param mac_addr The MAC address
  * @param ip_addr The IP address
@@ -54,14 +54,14 @@ int set_ip_cmd(struct supervisor_context *context, uint8_t *mac_addr,
 
 /**
  * @brief SUPERVISOR_PING command
- * 
+ *
  * @return char* the ping reply string, NULL on failure
  */
 char* ping_cmd(void);
 
 /**
  * @brief SUBSCRIBE_EVENTS command
- * 
+ *
  * @param context The supervisor structure instance
  * @param addr The subscriber address
  * @return 0 on success, -1 on failure

--- a/src/utils/allocs.c
+++ b/src/utils/allocs.c
@@ -19,7 +19,7 @@
 
 /**
  * @file allocs.c
- * @author Alexandru Mereacre 
+ * @author Alexandru Mereacre
  * @brief File containing the implementation of the allocs functionalities.
  */
 

--- a/src/utils/allocs.h
+++ b/src/utils/allocs.h
@@ -18,8 +18,8 @@
  ****************************************************************************/
 
 /**
- * @file allocs.h 
- * @author Alexandru Mereacre 
+ * @file allocs.h
+ * @author Alexandru Mereacre
  * @brief File containing the definition of the allocs functionalities.
  */
 #ifndef ALLOCS_H
@@ -41,9 +41,9 @@ extern "C" {
 
 /**
  * @brief Allocate and zero memory
- * 
+ *
  * Caller is responsible for freeing the returned buffer with os_free().
- * 
+ *
  * @param size Number of bytes to allocate
  * @return void* Pointer to allocated and zeroed memory or %NULL on failure
  */
@@ -51,7 +51,7 @@ void * os_zalloc(size_t size);
 
 /**
  * @brief Allocate and zero memory for an array
- * 
+ *
  * This function can be used as a wrapper for os_zalloc(nmemb * size) when an
  * allocation is used for an array. The main benefit over os_zalloc() is in
  * having an extra check to catch integer overflows in multiplication.
@@ -97,7 +97,7 @@ static inline void * os_realloc_array(void *ptr, size_t nmemb, size_t size)
 
 /**
  * @brief Allocate duplicate of passed memory chunk
- * 
+ *
  * This function allocates a memory block like os_malloc() would, and
  * copies the given source buffer into it.
  *
@@ -122,7 +122,7 @@ void * os_memdup(const void *src, size_t len);
 
 /**
  * @brief Returns a pointer to a new string which is a duplicate of the string s
- * 
+ *
  * @param s The input string
  * @return char* The dublicate string pointer, NULL on error
  */

--- a/src/utils/cryptou.c
+++ b/src/utils/cryptou.c
@@ -19,7 +19,7 @@
 
 /**
  * @file cryptou.c
- * @author Alexandru Mereacre 
+ * @author Alexandru Mereacre
  * @brief File containing the implementation of the cryptographic utilities.
  */
 
@@ -157,7 +157,7 @@ ssize_t crypto_decrypt(uint8_t *in, int in_size, uint8_t *key,
 {
 #ifdef WITH_OPENSSL_SERVICE
   EVP_CIPHER_CTX *ctx;
-  
+
   int len = 0;
   int plaintext_len = 0;
 
@@ -266,13 +266,13 @@ EVP_PKEY *crypto_generate_ec_key(void)
   if(!EVP_PKEY_CTX_set_ec_paramgen_curve_nid(ctx, NID_X9_62_prime256v1)) {
     log_trace("EVP_PKEY_CTX_set_ec_paramgen_curve_nid fail with code=%d", ERR_get_error());
     EVP_PKEY_CTX_free(ctx);
-    return NULL;    
+    return NULL;
   }
 
   if (!EVP_PKEY_paramgen(ctx, &params)) {
     log_trace("EVP_PKEY_paramgen fail with code=%d", ERR_get_error());
     EVP_PKEY_CTX_free(ctx);
-    return NULL;    
+    return NULL;
   }
 
 
@@ -280,7 +280,7 @@ EVP_PKEY *crypto_generate_ec_key(void)
 
   if((ctx = EVP_PKEY_CTX_new(params, NULL)) == NULL) {
     log_trace("EVP_PKEY_CTX_new fail with code=%d", ERR_get_error());
-    EVP_PKEY_free(params); 
+    EVP_PKEY_free(params);
     return NULL;
   }
 
@@ -327,7 +327,7 @@ X509* crypto_generate_cert(EVP_PKEY *pkey, struct certificate_meta *meta)
   X509_NAME_add_entry_by_txt(name, "O", MBSTRING_ASC, (unsigned char*)meta->o, -1, -1, 0);
   X509_NAME_add_entry_by_txt(name, "OU", MBSTRING_ASC, (unsigned char*)meta->ou, -1, -1, 0);
   X509_NAME_add_entry_by_txt(name, "CN", MBSTRING_ASC, (unsigned char*)meta->cn, -1, -1, 0);
-  
+
   X509_set_issuer_name(x509, name);
 
   /* sign the certificate with the key. */

--- a/src/utils/cryptou.h
+++ b/src/utils/cryptou.h
@@ -18,8 +18,8 @@
  ****************************************************************************/
 
 /**
- * @file cryptou.h 
- * @author Alexandru Mereacre 
+ * @file cryptou.h
+ * @author Alexandru Mereacre
  * @brief File containing the definition of the cryptographic utilities.
  */
 
@@ -48,7 +48,7 @@ struct certificate_meta {
   char c[MAX_CERT_FIELD_SIZE];
   char o[MAX_CERT_FIELD_SIZE];
   char ou[MAX_CERT_FIELD_SIZE];
-  char cn[MAX_CERT_FIELD_SIZE]; 
+  char cn[MAX_CERT_FIELD_SIZE];
 };
 
 enum CRYPTO_KEY_TYPE {
@@ -59,7 +59,7 @@ enum CRYPTO_KEY_TYPE {
 
 /**
  * @brief Generate IV
- * 
+ *
  * @param The output buffer
  * @param The IV size
  * @return 1 on success, 0 on failure
@@ -68,7 +68,7 @@ int crypto_geniv(uint8_t *buf, int iv_size);
 
 /**
  * @brief Generate salt
- * 
+ *
  * @param buf The output buffer
  * @param salt_size The salt size in bytes
  * @return 1 on success, 0 on failure
@@ -77,7 +77,7 @@ int crypto_gensalt(uint8_t *buf, int salt_size);
 
 /**
  * @brief Generate a random key
- * 
+ *
  * @param buf The output buffer
  * @param key_size The key size in bytes
  * @return 1 on success, 0 on failure
@@ -86,7 +86,7 @@ int crypto_genkey(uint8_t *buf, int key_size);
 
 /**
  * @brief Transforms a secret buf into a key
- * 
+ *
  * @param buf The secret buf
  * @param buf_size The buf size
  * @param salt The salt buf
@@ -100,7 +100,7 @@ int crypto_buf2key(uint8_t *buf, int buf_size, uint8_t *salt, int salt_size,
 
 /**
  * @brief Encrypts a buffer with AES CBC 256
- * 
+ *
  * @param in The input buffer
  * @param in_size The input buffer size
  * @param key The 256 bit key
@@ -113,7 +113,7 @@ ssize_t crypto_encrypt(uint8_t *in, int in_size, uint8_t *key,
 
 /**
  * @brief Decrypts a buffer with AES CBC 256
- * 
+ *
  * @param in The input buffer
  * @param in_size The input buffer size
  * @param key The 256 bit key
@@ -126,7 +126,7 @@ ssize_t crypto_decrypt(uint8_t *in, int in_size, uint8_t *key,
 
 /**
  * @brief Generate a private RSA key string
- * 
+ *
  * @param type The key type
  * @param bits Number of key bits
  * @param key The output key string
@@ -136,7 +136,7 @@ int crypto_generate_privkey_str(enum CRYPTO_KEY_TYPE type, int bits, char **key)
 
 /**
  * @brief Generates a public key string from a private key
- * 
+ *
  * @param key The private key buffer
  * @param key_size The private key buffer size
  * @param pub The public key string
@@ -146,7 +146,7 @@ int crypto_generate_pubkey_str(uint8_t *key, size_t key_size, char **pub);
 
 /**
  * @brief Generates a pair of private key and certificate strings
- * 
+ *
  * @param meta Certificate metadata
  * @param key The private key buffer
  * @param key_size The private key buffer size
@@ -157,7 +157,7 @@ int crypto_generate_cert_str(struct certificate_meta *meta, uint8_t *key, size_t
 
 /**
  * @brief Signs a buffer with a private key string
- * 
+ *
  * @param key The private key buffer
  * @param key_size The private key buffer size
  * @param in The input buffer

--- a/src/utils/domain.c
+++ b/src/utils/domain.c
@@ -18,8 +18,8 @@
  ****************************************************************************/
 
 /**
- * @file domain.c 
- * @author Alexandru Mereacre 
+ * @file domain.c
+ * @author Alexandru Mereacre
  * @brief File containing the implementation of the domain utils.
  */
 
@@ -90,7 +90,7 @@ int create_domain_client(char *addr)
     addrlen = sizeof(struct sockaddr_un);
   }
 
-  
+
 
   if (bind(sock, (struct sockaddr *) &claddr, addrlen) == -1) {
     log_err("bind");

--- a/src/utils/domain.h
+++ b/src/utils/domain.h
@@ -18,8 +18,8 @@
  ****************************************************************************/
 
 /**
- * @file domain.h 
- * @author Alexandru Mereacre 
+ * @file domain.h
+ * @author Alexandru Mereacre
  * @brief File containing the definition of the domain utilities.
  */
 
@@ -37,7 +37,7 @@ extern "C" {
 
 /**
  * @brief Client address structure definition
- * 
+ *
  */
 struct client_address {
   struct sockaddr_un addr;
@@ -46,7 +46,7 @@ struct client_address {
 
 /**
  * @brief Create a domain client object
- * 
+ *
  * @param addr The socket addr, if NULL is auto genereated and hidden
  * @return int Client socket
  */
@@ -54,7 +54,7 @@ int create_domain_client(char *add);
 
 /**
  * @brief Create a domain server object
- * 
+ *
  * @param server_path Server UNIX domain socket path
  * @return int Domain server socket
  */
@@ -62,7 +62,7 @@ int create_domain_server(char *server_path);
 
 /**
  * @brief Read data from the domain server socket
- * 
+ *
  * @param sock Domain Server socket
  * @param data Data buffer
  * @param data_len Data buffer length
@@ -74,7 +74,7 @@ ssize_t read_domain_data(int sock, char *data, size_t data_len, struct client_ad
 
 /**
  * @brief Read data from the domain server socket with a string address
- * 
+ *
  * @param sock Domain Server socket
  * @param data Data buffer
  * @param data_len Data buffer length
@@ -86,7 +86,7 @@ ssize_t read_domain_data_s(int sock, char *data, size_t data_len, char *addr, in
 
 /**
  * @brief Write data to the domain server socket
- * 
+ *
  * @param sock Domain server socket
  * @param data Data buffer
  * @param data_len Data buffer length
@@ -97,7 +97,7 @@ ssize_t write_domain_data(int sock, char *data, size_t data_len, struct client_a
 
 /**
  * @brief Write data to the domain server socket with a string address
- * 
+ *
  * @param sock Domain server socket
  * @param data Data buffer
  * @param data_len Data buffer length
@@ -108,7 +108,7 @@ ssize_t write_domain_data_s(int sock, char *data, size_t data_len, char *addr);
 
 /**
  * @brief Closes the domain socket
- * 
+ *
  * @param sfd The domain socket
  * @return int 0 on success, -1 on failure
  */
@@ -116,7 +116,7 @@ int close_domain(int sfd);
 
 /**
  * @brief Write and read a domain data string
- * 
+ *
  * @param socket_path The domain socket path
  * @param write_str The write string
  * @param reply The reply string

--- a/src/utils/eloop.h
+++ b/src/utils/eloop.h
@@ -15,7 +15,7 @@
  */
 
 /**
- * @file eloop.h 
+ * @file eloop.h
  * @author Jouni Malinen
  * @brief Event loop.
  */

--- a/src/utils/ename.h
+++ b/src/utils/ename.h
@@ -18,42 +18,42 @@
  ****************************************************************************/
 
 /**
- * @file ename.h 
- * @author Alexandru Mereacre 
+ * @file ename.h
+ * @author Alexandru Mereacre
  * @brief error strings from errno.h include file.
  */
 
 static char *ename[] = {
-    /*   0 */ "", 
-    /*   1 */ "EPERM", "ENOENT", "ESRCH", "EINTR", "EIO", "ENXIO", 
-    /*   7 */ "E2BIG", "ENOEXEC", "EBADF", "ECHILD", 
-    /*  11 */ "EAGAIN/EWOULDBLOCK", "ENOMEM", "EACCES", "EFAULT", 
-    /*  15 */ "ENOTBLK", "EBUSY", "EEXIST", "EXDEV", "ENODEV", 
-    /*  20 */ "ENOTDIR", "EISDIR", "EINVAL", "ENFILE", "EMFILE", 
-    /*  25 */ "ENOTTY", "ETXTBSY", "EFBIG", "ENOSPC", "ESPIPE", 
-    /*  30 */ "EROFS", "EMLINK", "EPIPE", "EDOM", "ERANGE", 
-    /*  35 */ "EDEADLK/EDEADLOCK", "ENAMETOOLONG", "ENOLCK", "ENOSYS", 
-    /*  39 */ "ENOTEMPTY", "ELOOP", "", "ENOMSG", "EIDRM", "ECHRNG", 
-    /*  45 */ "EL2NSYNC", "EL3HLT", "EL3RST", "ELNRNG", "EUNATCH", 
-    /*  50 */ "ENOCSI", "EL2HLT", "EBADE", "EBADR", "EXFULL", "ENOANO", 
-    /*  56 */ "EBADRQC", "EBADSLT", "", "EBFONT", "ENOSTR", "ENODATA", 
-    /*  62 */ "ETIME", "ENOSR", "ENONET", "ENOPKG", "EREMOTE", 
-    /*  67 */ "ENOLINK", "EADV", "ESRMNT", "ECOMM", "EPROTO", 
-    /*  72 */ "EMULTIHOP", "EDOTDOT", "EBADMSG", "EOVERFLOW", 
-    /*  76 */ "ENOTUNIQ", "EBADFD", "EREMCHG", "ELIBACC", "ELIBBAD", 
-    /*  81 */ "ELIBSCN", "ELIBMAX", "ELIBEXEC", "EILSEQ", "ERESTART", 
-    /*  86 */ "ESTRPIPE", "EUSERS", "ENOTSOCK", "EDESTADDRREQ", 
-    /*  90 */ "EMSGSIZE", "EPROTOTYPE", "ENOPROTOOPT", 
-    /*  93 */ "EPROTONOSUPPORT", "ESOCKTNOSUPPORT", 
-    /*  95 */ "EOPNOTSUPP/ENOTSUP", "EPFNOSUPPORT", "EAFNOSUPPORT", 
-    /*  98 */ "EADDRINUSE", "EADDRNOTAVAIL", "ENETDOWN", "ENETUNREACH", 
-    /* 102 */ "ENETRESET", "ECONNABORTED", "ECONNRESET", "ENOBUFS", 
-    /* 106 */ "EISCONN", "ENOTCONN", "ESHUTDOWN", "ETOOMANYREFS", 
-    /* 110 */ "ETIMEDOUT", "ECONNREFUSED", "EHOSTDOWN", "EHOSTUNREACH", 
-    /* 114 */ "EALREADY", "EINPROGRESS", "ESTALE", "EUCLEAN", 
-    /* 118 */ "ENOTNAM", "ENAVAIL", "EISNAM", "EREMOTEIO", "EDQUOT", 
-    /* 123 */ "ENOMEDIUM", "EMEDIUMTYPE", "ECANCELED", "ENOKEY", 
-    /* 127 */ "EKEYEXPIRED", "EKEYREVOKED", "EKEYREJECTED", 
+    /*   0 */ "",
+    /*   1 */ "EPERM", "ENOENT", "ESRCH", "EINTR", "EIO", "ENXIO",
+    /*   7 */ "E2BIG", "ENOEXEC", "EBADF", "ECHILD",
+    /*  11 */ "EAGAIN/EWOULDBLOCK", "ENOMEM", "EACCES", "EFAULT",
+    /*  15 */ "ENOTBLK", "EBUSY", "EEXIST", "EXDEV", "ENODEV",
+    /*  20 */ "ENOTDIR", "EISDIR", "EINVAL", "ENFILE", "EMFILE",
+    /*  25 */ "ENOTTY", "ETXTBSY", "EFBIG", "ENOSPC", "ESPIPE",
+    /*  30 */ "EROFS", "EMLINK", "EPIPE", "EDOM", "ERANGE",
+    /*  35 */ "EDEADLK/EDEADLOCK", "ENAMETOOLONG", "ENOLCK", "ENOSYS",
+    /*  39 */ "ENOTEMPTY", "ELOOP", "", "ENOMSG", "EIDRM", "ECHRNG",
+    /*  45 */ "EL2NSYNC", "EL3HLT", "EL3RST", "ELNRNG", "EUNATCH",
+    /*  50 */ "ENOCSI", "EL2HLT", "EBADE", "EBADR", "EXFULL", "ENOANO",
+    /*  56 */ "EBADRQC", "EBADSLT", "", "EBFONT", "ENOSTR", "ENODATA",
+    /*  62 */ "ETIME", "ENOSR", "ENONET", "ENOPKG", "EREMOTE",
+    /*  67 */ "ENOLINK", "EADV", "ESRMNT", "ECOMM", "EPROTO",
+    /*  72 */ "EMULTIHOP", "EDOTDOT", "EBADMSG", "EOVERFLOW",
+    /*  76 */ "ENOTUNIQ", "EBADFD", "EREMCHG", "ELIBACC", "ELIBBAD",
+    /*  81 */ "ELIBSCN", "ELIBMAX", "ELIBEXEC", "EILSEQ", "ERESTART",
+    /*  86 */ "ESTRPIPE", "EUSERS", "ENOTSOCK", "EDESTADDRREQ",
+    /*  90 */ "EMSGSIZE", "EPROTOTYPE", "ENOPROTOOPT",
+    /*  93 */ "EPROTONOSUPPORT", "ESOCKTNOSUPPORT",
+    /*  95 */ "EOPNOTSUPP/ENOTSUP", "EPFNOSUPPORT", "EAFNOSUPPORT",
+    /*  98 */ "EADDRINUSE", "EADDRNOTAVAIL", "ENETDOWN", "ENETUNREACH",
+    /* 102 */ "ENETRESET", "ECONNABORTED", "ECONNRESET", "ENOBUFS",
+    /* 106 */ "EISCONN", "ENOTCONN", "ESHUTDOWN", "ETOOMANYREFS",
+    /* 110 */ "ETIMEDOUT", "ECONNREFUSED", "EHOSTDOWN", "EHOSTUNREACH",
+    /* 114 */ "EALREADY", "EINPROGRESS", "ESTALE", "EUCLEAN",
+    /* 118 */ "ENOTNAM", "ENAVAIL", "EISNAM", "EREMOTEIO", "EDQUOT",
+    /* 123 */ "ENOMEDIUM", "EMEDIUMTYPE", "ECANCELED", "ENOKEY",
+    /* 127 */ "EKEYEXPIRED", "EKEYREVOKED", "EKEYREJECTED",
     /* 130 */ "EOWNERDEAD", "ENOTRECOVERABLE", "ERFKILL", "EHWPOISON"
 };
 

--- a/src/utils/hash.c
+++ b/src/utils/hash.c
@@ -18,8 +18,8 @@
  ****************************************************************************/
 
 /**
- * @file hash.c 
- * @author Alexandru Mereacre 
+ * @file hash.c
+ * @author Alexandru Mereacre
  * @brief File containing the implementation of the hash functions.
  */
 #include <stdio.h>

--- a/src/utils/hash.h
+++ b/src/utils/hash.h
@@ -18,8 +18,8 @@
  ****************************************************************************/
 
 /**
- * @file hash.h 
- * @author Alexandru Mereacre 
+ * @file hash.h
+ * @author Alexandru Mereacre
  * @brief File containing the definition of the hash functions.
  */
 
@@ -36,7 +36,7 @@
 
 /**
  * @brief Computes the Merkle–Damgård construction hash for a message
- * 
+ *
  * @param msg The message pointer
  * @param length The message length
  * @return uint32_t The hash value
@@ -45,7 +45,7 @@ uint32_t md_hash(const char* msg, size_t length);
 
 /**
  * @brief Computes the sha256 for an array
- * 
+ *
  * @param hash The resulting 32 byte hash
  * @param input The input array
  * @param len The size of the array

--- a/src/utils/hashmap.c
+++ b/src/utils/hashmap.c
@@ -19,7 +19,7 @@
 
 /**
  * @file hashmap.c
- * @author Alexandru Mereacre 
+ * @author Alexandru Mereacre
  * @brief File containing the implementation of the hashmap utilities.
  */
 

--- a/src/utils/hashmap.h
+++ b/src/utils/hashmap.h
@@ -18,8 +18,8 @@
  ****************************************************************************/
 
 /**
- * @file hashmap.h 
- * @author Alexandru Mereacre 
+ * @file hashmap.h
+ * @author Alexandru Mereacre
  * @brief File containing the definition of the hashmap utilities.
  */
 
@@ -34,7 +34,7 @@
 
 /**
  * @brief keyd array hasmap structure definition
- * 
+ *
  */
 typedef struct hashmap_str_keychar {
     char key[HASH_KEY_CHAR_SIZE];       /**< key (string is WITHIN the structure) */
@@ -44,7 +44,7 @@ typedef struct hashmap_str_keychar {
 
 /**
  * @brief string hasmap structure definition
- * 
+ *
  */
 typedef struct hashmap_str_keyptr {
     char *key;             			    /**< key (string is WITHIN the structure) */
@@ -54,14 +54,14 @@ typedef struct hashmap_str_keyptr {
 
 /**
  * @brief Creates a new string hasmap
- * 
+ *
  * @return hmap_str_keychar* The string hashmap object
  */
 hmap_str_keychar *hmap_str_keychar_new(void);
 
 /**
  * @brief Retrieves a string from string hashmap for a given key
- * 
+ *
  * @param hmap The string hashmap object
  * @param keyptr The hashmap key
  * @return char* Returned string, NULL if not found
@@ -70,7 +70,7 @@ char *hmap_str_keychar_get(hmap_str_keychar **hmap, char *keyptr);
 
 /**
  * @brief Inserts a string into a string hashmap for a given key
- * 
+ *
  * @param hmap The string hashmap object
  * @param keyptr The hashmap key
  * @param value The hashmap string value
@@ -79,8 +79,8 @@ char *hmap_str_keychar_get(hmap_str_keychar **hmap, char *keyptr);
 bool hmap_str_keychar_put(hmap_str_keychar **hmap, char *keyptr, char *value);
 
 /**
- * @brief Deletes the string hashmap object 
- * 
+ * @brief Deletes the string hashmap object
+ *
  * @param hmap The string hashmap object
  */
 void hmap_str_keychar_free(hmap_str_keychar **hmap);

--- a/src/utils/iface.h
+++ b/src/utils/iface.h
@@ -18,7 +18,7 @@
  ****************************************************************************/
 
 /**
- * @file iface.h 
+ * @file iface.h
  * @author Alexandru Mereacre
  * @brief File containing the definition of the network interface utilities.
  */
@@ -57,7 +57,7 @@ struct iface_context {
 
 /**
  * @brief Initialises the interface context
- * 
+ *
  * @param params The parameters for interface context
  * @return struct iface_context* The interface context
  */
@@ -65,14 +65,14 @@ struct iface_context* iface_init_context(void* params);
 
 /**
  * @brief Initialises the interface context
- * 
+ *
  * @param context The interface context
  */
 void iface_free_context(struct iface_context *xontext);
 
 /**
  * @brief Returns an exisiting WiFi interface name that supports VLAN
- * 
+ *
  * @param if_buf Interface working buffer
  * @return char* WiFi interface name
  */
@@ -80,7 +80,7 @@ char* iface_get_vlan(char *if_buf);
 
 /**
  * @brief Get the array of @c struct netif_info_t for each available interface
- * 
+ *
  * @param id The interface name, if NULL return all interfaces
  * @return UT_array* The returned array of @c struct netif_info_t
  */
@@ -88,7 +88,7 @@ UT_array *iface_get(char *ifname);
 
 /**
  * @brief Creates and interface and assigns an IP
- * 
+ *
  * @param context The interface context
  * @param brname The bridge name
  * @param ifname The interface name
@@ -103,7 +103,7 @@ int iface_create(struct iface_context *context, char *brname, char *ifname,
 
 /**
  * @brief Commits the interface changes
- * 
+ *
  * @param context The interface context
  * @return int 0 on success, -1 on failure
  */
@@ -111,7 +111,7 @@ int iface_commit(struct iface_context *context);
 
 /**
  * @brief Resets an interface
- * 
+ *
  * @param context The interface context
  * @param ifname The interface name
  * @return int 0 on success, -1 on failure

--- a/src/utils/iface_mapper.c
+++ b/src/utils/iface_mapper.c
@@ -63,7 +63,7 @@ int get_if_mapper(hmap_if_conn **hmap, in_addr_t subnet, char *ifname)
 	os_memcpy(ifname, s->value, IFNAMSIZ);
     return 1;
   }
- 
+
   return 0;
 }
 
@@ -131,7 +131,7 @@ int get_vlan_mapper(hmap_vlan_conn **hmap, int vlanid, struct vlan_conn	*conn)
 
     return 1;
   }
- 
+
   return 0;
 }
 
@@ -193,12 +193,12 @@ int find_ifinfo(UT_array *config_ifinfo_array, char *ip, config_ifinfo_t *ifinfo
 	    log_trace("ip_2_nbo fail");
 	    return -1;
 	  }
-  
+
 	  if (ip_2_nbo(ip, p->subnet_mask, &addr_ip) < 0) {
 	    log_trace("ip_2_nbo fail");
 	    return -1;
 	  }
-  
+
 	  if (addr_ip == addr_subnet) {
       os_memcpy(ifinfo, p, sizeof(config_ifinfo_t));
 	    return 0;

--- a/src/utils/iface_mapper.h
+++ b/src/utils/iface_mapper.h
@@ -18,7 +18,7 @@
  ****************************************************************************/
 
 /**
- * @file iface_mapper.h 
+ * @file iface_mapper.h
  * @author Alexandru Mereacre
  * @brief File containing the definition of the interface mapper utilities.
  */
@@ -50,7 +50,7 @@ enum IF_STATE{
 
 /**
  * @brief Network interface definition structure
- * 
+ *
  */
 typedef struct {
 	char 			ifname[IFNAMSIZ];					/**< Interface string name */
@@ -67,7 +67,7 @@ typedef struct {
 
 /**
  * @brief Interface configuration info structure
- * 
+ *
  */
 typedef struct config_ifinfo_t{
   int       				vlanid;                 /**< Interface VLAN ID */
@@ -80,7 +80,7 @@ typedef struct config_ifinfo_t{
 
 /**
  * @brief Subnet to interface connection mapper
- * 
+ *
  */
 typedef struct hashmap_if_conn {
     in_addr_t 				key;               		/**< key as subnet */
@@ -90,7 +90,7 @@ typedef struct hashmap_if_conn {
 
 /**
  * @brief MAC connection structure
- * 
+ *
  */
 struct vlan_conn {
   int 	vlanid;								/**< the VLAN ID */
@@ -100,7 +100,7 @@ struct vlan_conn {
 
 /**
  * @brief VLAN to interface connection mapper
- * 
+ *
  */
 typedef struct hashmap_vlan_conn {
     int 						key;               		/**< VLAN id as subnet */
@@ -110,17 +110,17 @@ typedef struct hashmap_vlan_conn {
 
 /**
  * @brief Get the interface name corresponding to an IP address of the subnet
- * 
+ *
  * @param hmap The interface connection mapper object
  * @param subnet The IP address of the subnet
- * @param ifname The returned interface name 
+ * @param ifname The returned interface name
  * @return int 1 if found, 0 not found, -1 on error
  */
 int get_if_mapper(hmap_if_conn **hmap, in_addr_t subnet, char *ifname);
 
 /**
  * @brief Insertes an interface and subnet IP value into the interface connection mapper
- * 
+ *
  * @param hmap The interface connection mapper object
  * @param subnet The IP address of the subnet
  * @param ifname The interface name
@@ -130,14 +130,14 @@ bool put_if_mapper(hmap_if_conn **hmap, in_addr_t subnet, char *ifname);
 
 /**
  * @brief Frees the interface connection mapper object
- * 
+ *
  * @param hmap The interface connection mapper object
  */
 void free_if_mapper(hmap_if_conn **hmap);
 
 /**
  * @brief Get the vlan connection structure corresponding to a VLAN ID
- * 
+ *
  * @param hmap The VLAN ID to vlan connection mapper object
  * @param vlanid The VLAN ID
  * @param conn The returned VLAN connection structure
@@ -147,7 +147,7 @@ int get_vlan_mapper(hmap_vlan_conn **hmap, int vlanid, struct vlan_conn	*conn);
 
 /**
  * @brief Inserts a vlan connection structure and VLAN ID value into the interface connection mapper
- * 
+ *
  * @param hmap The VLAN ID to interface connection mapper object
  * @param conn The VLAN connection structure
  * @return true on success, false otherwise
@@ -156,14 +156,14 @@ bool put_vlan_mapper(hmap_vlan_conn **hmap, struct vlan_conn *conn);
 
 /**
  * @brief Frees the VLAN ID to interface connection mapper object
- * 
+ *
  * @param hmap The VLAN ID to interface connection mapper object
  */
 void free_vlan_mapper(hmap_vlan_conn **hmap);
 
 /**
  * @brief Get the interface name from an IP string
- * 
+ *
  * @param config_ifinfo_array The list of IP subnets
  * @param ip The input IP address
  * @param ifname The returned interface name (buffer has to be preallocated)
@@ -173,7 +173,7 @@ int get_ifname_from_ip(UT_array *config_ifinfo_array, char *ip, char *ifname);
 
 /**
  * @brief Get the bridge name from an IP string
- * 
+ *
  * @param config_ifinfo_array The list of IP subnets
  * @param ip The input IP address
  * @param ifname The returned interface name (buffer has to be preallocated)
@@ -183,7 +183,7 @@ int get_brname_from_ip(UT_array *config_ifinfo_array, char *ip_addr, char *brnam
 
 /**
  * @brief Create the subnet to interface mapper
- * 
+ *
  * @param config_ifinfo_array The connection info array
  * @param hmap The subnet to interface mapper
  * @return true on success, false otherwise
@@ -192,7 +192,7 @@ bool create_if_mapper(UT_array *config_ifinfo_array, hmap_if_conn **hmap);
 
 /**
  * @brief Create the VLAN ID to interface mapper
- * 
+ *
  * @param config_ifinfo_array The connection info array
  * @param hmap The VLAN ID to interface mapper
  * @return true on success, false otherwise
@@ -201,7 +201,7 @@ bool create_vlan_mapper(UT_array *config_ifinfo_array, hmap_vlan_conn **hmap);
 
 /**
  * @brief Initialise the interface names
- * 
+ *
  * @param config_ifinfo_array The connection info array
  * @param ifname The interface name prefix
  * @param brname The bridge name prefix

--- a/src/utils/ifaceu.h
+++ b/src/utils/ifaceu.h
@@ -18,7 +18,7 @@
  ****************************************************************************/
 
 /**
- * @file ifaceu.h 
+ * @file ifaceu.h
  * @author Alexandru Mereacre
  * @brief File containing the definition of the network interface utilities.
  */
@@ -34,13 +34,13 @@
 
 /**
  * @brief if_nametoindex from net/if.h
- * 
+ *
  */
 unsigned int iface_nametoindex (const char *ifname);
 
 /**
  * @brief Check if interface exists
- * 
+ *
  * @param ifname The interface name string
  * @return true if it exists, false otherwise
  */

--- a/src/utils/ipgen.c
+++ b/src/utils/ipgen.c
@@ -18,7 +18,7 @@
  ****************************************************************************/
 
 /**
- * @file ipgen.h 
+ * @file ipgen.h
  * @author Alexandru Mereacre
  * @brief File containing the definition of the ip generic interface utilities.
  */
@@ -57,7 +57,7 @@ struct ipgenctx* ipgen_init_context(char *path)
 
 /**
  * @brief Frees the ipgen context
- * 
+ *
  * @param context The ipgen context
  */
 void ipgen_free_context(struct ipgenctx *context)

--- a/src/utils/ipgen.h
+++ b/src/utils/ipgen.h
@@ -18,7 +18,7 @@
  ****************************************************************************/
 
 /**
- * @file ipgen.h 
+ * @file ipgen.h
  * @author Alexandru Mereacre
  * @brief File containing the definition of the ip generic interface utilities.
  */
@@ -40,7 +40,7 @@ struct ipgenctx {
 
 /**
  * @brief Initialises the ipgen context
- * 
+ *
  * @param path The path string to the ip command
  * @return struct ipgenctx* The ip generic context
  */
@@ -49,7 +49,7 @@ struct ipgenctx* ipgen_init_context(char *path);
 
 /**
  * @brief Frees the ipgen context
- * 
+ *
  * @param context The ipgen context
  */
 void ipgen_free_context(struct ipgenctx *context);
@@ -57,7 +57,7 @@ void ipgen_free_context(struct ipgenctx *context);
 
 /**
  * @brief Creates and interface and assigns an IP
- * 
+ *
  * @param context The ipgen context interface
  * @param ifname The interface name
  * @param type The interface type
@@ -71,7 +71,7 @@ int ipgen_create_interface(struct ipgenctx *context, char *ifname, char *type,
 
 /**
  * @brief Resets the interface
- * 
+ *
  * @param context The ipgen context interface
  * @param ifname The interface name
  * @return int 0 on success, -1 on failure

--- a/src/utils/iptables.c
+++ b/src/utils/iptables.c
@@ -19,7 +19,7 @@
 
 /**
  * @file iptables.c
- * @author Alexandru Mereacre 
+ * @author Alexandru Mereacre
  * @brief File containing the implementation of the IP tables utilities.
  */
 
@@ -175,7 +175,7 @@ bool process_rule_lines(struct iptables_context *ctx, char *rule_str)
           return true;
         }
       }
-    }    
+    }
   }
 
   utarray_free(line_arr);
@@ -223,7 +223,7 @@ bool flush_iptables(struct iptables_context *ctx)
 
     rule_count ++;
   }
-  
+
   return true;
 }
 
@@ -293,7 +293,7 @@ struct iptables_context* iptables_init(char *path, UT_array *ifinfo_array, bool 
 bool get_filter_rules(struct iptables_context *ctx)
 {
   char *list_rule[8] = {"-L", "FORWARD", "-t", "filter", "--line-numbers", "-n", "-v", NULL};
- 
+
   if (run_iptables(ctx, list_rule, list_rule_cb) < 0) {
     log_trace("run_iptables fail");
     return false;
@@ -305,7 +305,7 @@ bool get_filter_rules(struct iptables_context *ctx)
 bool get_nat_rules(struct iptables_context *ctx)
 {
   char *list_rule[8] = {"-L", "POSTROUTING", "-t", "nat", "--line-numbers", "-n", "-v", NULL};
- 
+
   if (run_iptables(ctx, list_rule, list_rule_cb) < 0) {
     log_trace("run_iptables fail");
     return false;

--- a/src/utils/iptables.h
+++ b/src/utils/iptables.h
@@ -19,7 +19,7 @@
 
 /**
  * @file iptables.h
- * @author Alexandru Mereacre 
+ * @author Alexandru Mereacre
  * @brief File containing the definition of the IP tables utilities.
  */
 
@@ -34,17 +34,17 @@
 
 /**
  * @brief iptables context structure definition
- * 
+ *
  */
 struct iptables_context {
   char iptables_path[MAX_OS_PATH_LEN];      /**< The iptables executable path */
-  UT_array *rule_list;                      /**< Current iptables rules */  
+  UT_array *rule_list;                      /**< Current iptables rules */
   bool  exec_iptables;                      /**< Flag to execute iptables command */
 };
 
 /**
  * @brief Initialises the iptables rules list
- * 
+ *
  * @param path The iptables binary path
  * @param ifinfo_array Array of interface configuration info structure
  * @param exec_iptables Execute the iptables command
@@ -54,14 +54,14 @@ struct iptables_context* iptables_init(char *path, UT_array *ifinfo_array, bool 
 
 /**
  * @brief Free the iptables context
- * 
+ *
  * @param ctx The iptables context
  */
 void iptables_free(struct iptables_context* ctx);
 
 /**
  * @brief Add a bridge rule to the list of rules
- * 
+ *
  * @param ctx The iptables context
  * @param sip Source IP string
  * @param sif Source interface name string
@@ -73,7 +73,7 @@ bool iptables_add_bridge(struct iptables_context *ctx, char *sip, char *sif, cha
 
 /**
  * @brief Delete a bridge rule
- * 
+ *
  * @param ctx The iptables context
  * @param sip Source IP string
  * @param sif Source interface name string
@@ -85,7 +85,7 @@ bool iptables_delete_bridge(struct iptables_context* ctx, char *sip, char *sif, 
 
 /**
  * @brief Add a NAT rule
- * 
+ *
  * @param ctx The iptables context
  * @param sip Source IP string
  * @param sif Source interface name string
@@ -96,7 +96,7 @@ bool iptables_add_nat(struct iptables_context* ctx, char *sip, char *sif, char *
 
 /**
  * @brief Delete a NAT rule
- * 
+ *
  * @param ctx The iptables context
  * @param sip Source IP string
  * @param sif Source interface name string

--- a/src/utils/list.h
+++ b/src/utils/list.h
@@ -7,7 +7,7 @@
  */
 
 /**
- * @file list.h 
+ * @file list.h
  * @authora Jouni Malinen, Alexandru Mereacre
  * @brief Doubly-linked list.
  */

--- a/src/utils/log.c
+++ b/src/utils/log.c
@@ -21,8 +21,8 @@
  */
 
 /**
- * @file log.h 
- * @authors rxi, Alexandru Mereacre 
+ * @file log.h
+ * @authors rxi, Alexandru Mereacre
  * @brief File containing the implementation of the logging functions.
  */
 
@@ -226,13 +226,13 @@ void print_to(uint8_t level, const char *file, uint32_t line,
 
   if (err > 0 && err <= MAX_ENAME)
     fprintf(stream, "[%s] ", strerror(err));
-  
+
   vfprintf(stream, format, args);
   fprintf(stream, "\n");
-  fflush(stream); 
+  fflush(stream);
 }
 
-void log_msg(uint8_t level, const char *file, uint32_t line, bool flush_std, 
+void log_msg(uint8_t level, const char *file, uint32_t line, bool flush_std,
   bool ignore_level, uint8_t err, const char *format, va_list args)
 {
   (void) flush_std; /* unused */

--- a/src/utils/log.h
+++ b/src/utils/log.h
@@ -6,8 +6,8 @@
  */
 
 /**
- * @file log.h 
- * @authors rxi, Alexandru Mereacre 
+ * @file log.h
+ * @authors rxi, Alexandru Mereacre
  * @brief File containing the definition of the logging functions.
  */
 

--- a/src/utils/minGlue.h
+++ b/src/utils/minGlue.h
@@ -9,7 +9,7 @@
  */
 
 /**
- * @file minGlue.h 
+ * @file minGlue.h
  * @author CompuPhase
  * @brief Glue functions for the minIni library.
  */

--- a/src/utils/minIni.c
+++ b/src/utils/minIni.c
@@ -21,7 +21,7 @@
  */
 
 /**
- * @file minIni.c 
+ * @file minIni.c
  * @author CompuPhase
  * @brief minIni - Multi-Platform INI file parser, suitable for embedded systems.
  */

--- a/src/utils/minIni.h
+++ b/src/utils/minIni.h
@@ -18,7 +18,7 @@
  */
 
 /**
- * @file minIni.h 
+ * @file minIni.h
  * @author CompuPhase
  * @brief minIni - Multi-Platform INI file parser, suitable for embedded systems.
  */

--- a/src/utils/net.c
+++ b/src/utils/net.c
@@ -124,7 +124,7 @@ int ip4_2_buf(char *ip, uint8_t *buf)
 	  log_err("inet_pton");
 	  return -1;
   }
-  
+
   buf[0] = (uint8_t) (addr.s_addr & 0x000000FF);
   buf[1] = (uint8_t) ((addr.s_addr >> 8) & 0x000000FF);
   buf[2] = (uint8_t) ((addr.s_addr >> 16) & 0x000000FF);
@@ -175,7 +175,7 @@ uint8_t get_short_subnet(char *subnet_mask)
 int get_ip_host(char *ip, char *subnet_mask, uint32_t *host)
 {
   uint8_t ipbuf[4], mbuf[4];
-  
+
   if (ip4_2_buf(ip, ipbuf) < 0) {
     log_trace("ip4_2_buf fail");
     return -1;

--- a/src/utils/net.h
+++ b/src/utils/net.h
@@ -18,7 +18,7 @@
  ****************************************************************************/
 
 /**
- * @file net.h 
+ * @file net.h
  * @author Alexandru Mereacre
  * @brief File containing the definition of the network utilities.
  */
@@ -39,15 +39,15 @@
 
 /**
  * @brief Checks whether a string denotes a IPv4 address
- * 
+ *
  * @param ip The IP in fromat x.y.z.q
- * @return true if the string is an IP, false otherwise 
+ * @return true if the string is an IP, false otherwise
  */
 bool validate_ipv4_string(char *ip);
 
 /**
  * @brief IP string to @c struct in_addr_t converter
- * 
+ *
  * @param ip The IP address string
  * @param subnetMask The IP address subnet mask
  * @param addr The output @c struct in_addr_t value
@@ -57,7 +57,7 @@ int ip_2_nbo(char *ip, char *subnetMask, in_addr_t *addr);
 
 /**
  * @brief IP string to buffer
- * 
+ *
  * @param ip The IP address string
  * @param buf The output buffer of size IP_ALEN
  * @return 0 on success, -1 on failure
@@ -66,7 +66,7 @@ int ip4_2_buf(char *ip, uint8_t *buf);
 
 /**
  * @brief Convert a 32 bit number IP to an IP string (string needs to be freed)
- * 
+ *
  * @param addr The IP in 32 bit format
  * @param ip The input buffer to store the IP
  * @return char* Pointer to the returned IP
@@ -75,7 +75,7 @@ const char *bit32_2_ip(uint32_t addr, char *ip);
 
 /**
  * @brief Convert the in_addr encoded IP4 address to an IP string (string needs to be freed)
- * 
+ *
  * @param addr The in_addr encoded IP
  * @param ip The input buffer to store the IP
  * @return char* Pointer to the returned IP
@@ -84,7 +84,7 @@ const char *inaddr4_2_ip(struct in_addr *addr, char *ip);
 
 /**
  * @brief Convert the in6_addr encoded IP6 address to an IP string (string needs to be freed)
- * 
+ *
  * @param addr The in6_addr encoded IP
  * @param ip The input buffer to store the IP
  * @return char* Pointer to the returned IP
@@ -93,7 +93,7 @@ const char *inaddr6_2_ip(struct in6_addr *addr, char *ip);
 
 /**
  * @brief Convert from a string subnet mask to a short integer version
- * 
+ *
  * @param subnet_mask The subnet mask string
  * @return uint8_t The short integer version subnet mask
  */

--- a/src/utils/nl.c
+++ b/src/utils/nl.c
@@ -211,7 +211,7 @@ enum IF_STATE get_operstate(__u8 state)
 	if (state >= 7) {
 		return IF_STATE_OTHER;
 	} else {
-		return (enum IF_STATE) state; 
+		return (enum IF_STATE) state;
 	}
 }
 

--- a/src/utils/nl.h
+++ b/src/utils/nl.h
@@ -18,7 +18,7 @@
  ****************************************************************************/
 
 /**
- * @file nl.h 
+ * @file nl.h
  * @author Alexandru Mereacre
  * @brief File containing the definition of the netlink utilities.
  */
@@ -49,7 +49,7 @@ struct nl80211_state {
 
 /**
  * @brief Network wireless interface information structure
- * 
+ *
  */
 typedef struct {
 	char ifname[IFNAMSIZ];				/**< Interface string name */
@@ -67,21 +67,21 @@ struct iplink_req {
 
 /**
  * @brief Initialises the nl context
- * 
+ *
  * @return struct nlctx* The nl context
  */
 struct nlctx* nl_init_context(void);
 
 /**
  * @brief Frees the nl context
- * 
+ *
  * @param context The nl context
  */
 void nl_free_context(struct nlctx *context);
 
 /**
  * @brief Get the array of @c struct netif_info_t for each available interface
- * 
+ *
  * @param if_id The intreface id, if 0 return all interfaces
  * @return UT_array* The returned array of @c struct netif_info_t
  */
@@ -90,7 +90,7 @@ UT_array *nl_get_interfaces(int if_id);
 
 /**
  * @brief Creates a new interface object
- * 
+ *
  * @param if_name The interface string name
  * @param type The interface string type (ex. "bridge")
  * @return true on success, false otherwise
@@ -99,7 +99,7 @@ bool nl_new_interface(char *if_name, char *type);
 
 /**
  * @brief Set the interface IP
- * 
+ *
  * @param ip_addr The IP address string
  * @param brd_addr The broadcast IP address string
  * @param if_name The interface name string
@@ -109,7 +109,7 @@ bool nl_set_interface_ip(char *ip_addr, char *brd_addr, char *if_name);
 
 /**
  * @brief Set the interface state
- * 
+ *
  * @param if_name The interface name string
  * @param state The interface state value (true - "up", false - "down")
  * @return true on success, false otherwise
@@ -119,7 +119,7 @@ bool nl_set_interface_state(char *if_name, bool state);
 
 /**
  * @brief Creates and interface and assigns an IP
- * 
+ *
  * @param context The nl context interface
  * @param ifname The interface name
  * @param type The interface type
@@ -133,7 +133,7 @@ int nl_create_interface(struct nlctx *context, char *ifname, char *type,
 
 /**
  * @brief Resets the interface
- * 
+ *
  * @param if_name The interface name string
  * @return 0 on success, -1 otherwise
  */
@@ -141,7 +141,7 @@ int nl_reset_interface(char *ifname);
 
 /**
  * @brief Check if wireless physical interface has VLAN capability
- * 
+ *
  * @param wiphy Wireless physical interface ID
  * @return true if capability present, false otherwise
  */
@@ -149,14 +149,14 @@ bool iwace_isvlan(uint32_t wiphy);
 
 /**
  * @brief Get the array of all wireless physical interfaces
- * 
+ *
  * @return UT_array* The array of wireless physical interfaces
  */
 UT_array *get_netiw_info(void);
 
 /**
  * @brief Check if interface has the VLAN capability
- * 
+ *
  * @param ifname Interface name string
  * @return int 0 if VLAN capable, -1 on error and 1 if not VLAN capable
  */
@@ -164,7 +164,7 @@ int nl_is_iw_vlan(const char *ifname);
 
 /**
  * @brief Returns an exisiting WiFi interface name that supports VLAN
- * 
+ *
  * @param buf Interface working buffer
  * @return char* WiFi interface name
  */

--- a/src/utils/nl80211.h
+++ b/src/utils/nl80211.h
@@ -1,6 +1,6 @@
 /**
- * @file nl80211.h 
- * @author Intel Corporation 
+ * @file nl80211.h
+ * @author Intel Corporation
  * @brief 802.11 netlink interface public header.
  */
 

--- a/src/utils/os.c
+++ b/src/utils/os.c
@@ -298,10 +298,10 @@ int run_command(char *const argv[], char *const envp[], process_callback_fn fn, 
     if (fn == NULL) {
       /* redirect stdout, stdin and stderr to /dev/null */
       close(STDIN_FILENO);
-  
+
       /* Reopen standard fd's to /dev/null */
       int fd = open("/dev/null", O_RDWR);
-  
+
       if (fd != STDIN_FILENO)         /* 'fd' should be 0 */
         _exit(EXIT_FAILURE);
       if (dup2(STDIN_FILENO, STDOUT_FILENO) != STDOUT_FILENO)
@@ -395,9 +395,9 @@ int run_argv_command(char *path, char *argv[], process_callback_fn fn, void *ctx
     log_trace("argv param is NULL");
     return -1;
   }
-  
+
   while(argv[arg_count++] != NULL);
-  
+
   full_arg = (char **) os_malloc(sizeof(char *) * (arg_count + 1));
 
   full_arg[0] = path;
@@ -407,7 +407,7 @@ int run_argv_command(char *path, char *argv[], process_callback_fn fn, void *ctx
   }
 
   full_arg[count + 1] = NULL;
-  
+
   log_run_command(full_arg, arg_count);
 
   int status = run_command(full_arg, NULL, fn, (void *)ctx);
@@ -472,7 +472,7 @@ ssize_t split_string_array(const char *str, char sep, UT_array *arr)
 {
   if (arr == NULL) {
     log_trace("input arr is NULL");
-    return -1;   
+    return -1;
   }
 
   return split_string(str, sep, fn_split_string_array, (void *)arr);
@@ -523,7 +523,7 @@ char *get_valid_path(char *path)
   if (dir == NULL && path != NULL) {
     log_trace("strdup fail");
     return NULL;
-  } 
+  }
 
   char *base = os_strdup(path);
   if (base == NULL && path != NULL) {
@@ -572,7 +572,7 @@ char *construct_path(char *path_left, char *path_right)
   char *valid_left = get_valid_path(path_left);
   char *valid_right = get_valid_path(path_right);
   char *beg_right = valid_right;
-  
+
   if (strlen(valid_right) >= 2) {
     if (valid_right[0] == '.' && valid_right[1] == '/')
       beg_right++;
@@ -614,7 +614,7 @@ char* get_secure_path(UT_array *bin_path_arr, char *filename, bool real)
         if (real_path == NULL) {
           log_err("realpath");
           os_free(path);
-          return NULL;  
+          return NULL;
         }
 
         log_trace("got real path %s", real_path);
@@ -1029,7 +1029,7 @@ size_t os_strnlen_s(char *str, size_t max_len)
 
   if (end == NULL)
     return max_len;
-  
+
   return end - str;
 }
 

--- a/src/utils/os.h
+++ b/src/utils/os.h
@@ -18,8 +18,8 @@
  ****************************************************************************/
 
 /**
- * @file os.h 
- * @author Alexandru Mereacre 
+ * @file os.h
+ * @author Alexandru Mereacre
  * @brief File containing the definition of the os functionalities.
  */
 
@@ -120,7 +120,7 @@ extern "C" {
 
 /**
  * @brief Get current time (sec, usec)
- * 
+ *
  * @param t Pointer to buffer for the time
  * @return int 0 on success, -1 on failure
  */
@@ -128,7 +128,7 @@ int os_get_time(struct os_time *t);
 
 /**
  * @brief Get relative time (sec, usec)
- * 
+ *
  * @param t Pointer to buffer for the time
  * @return int 0 on success, -1 on failure
  */
@@ -137,7 +137,7 @@ int os_get_reltime(struct os_reltime *t);
 
 /**
  * @brief Compares the seconds value of two time params
- * 
+ *
  * @param a struct os_reltime first param
  * @param b struct os_reltime second param
  * @return int true if a->sec < b->sec
@@ -151,7 +151,7 @@ static inline int os_reltime_before(struct os_reltime *a,
 
 /**
  * @brief Subtracts the time value of two time params
- * 
+ *
  * @param a struct os_reltime first param
  * @param b struct os_reltime second param
  * @param res The resulting difference of the time params
@@ -169,7 +169,7 @@ static inline void os_reltime_sub(struct os_reltime *a, struct os_reltime *b,
 
 /**
  * @brief get the timestamp in microseconds from system time
- * 
+ *
  * @patat, timestamp The returned timestamp
  * @return int 0 on success, -1 on failure
  */
@@ -177,7 +177,7 @@ int os_get_timestamp(uint64_t *timestamp);
 
 /**
  * @brief get the timestamp in microseconds from struct timeval
- * 
+ *
  * @param ts The input struct timeval
  * @param timestamp The returned timestamp
  */
@@ -185,7 +185,7 @@ void os_to_timestamp(struct timeval ts, uint64_t *timestamp);
 
 /**
  * @brief Get cryptographically strong pseudo random data
- * 
+ *
  * @param buf Buffer for pseudo random data.
  * @param len Length of the buffer.
  * @return int 0 on success, -1 on failure
@@ -195,7 +195,7 @@ int os_get_random(unsigned char *buf, size_t len);
 
 /**
  * @brief Return a random int from a give range
- * 
+ *
  * @param low The range lower bound
  * @param up The range upper bound
  * @return int The returned random int
@@ -204,13 +204,13 @@ int os_get_random_int_range(int low, int up);
 
 /**
  * @brief Initialises the random seed
- * 
+ *
  */
 void os_init_random_seed(void);
 
 /**
  * @brief Get a random number string
- * 
+ *
  * @param buf Buffer for the random string.
  * @param len Length of the buffer.
  * @return int 0 on success, -1 on failure
@@ -218,8 +218,8 @@ void os_init_random_seed(void);
 int os_get_random_number_s(unsigned char *buf, size_t len);
 
 /**
- * @brief Hex two char string to byte convertes 
- * 
+ * @brief Hex two char string to byte convertes
+ *
  * @param hex Two char string
  * @return int Converted byte
  */
@@ -227,7 +227,7 @@ int hex2byte(const char *hex);
 
 /**
  * @brief Convert ASCII hex string into binary data
- * 
+ *
  * @param hex ASCII hex string (e.g., "01ab")
  * @param buf Buffer for the binary data
  * @param len Length of the text to convert in bytes (of buf); hex will be double this size
@@ -237,7 +237,7 @@ int hexstr2bin(const char *hex, uint8_t *buf, size_t len);
 
 /**
  * @brief Convert ASCII string to MAC address (in any known format)
- * 
+ *
  * @param txt MAC address as a string (e.g., 00:11:22:33:44:55 or 0011.2233.4455)
  * @param addr Buffer for the MAC address (ETH_ALEN = 6 bytes)
  * @return int Characters used (> 0) on success, -1 on failure
@@ -246,7 +246,7 @@ int hwaddr_aton2(const char *txt, uint8_t *addr);
 
 /**
  * @brief Check if a string is a number
- * 
+ *
  * @param ptr String pointer
  * @return true if numer, false otherwise
  */
@@ -254,9 +254,9 @@ bool is_number(const char *ptr);
 
 /**
  * @brief Copy a string with size bound and NUL-termination
- * 
+ *
  * This function matches in behavior with the strlcpy(3) function in OpenBSD.
- * 
+ *
  * @param dest Destination string
  * @param src Source string
  * @param siz Size of the target buffer
@@ -266,7 +266,7 @@ size_t os_strlcpy(char *dest, const char *src, size_t siz);
 
 /**
  * @brief Returns the size of string with a give max length
- * 
+ *
  * @param str The string pointer
  * @param max_len The string max length
  * @return size_t Total length of the string
@@ -308,7 +308,7 @@ typedef void (*process_callback_fn)(void *ctx, void *buf, size_t count);
 
 /**
  * @brief Executes a command
- * 
+ *
  * @param argv The command arguments including the process path
  * @param envp The environment variables
  * @param process_callback_fn Callback function
@@ -319,7 +319,7 @@ int run_command(char *const argv[], char *const envp[], process_callback_fn, voi
 
 /**
  * @brief Executes a command with argument
- * 
+ *
  * @param path The command path
  * @param argv The command arguments without the process path
  * @param process_callback_fn Callback function
@@ -330,14 +330,14 @@ int run_argv_command(char *path, char *argv[], process_callback_fn fn, void *ctx
 
 /**
  * @brief Convert the string to upper case
- * 
+ *
  * @param s The input string
  */
 void upper_string(char *s);
 
 /**
  * @brief Replace a character in a string with a given characater
- * 
+ *
  * @param s The input string
  * @param in The character to be replaced
  * @param out The character to replace with
@@ -348,7 +348,7 @@ typedef int(*split_string_fn)(const char *, size_t, void *);
 
 /**
  * @brief Splits a string into substrings (execute callback function)
- * 
+ *
  * @param str String to split
  * @param sep String separator
  * @param fun Callback function
@@ -359,7 +359,7 @@ ssize_t split_string(const char *str, char sep, split_string_fn fun, void *data)
 
 /**
  * @brief Splits a string into substrings (save to array)
- * 
+ *
  * @param str String to split
  * @param sep String separator
  * @param arr Array to save the substrings
@@ -369,7 +369,7 @@ ssize_t split_string_array(const char *str, char sep, UT_array *arr);
 
 /**
  * @brief Concatenate two string paths
- * 
+ *
  * @param path_left First string path
  * @param path_right Second string path
  * @return char* Concatenated paths
@@ -378,7 +378,7 @@ char *concat_paths(char *path_left, char *path_right);
 
 /**
  * @brief Get the valid path string
- * 
+ *
  * @param path Input string path
  * @return char* output valid path
  */
@@ -386,7 +386,7 @@ char *get_valid_path(char *path);
 
 /**
  * @brief Construct a valid path from two paths
- * 
+ *
  * @param path_left First path
  * @param path_right Second path
  * @return char* output valid path
@@ -395,7 +395,7 @@ char *construct_path(char *path_left, char *path_right);
 
 /**
  * @brief Get the secure path string of a binary
- * 
+ *
  * @param bin_path_arr The path string of binary
  * @param filename The binary name
  * @param real true to return the real link
@@ -407,17 +407,17 @@ typedef bool(*list_dir_fn)(char *, void *args);
 
 /**
  * @brief List the files in a directory
- * 
+ *
  * @param dirpath The directory path
  * @param fun The callback function
  * @param args The callback function arguments
- * @return int 
+ * @return int
  */
 int list_dir(char *dirpath, list_dir_fn fun, void *args);
 
 /**
  * @brief Check if a process path from /proc folder contains the process name
- * 
+ *
  * @param path The process path from /proc fodler
  * @param proc_name The process name
  * @return long The process PID
@@ -426,15 +426,15 @@ long is_proc_app(char *path, char *proc_name);
 
 /**
  * @brief Kill a process by name
- * 
+ *
  * @param proc_name The process name
- * @return bool true on success, false otherwise 
+ * @return bool true on success, false otherwise
  */
 bool kill_process(char *proc_name);
 
 /**
  * @brief Signal a process
- * 
+ *
  * @param proc_name The process name
  * @param sig The signal value
  * @return true on success, false on failure
@@ -443,7 +443,7 @@ bool signal_process(char *proc_name, int sig);
 
 /**
  * @brief Executes a process with an array of strign arguments
- * 
+ *
  * @param argv The array of string arguments terminated with NULL and the first argument is the absolute path of the process.
  * @param child_pid The returned child pid
  * @return int 1 if process started, 0 if the child specified by pid exist, but have not yet changed state, -1 on error
@@ -452,7 +452,7 @@ int run_process(char *argv[], pid_t *child_pid);
 
 /**
  * @brief Check if a process is running
- * 
+ *
  * @param name The process name
  * @return int 1 if running, 0 otherwise, -1 on failure
  */
@@ -460,7 +460,7 @@ int is_proc_running(char *name);
 
 /**
  * @brief Makes a file given by descriptor executable
- * 
+ *
  * @param fd File descriptor
  * @return int 0 on succes, -1 on error
  */
@@ -468,7 +468,7 @@ int make_file_exec_fd(int fd);
 
 /**
  * @brief Right trim the string
- * 
+ *
  * @param str The source string
  * @param seps The separator string, if NULL then the separator used is "\t\n\v\f\r "
  * @return char* The pointer to the source string
@@ -477,7 +477,7 @@ char *rtrim(char *str, const char *seps);
 
 /**
  * @brief Concatenates an array of strings into a single string
- * 
+ *
  * @param strings The array of string, the last element is NULL
  * @return char* The concatenated string
  */
@@ -485,14 +485,14 @@ char* string_array2string(char *strings[]);
 
 /**
  * @brief Generates a random UUID string of MAX_RANDOM_UUID_LEN - 1 characters long not including '\0'
- * 
+ *
  * @param rid The output string of MAX_RANDOM_UUID_LEN bytes
  */
 void generate_radom_uuid(char *rid);
 
 /**
  * @brief Callback function for list_dir function to check if process running
- * 
+ *
  * @param path The process path
  * @param args The callback arguments of type struct find_dir_type
  * @return bool true if process running, false otherwise
@@ -501,7 +501,7 @@ bool find_dir_proc_fn(char *path, void *args);
 
 /**
  * @brief Check if folder exists
- * 
+ *
  * @param dirpath The folder path
  * @return int 1 if exists, 0 otherwise, -1 on failure
  */
@@ -538,30 +538,30 @@ int make_dirs_to_path(const char* file_path, mode_t mode);
  *
  * @param[in] dirpath The folder path
  * @param mode The folder creation mode
- * @return 0 on success, -1 on failure 
+ * @return 0 on success, -1 on failure
  */
 int create_dir(const char *dirpath, mode_t mode);
 
 /**
  * @brief Check if a file exists
- * 
+ *
  * @param path The path to the file
  * @param sb Optional stat struct
- * @return 0 if it exists, -1 on failure 
+ * @return 0 if it exists, -1 on failure
  */
 int check_file_exists(char *path, struct stat *sb);
 
 /**
  * @brief Check if a socket file exists
- * 
+ *
  * @param path The path to the socket file
- * @return 0 if it exists, -1 otherwise 
+ * @return 0 if it exists, -1 otherwise
  */
 int check_sock_file_exists(char *path);
 
 /**
  * @brief Get the hostname of the running machine
- * 
+ *
  * @param buf The returned hostname
  * @return int 0 on success, -1 on failure
  */
@@ -576,7 +576,7 @@ int get_hostname(char *buf);
    name of the calling program (i.e., argv[0] or similar), and is used only for
    diagnostic messages. If we can't open 'pidFile', or we encounter some other
    error, then we print an appropriate diagnostic and terminate.
- * 
+ *
  * @param pid_file The pid file path to create
  * @param flags The pid file open flags
  * @return int The pif file descriptor, -1 on failure
@@ -585,7 +585,7 @@ int create_pid_file(const char *pid_file, int flags);
 
 /**
  * @brief Read the entire file
- * 
+ *
  * @param path The file path
  * @param out The output buffer
  * @return ssize_t The file size, -1 on failure
@@ -594,7 +594,7 @@ ssize_t read_file(char *path, uint8_t **out);
 
 /**
  * @brief Read the entire file into a string
- * 
+ *
  * @param path The file path
  * @param out The output string
  * @return 0 on success, -1 on failure

--- a/src/utils/sqliteu.c
+++ b/src/utils/sqliteu.c
@@ -19,7 +19,7 @@
 
 /**
  * @file sqliteu.c
- * @author Alexandru Mereacre 
+ * @author Alexandru Mereacre
  * @brief File containing the implementation of the sqlite utilities.
  */
 #include <stdio.h>
@@ -37,7 +37,7 @@ int execute_sqlite_query(sqlite3 *db, char *statement)
   if (rc != SQLITE_OK ) {
     log_trace("Failed to execute statement %s", err);
     sqlite3_free(err);
-    
+
     return -1;
   }
 

--- a/src/utils/sqliteu.h
+++ b/src/utils/sqliteu.h
@@ -18,8 +18,8 @@
  ****************************************************************************/
 
 /**
- * @file sqliteu.h 
- * @author Alexandru Mereacre 
+ * @file sqliteu.h
+ * @author Alexandru Mereacre
  * @brief File containing the definition of the sqlite utilities.
  */
 
@@ -33,7 +33,7 @@
 
 /**
  * @brief Executes and sqlite query statement
- * 
+ *
  * @param db The sqlite db structure.
  * @param statement The sqlite query statement.
  * @return int 0 on success, -1 on failure.
@@ -42,7 +42,7 @@ int execute_sqlite_query(sqlite3 *db, char *statement);
 
 /**
  * @brief Check if sqlite table exists
- * 
+ *
  * @param db The sqlite db structure
  * @param table_name The table name
  * @return int 0 if it doesn't exist, 1 if it excists and -1 on failure

--- a/src/utils/squeue.c
+++ b/src/utils/squeue.c
@@ -19,7 +19,7 @@
 
 /**
  * @file squeue.c
- * @author Alexandru Mereacre 
+ * @author Alexandru Mereacre
  * @brief File containing the implementation of the string queue utilities.
  */
 

--- a/src/utils/squeue.h
+++ b/src/utils/squeue.h
@@ -18,8 +18,8 @@
  ****************************************************************************/
 
 /**
- * @file squeue.h 
- * @author Alexandru Mereacre 
+ * @file squeue.h
+ * @author Alexandru Mereacre
  * @brief File containing the definition of the string queue utilities.
  */
 
@@ -35,7 +35,7 @@
 
 /**
  * @brief String queue structure definition
- * 
+ *
  */
 struct string_queue {
   char *str;                    /**< String value */
@@ -45,7 +45,7 @@ struct string_queue {
 
 /**
  * @brief Initialises and empty string queue
- * 
+ *
  * @param max_length Maximum queue size, -1 for unlimited
  * @return struct string_queue* Returned initialised empty string queue
  */
@@ -53,7 +53,7 @@ struct string_queue* init_string_queue(ssize_t max_length);
 
 /**
  * @brief Pushes a string in the string queue
- * 
+ *
  * @param queue The string queue
  * @param str The string value
  * @return 0 on success, -1 on failure
@@ -62,7 +62,7 @@ int push_string_queue(struct string_queue* queue, char *str);
 
 /**
  * @brief Extract the first string from the string queueu
- * 
+ *
  * @param queue The string queue
  * @param str The returned string
  * @return int 0 on success, -1 on failure
@@ -71,7 +71,7 @@ int pop_string_queue(struct string_queue* queue, char **str);
 
 /**
  * @brief Peek the first string from the string queueu
- * 
+ *
  * @param queue The string queue
  * @param str The returned string
  * @return int 0 on success, -1 on failure
@@ -80,7 +80,7 @@ int peek_string_queue(struct string_queue* queue, char **str);
 
 /**
  * @brief Empty a string entry
- * 
+ *
  * @param queue The string queue
  * @param count NUmber of elements to remove, -1 for all
  */
@@ -88,14 +88,14 @@ void empty_string_queue(struct string_queue* queue, ssize_t count);
 
 /**
  * @brief Delete a string entry
- * 
+ *
  * @param el The string queue entry
  */
 void free_string_queue_el(struct string_queue* el);
 
 /**
  * @brief Returns the string queue length
- * 
+ *
  * @param el The pointer to the string queue
  * @return ssize_t The string queue length
  */
@@ -103,14 +103,14 @@ ssize_t get_string_queue_length(struct string_queue* queue);
 
 /**
  * @brief Frees the string queue
- * 
+ *
  * @param queue The pointer to the string queue
  */
 void free_string_queue(struct string_queue* queue);
 
 /**
  * @brief Concat teh first count string in the queue
- * 
+ *
  * @param queue The pointer to the string queue
  * @param count Number of queue strings to concat, if -1 concat the entire queue
  * @return char* The pointer to the concatenated string, NULL for failure or empty queue

--- a/src/utils/uci_wrt.c
+++ b/src/utils/uci_wrt.c
@@ -468,9 +468,9 @@ UT_array *uwrt_get_interfaces(struct uctx *context, char *ifname)
 
   while(true) {
     if (ifname == NULL) {
-      snprintf(key, 64, "network.@interface[%d]", idx++); 
+      snprintf(key, 64, "network.@interface[%d]", idx++);
     } else {
-      snprintf(key, 64, "network.%s", ifname); 
+      snprintf(key, 64, "network.%s", ifname);
     }
 
     utarray_new(kv, &ut_str_icd);
@@ -840,7 +840,7 @@ int uwrt_gen_hostapd_instance(struct uctx *context, struct hostapd_params *param
 
   if (params->device == NULL) {
     log_trace("device param is NULL");
-    return -1;    
+    return -1;
   }
 
   sprintf(property, "wireless.%s=wifi-device", params->device);

--- a/src/utils/uci_wrt.h
+++ b/src/utils/uci_wrt.h
@@ -18,7 +18,7 @@
  ****************************************************************************/
 
 /**
- * @file uci.h 
+ * @file uci.h
  * @author Alexandru Mereacre
  * @brief File containing the definition of the uci utilities.
  */
@@ -58,7 +58,7 @@ struct hostapd_params {
 
 /**
  * @brief Initialises the uci context
- * 
+ *
  * @param path The path string to the config folder
  * @return struct uctx* The uci context
  */
@@ -66,14 +66,14 @@ struct uctx* uwrt_init_context(char *path);
 
 /**
  * @brief Frees the uci context
- * 
+ *
  * @param context The uci context
  */
 void uwrt_free_context(struct uctx *context);
 
 /**
  * @brief Get the array of @c struct netif_info_t for each available interface
- * 
+ *
  * @param context The uci context
  * @param ifname The interface name, if NULL return all interfaces
  * @return UT_array* The returned array of @c struct netif_info_t
@@ -82,7 +82,7 @@ UT_array *uwrt_get_interfaces(struct uctx *context, char *ifname);
 
 /**
  * @brief Creates and interface and assigns an IP
- * 
+ *
  * @param context The uci context
  * @param ifname The interface name
  * @param type The interface type
@@ -96,7 +96,7 @@ int uwrt_create_interface(struct uctx *context, char *ifname, char *type,
 
 /**
  * @brief Commit a uci section
- * 
+ *
  * @param context The uci context
  * @param context The uci section
  * @return int 0 on success, -1 on failure
@@ -105,7 +105,7 @@ int uwrt_commit_section(struct uctx *context, char *section);
 
 /**
  * @brief Generates a dnsmasq uci instance
- * 
+ *
  * @param context The uci context
  * @param ifname_queue The interface queue
  * @param server_array The array of servers
@@ -118,7 +118,7 @@ int uwrt_gen_dnsmasq_instance(struct uctx *context, struct string_queue *ifname_
 
 /**
  * @brief Adds a dhcp pool entry
- * 
+ *
  * @param context The uci context
  * @param ifname The interface name
  * @param ip_addr_low Interface string IP address lower bound
@@ -133,7 +133,7 @@ int uwrt_add_dhcp_pool(struct uctx *context, char *ifname,
 
 /**
  * @brief Generate the hostapd configf
- * 
+ *
  * @param context The uci context
  * @param params The hostapd params
  * @return int 0 on success, -1 on failure
@@ -142,7 +142,7 @@ int uwrt_gen_hostapd_instance(struct uctx *context, struct hostapd_params *param
 
 /**
  * @brief Generate a firewall zone for a bridge
- * 
+ *
  * @param context The uci context
  * @param params The bridge name
  * @return int 0 on success, -1 on failure
@@ -152,7 +152,7 @@ int uwrt_gen_firewall_zone(struct uctx *context, char *brname);
 
 /**
  * @brief Adds a firewall rule for an IP address
- * 
+ *
  * @param context The uci context
  * @param brname The bridge name
  * @param ip_addr The IP address
@@ -163,7 +163,7 @@ int uwrt_add_firewall_nat(struct uctx *context, char *brname, char *ip_addr, cha
 
 /**
  * @brief Deletes a firewall rule for an IP address
- * 
+ *
  * @param context The uci context
  * @param ip_addr The IP address
  * @return int 0 on success, -1 on failure
@@ -172,7 +172,7 @@ int uwrt_delete_firewall_nat(struct uctx *context, char *ip_addr);
 
 /**
  * @brief Adds a firewall bridge rule for two IP addresses
- * 
+ *
  * @param context The uci context
  * @param sip The source IP address
  * @param sbr The source bridge interface name
@@ -184,7 +184,7 @@ int uwrt_add_firewall_bridge(struct uctx *context, char *sip, char *sbr, char *d
 
 /**
  * @brief Deletes a firewall bridge rule for two IP addresses
- * 
+ *
  * @param context The uci context
  * @param sip The source IP address
  * @param dip The destination IP address
@@ -194,7 +194,7 @@ int uwrt_delete_firewall_bridge(struct uctx *context, char *sip, char *dip);
 
 /**
  * @brief Removes all the firewall rules
- * 
+ *
  * @param context The uci context
  * @return int 0 on success, -1 on failure
  */


### PR DESCRIPTION
Most editors like VS Code automatically delete trailing whitespace when you save a file.

`git diff --ignore-space-at-eol` confirms that trailing EOL whitespace are the only ones that have been removed.

I've made this as a separate PR, since I've noticed in my other PRs, there's loads of these changes.

@mereacre, do you think it's worth setting up something like `clang-format` to format the C and C++ code? See https://clang.llvm.org/docs/ClangFormat.html

It's what a lot of big C/C++ code-bases do. It can automatically style/lint our code to use a specific style: https://clang.llvm.org/docs/ClangFormatStyleOptions.html#configurable-format-style-options

(see https://zed0.co.uk/clang-format-configurator/ for a quick and easy way to see what styles there are, my personal preferences are LLVM or Google style, but you're the C programmer here so you should pick the style you like)
