### PR TITLE
Sort `#include`'s in `clang-format`

### DIFF
--- a/.clang-format
+++ b/.clang-format
@@ -3,20 +3,27 @@ Language:      Cpp
 BasedOnStyle:  LLVM
 # indent case in switch statement
 IndentCaseLabels: true
-# ---- TODO: Make another PR where we do sort includes ---- #
-SortIncludes: false
 IncludeCategories:
   - Regex: '^<std'
     SortPriority: 1
+    Priority: 1
+  - Regex: '<setjmp.h>'
+    SortPriority: 1
   - Regex: '^<cmocka.h>'
-    # <cmocha.h> relies on <std...h> being included first
+    # <cmocha.h> relies on <std...h> and <setjmp.h> being included first
     SortPriority: 2
+    Priority: 1
   - Regex: '^<sys/socket.h>'
     # On FreeBSD, sys/socket.h must be included before `<netinet/in.h>`
     SortPriority: 1
+    Priority: 2
   - Regex: '^<netinet/in.h>'
     SortPriority: 2
+    Priority: 2
   - Regex: '^<netinet/'
     # On FreeBSD, you must include `<netinet/in.h>` before `<netinet/if_ether.h>`
     SortPriority: 3
+    Priority: 2
+  - Regex: '^<'
+    Priority: 3
 ...

--- a/lib/eloop/patches/0004-list-add-missing-include-on-stdddef.h.patch
+++ b/lib/eloop/patches/0004-list-add-missing-include-on-stdddef.h.patch
@@ -1,0 +1,26 @@
+From 203dddf79ec58094eff4b2e3c20f6b86999722fc Mon Sep 17 00:00:00 2001
+From: Alois Klink <alois@nquiringminds.com>
+Date: Fri, 11 Nov 2022 14:59:44 +0000
+Subject: [PATCH 4/4] list: add missing include on <stdddef.h>
+
+The `list.h` header uses `NULL`, which is defined in stddef.h
+---
+ src/utils/list.h | 2 ++
+ 1 file changed, 2 insertions(+)
+
+diff --git a/src/utils/list.h b/src/utils/list.h
+index aa62c0881..2237c5d8e 100644
+--- a/src/utils/list.h
++++ b/src/utils/list.h
+@@ -9,6 +9,8 @@
+ #ifndef LIST_H
+ #define LIST_H
+ 
++#include <stddef.h>
++
+ /**
+  * struct dl_list - Doubly-linked list
+  */
+-- 
+2.34.1
+

--- a/src/ap/ap_config.h
+++ b/src/ap/ap_config.h
@@ -14,13 +14,13 @@
 #ifndef CONFIG_GENERATOR_H
 #define CONFIG_GENERATOR_H
 
-#include <sys/types.h>
-#include <net/if.h>
 #include <stdbool.h>
+#include <net/if.h>
+#include <sys/types.h>
 
+#include "../radius/radius_server.h"
 #include "../utils/allocs.h"
 #include "../utils/os.h"
-#include "../radius/radius_server.h"
 
 #define AP_NAME_LEN 32 /* Maximum length of the AP name, i.e., ESSID name */
 #define AP_SECRET_LEN                                                          \

--- a/src/ap/ap_service.c
+++ b/src/ap/ap_service.c
@@ -11,21 +11,21 @@
  * defines auxiliary commands to manage the acces control list for stations
  * connected to the AP.
  */
-#include <unistd.h>
 #include <errno.h>
 #include <sys/ioctl.h>
+#include <unistd.h>
 
 #include "ap_config.h"
 #include "ap_service.h"
 #include "hostapd.h"
 
-#include "../supervisor/supervisor_config.h"
-#include "../radius/radius_server.h"
-#include "../utils/allocs.h"
-#include "../utils/os.h"
 #include <eloop.h>
+#include "../radius/radius_server.h"
+#include "../supervisor/supervisor_config.h"
+#include "../utils/allocs.h"
 #include "../utils/iface.h"
 #include "../utils/log.h"
+#include "../utils/os.h"
 #include "../utils/sockctl.h"
 
 #define AP_STA_DISCONNECTED "AP-STA-DISCONNECTED"

--- a/src/ap/ap_service.h
+++ b/src/ap/ap_service.h
@@ -15,15 +15,15 @@
 #ifndef HOSTAPD_SERVICE_H
 #define HOSTAPD_SERVICE_H
 
-#include <sys/types.h>
 #include <stdbool.h>
+#include <sys/types.h>
 
-#include "ap_config.h"
-#include "../supervisor/supervisor_config.h"
 #include "../radius/radius_server.h"
+#include "../supervisor/supervisor_config.h"
 #include "../utils/allocs.h"
-#include "../utils/os.h"
 #include "../utils/iface.h"
+#include "../utils/os.h"
+#include "ap_config.h"
 
 #define ATTACH_AP_COMMAND "ATTACH"
 

--- a/src/ap/hostapd.c
+++ b/src/ap/hostapd.c
@@ -12,22 +12,22 @@
  * manages (execute, kill and signal) the hostapd process.
  */
 
-#include <sys/stat.h>
-#include <sys/types.h>
-#include <sys/wait.h>
 #include <stdbool.h>
 #include <stdio.h>
 #include <errno.h>
-#include <signal.h>
-#include <unistd.h>
-#include <libgen.h>
 #include <fcntl.h>
+#include <libgen.h>
+#include <signal.h>
+#include <sys/stat.h>
+#include <sys/types.h>
+#include <sys/wait.h>
+#include <unistd.h>
 
 #include "ap_config.h"
-#include "utils/log.h"
 #include "utils/allocs.h"
-#include "utils/os.h"
 #include "utils/iface.h"
+#include "utils/log.h"
+#include "utils/os.h"
 
 #define WITH_HOSTAPD_UCI
 

--- a/src/ap/hostapd.h
+++ b/src/ap/hostapd.h
@@ -14,13 +14,13 @@
 #ifndef HOSTAPD_H
 #define HOSTAPD_H
 
-#include <sys/types.h>
 #include <stdbool.h>
+#include <sys/types.h>
 
-#include "ap_config.h"
+#include "../radius/radius_server.h"
 #include "../utils/allocs.h"
 #include "../utils/os.h"
-#include "../radius/radius_server.h"
+#include "ap_config.h"
 
 /**
  * @brief Generates and saves the hostapd configuration files

--- a/src/capture/capture_service.c
+++ b/src/capture/capture_service.c
@@ -11,27 +11,27 @@
  * @brief File containing the implementation of the capture service.
  */
 
+#include <stdarg.h>
+#include <stdbool.h>
 #include <stdio.h>
 #include <stdlib.h>
-#include <stdarg.h>
-#include <fcntl.h>
 #include <ctype.h>
-#include <unistd.h>
-#include <stdbool.h>
 #include <errno.h>
+#include <fcntl.h>
 #include <libgen.h>
 #include <pthread.h>
+#include <unistd.h>
 
 #include "capture_config.h"
 #include "capture_service.h"
 #include "pcap_service.h"
 
-#include "../utils/sockctl.h"
-#include "../utils/squeue.h"
-#include "../utils/log.h"
 #include <eloop.h>
 #include "../utils/allocs.h"
+#include "../utils/log.h"
 #include "../utils/os.h"
+#include "../utils/sockctl.h"
+#include "../utils/squeue.h"
 
 #include "middlewares_list.h"
 

--- a/src/capture/capture_service.h
+++ b/src/capture/capture_service.h
@@ -11,13 +11,13 @@
 #ifndef CAPTURE_SERVICE_H
 #define CAPTURE_SERVICE_H
 
-#include <sqlite3.h>
 #include <pcap.h>
+#include <sqlite3.h>
 
 #include <eloop.h>
 
-#include "pcap_service.h"
 #include "capture_config.h"
+#include "pcap_service.h"
 
 #define DB_BUSY_TIMEOUT 5000 // Sets the sqlite busy timeout in milliseconds
 

--- a/src/capture/middleware.h
+++ b/src/capture/middleware.h
@@ -12,11 +12,11 @@
 #ifndef MIDDLEWARE_H
 #define MIDDLEWARE_H
 
-#include <sqlite3.h>
 #include <stdint.h>
+#include <sqlite3.h>
 
-#include "./pcap_service.h"
 #include <eloop.h>
+#include "./pcap_service.h"
 
 // params is a pointer to an already allocated string
 struct middleware_context {

--- a/src/capture/middlewares/cleaner_middleware/cleaner_middleware.c
+++ b/src/capture/middlewares/cleaner_middleware/cleaner_middleware.c
@@ -16,13 +16,13 @@
 
 #include "./cleaner_middleware.h"
 
-#include <sqlite3.h>
 #include <libgen.h>
+#include <sqlite3.h>
 #include <utarray.h>
 
-#include "../pcap_middleware/sqlite_pcap.h"
-#include "../../capture_service.h"
 #include "../../capture_config.h"
+#include "../../capture_service.h"
+#include "../pcap_middleware/sqlite_pcap.h"
 
 #include "../../../utils/allocs.h"
 #include "../../../utils/os.h"

--- a/src/capture/middlewares/header_middleware/dns_decoder.c
+++ b/src/capture/middlewares/header_middleware/dns_decoder.c
@@ -14,8 +14,8 @@
 #include <utarray.h>
 
 #include "../../../utils/allocs.h"
-#include "../../../utils/os.h"
 #include "../../../utils/hash.h"
+#include "../../../utils/os.h"
 
 #include "packet_decoder.h"
 

--- a/src/capture/middlewares/header_middleware/header_middleware.c
+++ b/src/capture/middlewares/header_middleware/header_middleware.c
@@ -10,20 +10,20 @@
  */
 #include "header_middleware.h"
 
-#include <sqlite3.h>
-#include <pcap.h>
 #include <stdint.h>
 #include <stdio.h>
 #include <stdlib.h>
+#include <pcap.h>
+#include <sqlite3.h>
 #include <string.h>
 
-#include "sqlite_header.h"
+#include <eloop.h>
+#include "../../../utils/allocs.h"
+#include "../../../utils/log.h"
+#include "../../../utils/os.h"
 #include "packet_decoder.h"
 #include "packet_queue.h"
-#include "../../../utils/allocs.h"
-#include "../../../utils/os.h"
-#include "../../../utils/log.h"
-#include <eloop.h>
+#include "sqlite_header.h"
 
 #include "../../pcap_service.h"
 

--- a/src/capture/middlewares/header_middleware/mdns_decoder.c
+++ b/src/capture/middlewares/header_middleware/mdns_decoder.c
@@ -12,13 +12,13 @@
 #include <netinet/udp.h>
 
 #include "../../../utils/allocs.h"
-#include "../../../utils/os.h"
-#include "../../../utils/iface.h"
 #include "../../../utils/hash.h"
+#include "../../../utils/iface.h"
+#include "../../../utils/os.h"
 #include "../../../utils/squeue.h"
 
-#include "packet_decoder.h"
 #include "mdns_decoder.h"
+#include "packet_decoder.h"
 
 #define COMPRESSION_FLAG 0xC0
 #define COMPRESSION_FLAG_BIT7 0x80

--- a/src/capture/middlewares/header_middleware/packet_decoder.c
+++ b/src/capture/middlewares/header_middleware/packet_decoder.c
@@ -9,31 +9,31 @@
  */
 
 #define _GNU_SOURCE
-#include <unistd.h>
 #include <stdio.h>
 #include <stdlib.h>
 #include <string.h>
+#include <unistd.h>
 
 #include <sys/socket.h>
 #include <netinet/in.h>
-#include <netinet/ip.h>
-#include <netinet/if_ether.h>
-#include <netinet/ip6.h>
 #include <netinet/icmp6.h>
+#include <netinet/if_ether.h>
+#include <netinet/ip.h>
+#include <netinet/ip6.h>
 #include <netinet/ip_icmp.h>
 #include <netinet/tcp.h>
 #include <netinet/udp.h>
 #include <pcap.h>
 
-#include "../../../utils/log.h"
 #include "../../../utils/allocs.h"
-#include "../../../utils/os.h"
-#include "../../../utils/net.h"
 #include "../../../utils/hash.h"
+#include "../../../utils/log.h"
+#include "../../../utils/net.h"
+#include "../../../utils/os.h"
 
-#include "packet_decoder.h"
 #include "dns_decoder.h"
 #include "mdns_decoder.h"
+#include "packet_decoder.h"
 
 #define LINKTYPE_LINUX_SLL "LINUX_SLL"
 #define LINKTYPE_ETHERNET "EN10MB"

--- a/src/capture/middlewares/header_middleware/packet_decoder.h
+++ b/src/capture/middlewares/header_middleware/packet_decoder.h
@@ -16,8 +16,8 @@
 
 #include <utarray.h>
 #include "../../../utils/allocs.h"
-#include "../../../utils/os.h"
 #include "../../../utils/net.h"
+#include "../../../utils/os.h"
 
 #define MAX_QUESTION_LEN 255
 

--- a/src/capture/middlewares/header_middleware/packet_queue.c
+++ b/src/capture/middlewares/header_middleware/packet_queue.c
@@ -12,11 +12,11 @@
 #include <stdlib.h>
 #include <string.h>
 
-#include "packet_queue.h"
-#include "packet_decoder.h"
 #include "../../../utils/allocs.h"
-#include "../../../utils/os.h"
 #include "../../../utils/log.h"
+#include "../../../utils/os.h"
+#include "packet_decoder.h"
+#include "packet_queue.h"
 
 struct packet_queue *init_packet_queue(void) {
   struct packet_queue *queue;

--- a/src/capture/middlewares/header_middleware/packet_queue.h
+++ b/src/capture/middlewares/header_middleware/packet_queue.h
@@ -15,8 +15,8 @@
 #include <stdlib.h>
 #include <string.h>
 
-#include "packet_decoder.h"
 #include <list.h>
+#include "packet_decoder.h"
 
 /**
  * @brief Packet queueu structure definition

--- a/src/capture/middlewares/header_middleware/sqlite_header.c
+++ b/src/capture/middlewares/header_middleware/sqlite_header.c
@@ -9,19 +9,19 @@
  * utilities.
  */
 
+#include <stdint.h>
 #include <stdio.h>
 #include <stdlib.h>
-#include <string.h>
-#include <stdint.h>
 #include <sqlite3.h>
+#include <string.h>
 
 #include "../../../utils/allocs.h"
-#include "../../../utils/os.h"
 #include "../../../utils/log.h"
+#include "../../../utils/os.h"
 #include "../../../utils/sqliteu.h"
 
-#include "sqlite_header.h"
 #include "packet_decoder.h"
+#include "sqlite_header.h"
 
 #define EXTRACT_META_PACKET(term, tp)                                          \
   term.hash = tp->mp.hash;                                                     \

--- a/src/capture/middlewares/header_middleware/sqlite_header.h
+++ b/src/capture/middlewares/header_middleware/sqlite_header.h
@@ -11,8 +11,8 @@
 #ifndef SQLITE_HEADER_H
 #define SQLITE_HEADER_H
 
-#include <pcap.h>
 #include <stdint.h>
+#include <pcap.h>
 #include <sqlite3.h>
 
 #include "../../../utils/allocs.h"

--- a/src/capture/middlewares/pcap_middleware/pcap_middleware.c
+++ b/src/capture/middlewares/pcap_middleware/pcap_middleware.c
@@ -9,22 +9,22 @@
  * utilities.
  */
 
+#include <stdint.h>
 #include <stdio.h>
 #include <stdlib.h>
-#include <string.h>
-#include <stdint.h>
 #include <libgen.h>
 #include <sqlite3.h>
+#include <string.h>
 
 #include "pcap_middleware.h"
 #include "pcap_queue.h"
 #include "sqlite_pcap.h"
 
-#include "../../../utils/allocs.h"
-#include "../../../utils/os.h"
-#include "../../../utils/log.h"
-#include "../../../utils/squeue.h"
 #include <eloop.h>
+#include "../../../utils/allocs.h"
+#include "../../../utils/log.h"
+#include "../../../utils/os.h"
+#include "../../../utils/squeue.h"
 
 #include "../../pcap_service.h"
 

--- a/src/capture/middlewares/pcap_middleware/pcap_queue.c
+++ b/src/capture/middlewares/pcap_middleware/pcap_queue.c
@@ -10,13 +10,13 @@
 
 #include <stdio.h>
 #include <stdlib.h>
-#include <string.h>
 #include <pcap.h>
+#include <string.h>
 
-#include "pcap_queue.h"
 #include "../../../utils/allocs.h"
-#include "../../../utils/os.h"
 #include "../../../utils/log.h"
+#include "../../../utils/os.h"
+#include "pcap_queue.h"
 
 struct pcap_queue *init_pcap_queue(void) {
   struct pcap_queue *queue;

--- a/src/capture/middlewares/pcap_middleware/pcap_queue.h
+++ b/src/capture/middlewares/pcap_middleware/pcap_queue.h
@@ -11,11 +11,11 @@
 #ifndef PCAP_QUEUE_H
 #define PCAP_QUEUE_H
 
+#include <stdint.h>
 #include <stdio.h>
 #include <stdlib.h>
-#include <string.h>
 #include <pcap.h>
-#include <stdint.h>
+#include <string.h>
 
 #include <list.h>
 

--- a/src/capture/middlewares/pcap_middleware/sqlite_pcap.c
+++ b/src/capture/middlewares/pcap_middleware/sqlite_pcap.c
@@ -8,17 +8,17 @@
  * @brief File containing the implementation of the sqlite pcap utilities.
  */
 
+#include <stdint.h>
 #include <stdio.h>
 #include <stdlib.h>
-#include <string.h>
-#include <stdint.h>
 #include <sqlite3.h>
+#include <string.h>
 
 #include "sqlite_pcap.h"
 
 #include "../../../utils/allocs.h"
-#include "../../../utils/os.h"
 #include "../../../utils/log.h"
+#include "../../../utils/os.h"
 #include "../../../utils/sqliteu.h"
 
 int init_sqlite_pcap_db(sqlite3 *db) {

--- a/src/capture/middlewares/protobuf_middleware/protobuf_encoder.c
+++ b/src/capture/middlewares/protobuf_middleware/protobuf_encoder.c
@@ -8,29 +8,29 @@
  * @brief File containing the implementation of the protobuf encoder utilities.
  */
 
-#include <unistd.h>
 #include <stdio.h>
 #include <stdlib.h>
 #include <string.h>
+#include <unistd.h>
 
-#include "../../../utils/log.h"
 #include "../../../utils/allocs.h"
+#include "../../../utils/log.h"
 #include "../../../utils/os.h"
 
 #include "../header_middleware/packet_decoder.h"
 
-#include "eth.pb-c.h"
 #include "arp.pb-c.h"
-#include "ip4.pb-c.h"
-#include "ip6.pb-c.h"
-#include "tcp.pb-c.h"
-#include "udp.pb-c.h"
+#include "dhcp.pb-c.h"
+#include "dns.pb-c.h"
+#include "eth.pb-c.h"
 #include "icmp4.pb-c.h"
 #include "icmp6.pb-c.h"
-#include "dns.pb-c.h"
+#include "ip4.pb-c.h"
+#include "ip6.pb-c.h"
 #include "mdns.pb-c.h"
-#include "dhcp.pb-c.h"
 #include "sync.pb-c.h"
+#include "tcp.pb-c.h"
+#include "udp.pb-c.h"
 
 #include "protobuf_utils.h"
 

--- a/src/capture/middlewares/protobuf_middleware/protobuf_middleware.c
+++ b/src/capture/middlewares/protobuf_middleware/protobuf_middleware.c
@@ -9,20 +9,20 @@
  * utilities.
  */
 
+#include <stdint.h>
 #include <stdio.h>
 #include <stdlib.h>
-#include <string.h>
-#include <stdint.h>
+#include <eloop.h>
 #include <libgen.h>
 #include <sqlite3.h>
-#include <eloop.h>
+#include <string.h>
 
 #include "protobuf_encoder.h"
 #include "protobuf_middleware.h"
 
 #include "../../../utils/allocs.h"
-#include "../../../utils/os.h"
 #include "../../../utils/log.h"
+#include "../../../utils/os.h"
 #include "../../../utils/squeue.h"
 
 #include "../../pcap_service.h"

--- a/src/capture/middlewares/tap_middleware/tap_middleware.c
+++ b/src/capture/middlewares/tap_middleware/tap_middleware.c
@@ -13,19 +13,19 @@
 sudo ip tuntap add mode tap tap0
 */
 
+#include <stdint.h>
 #include <stdio.h>
 #include <stdlib.h>
-#include <string.h>
-#include <stdint.h>
+#include <eloop.h>
 #include <libgen.h>
 #include <sqlite3.h>
-#include <eloop.h>
+#include <string.h>
 
 #include "tap_middleware.h"
 
 #include "../../../utils/allocs.h"
-#include "../../../utils/os.h"
 #include "../../../utils/log.h"
+#include "../../../utils/os.h"
 #include "../../../utils/squeue.h"
 
 #include "../../pcap_service.h"

--- a/src/capture/middlewares_list.h
+++ b/src/capture/middlewares_list.h
@@ -13,11 +13,11 @@
 #ifndef MIDDLEWARES_LIST_H
 #define MIDDLEWARES_LIST_H
 
-#include <sqlite3.h>
+#include <eloop.h>
 #include <pcap.h>
+#include <sqlite3.h>
 #include <utarray.h>
 #include "middleware.h"
-#include <eloop.h>
 
 /**
  * @brief Generic middleware context and functions.

--- a/src/capture/pcap_service.c
+++ b/src/capture/pcap_service.c
@@ -11,10 +11,10 @@
 
 #include "pcap_service.h"
 
-#include "../utils/net.h"
 #include "../utils/allocs.h"
-#include "../utils/os.h"
 #include "../utils/log.h"
+#include "../utils/net.h"
+#include "../utils/os.h"
 
 #define PCAP_SNAPSHOT_LENGTH 65535
 #define PCAP_BUFFER_SIZE 64 * 1024

--- a/src/capture/pcap_service.h
+++ b/src/capture/pcap_service.h
@@ -11,11 +11,11 @@
 #ifndef PCAP_SERVICE_H
 #define PCAP_SERVICE_H
 
-#include <net/if.h>
-#include <sys/types.h>
 #include <stdbool.h>
 #include <stdint.h>
+#include <net/if.h>
 #include <pcap.h>
+#include <sys/types.h>
 #include <utarray.h>
 
 typedef void (*capture_callback_fn)(const void *ctx, const void *pcap_ctx,

--- a/src/config.c
+++ b/src/config.c
@@ -8,19 +8,19 @@
  * @brief File containing the implementation of the app configuration utilities.
  */
 
+#include <stdarg.h>
+#include <stdbool.h>
 #include <stdio.h>
 #include <stdlib.h>
-#include <stdarg.h>
-#include <fcntl.h>
 #include <ctype.h>
-#include <unistd.h>
-#include <stdbool.h>
 #include <errno.h>
+#include <fcntl.h>
 #include <minIni.h>
+#include <unistd.h>
 
+#include "config.h"
 #include "utils/allocs.h"
 #include "utils/os.h"
-#include "config.h"
 
 #include "supervisor/cmd_processor.h"
 

--- a/src/config.h
+++ b/src/config.h
@@ -11,15 +11,15 @@
 #define CONFIG_H
 
 #include <utarray.h>
-#include "utils/hashmap.h"
-#include "utils/allocs.h"
-#include "utils/os.h"
 #include "ap/ap_config.h"
-#include "radius/radius_server.h"
-#include "dns/dns_config.h"
-#include "dhcp/dhcp_config.h"
-#include "supervisor/supervisor_config.h"
 #include "capture/capture_config.h"
+#include "dhcp/dhcp_config.h"
+#include "dns/dns_config.h"
+#include "radius/radius_server.h"
+#include "supervisor/supervisor_config.h"
+#include "utils/allocs.h"
+#include "utils/hashmap.h"
+#include "utils/os.h"
 
 #define MAX_USER_SECRET 255
 #define MAX_SALT_STRING_SIZE 255

--- a/src/crypt/crypt_service.c
+++ b/src/crypt/crypt_service.c
@@ -9,16 +9,16 @@
  * utilities.
  */
 
-#include "sqlite_crypt_writer.h"
-#include "crypt_config.h"
 #include "crypt_service.h"
+#include "crypt_config.h"
 #include "generic_hsm_driver.h"
+#include "sqlite_crypt_writer.h"
 
-#include "../utils/log.h"
 #include "../utils/allocs.h"
-#include "../utils/os.h"
-#include "../utils/cryptou.h"
 #include "../utils/base64.h"
+#include "../utils/cryptou.h"
+#include "../utils/log.h"
+#include "../utils/os.h"
 
 void free_crypt_service(struct crypt_context *ctx) {
   if (ctx != NULL) {

--- a/src/crypt/generic_hsm_driver.c
+++ b/src/crypt/generic_hsm_driver.c
@@ -16,8 +16,8 @@
 
 #include "generic_hsm_driver.h"
 
-#include "../utils/log.h"
 #include "../utils/allocs.h"
+#include "../utils/log.h"
 #include "../utils/os.h"
 
 struct hsm_context *init_hsm(void) {

--- a/src/crypt/generic_hsm_driver.h
+++ b/src/crypt/generic_hsm_driver.h
@@ -11,10 +11,10 @@
 #ifndef GENERIC_HSM_DRIVER_H
 #define GENERIC_HSM_DRIVER_H
 
-#include <sys/un.h>
-#include <sys/types.h>
 #include <stdbool.h>
 #include <inttypes.h>
+#include <sys/types.h>
+#include <sys/un.h>
 
 struct hsm_context {
   void *hsm_ctx;

--- a/src/crypt/sqlite_crypt_writer.c
+++ b/src/crypt/sqlite_crypt_writer.c
@@ -15,8 +15,8 @@
 #include "sqlite_crypt_writer.h"
 
 #include "../utils/allocs.h"
-#include "../utils/os.h"
 #include "../utils/log.h"
+#include "../utils/os.h"
 #include "../utils/sqliteu.h"
 
 int open_sqlite_crypt_db(const char *db_path, sqlite3 **sql) {

--- a/src/crypt/zymkey4_driver.c
+++ b/src/crypt/zymkey4_driver.c
@@ -12,8 +12,8 @@
 #include <sys/types.h>
 #include <zymkey/zk_app_utils.h>
 
-#include "../utils/log.h"
 #include "../utils/allocs.h"
+#include "../utils/log.h"
 #include "../utils/os.h"
 
 zkCTX *init_zymkey4(void) {

--- a/src/dhcp/dhcp_config.h
+++ b/src/dhcp/dhcp_config.h
@@ -14,8 +14,8 @@
 #include <utarray.h>
 
 #include "../utils/allocs.h"
-#include "../utils/os.h"
 #include "../utils/net.h"
+#include "../utils/os.h"
 
 #define DHCP_LEASE_TIME_SIZE 10
 

--- a/src/dhcp/dhcp_service.c
+++ b/src/dhcp/dhcp_service.c
@@ -8,11 +8,11 @@
  * @brief File containing the implementation of dhcp service configuration
  * utilities.
  */
-#include "dnsmasq.h"
 #include "dhcp_config.h"
+#include "dnsmasq.h"
 
-#include "../utils/log.h"
 #include "../utils/allocs.h"
+#include "../utils/log.h"
 #include "../utils/os.h"
 #include "dhcp_service.h"
 

--- a/src/dhcp/dnsmasq.c
+++ b/src/dhcp/dnsmasq.c
@@ -9,21 +9,21 @@
  * utilities.
  */
 
+#include <stdbool.h>
 #include <stdio.h>
+#include <errno.h>
+#include <fcntl.h>
+#include <libgen.h>
+#include <signal.h>
 #include <sys/stat.h>
 #include <sys/types.h>
 #include <sys/wait.h>
-#include <stdbool.h>
-#include <errno.h>
-#include <signal.h>
 #include <unistd.h>
-#include <libgen.h>
-#include <fcntl.h>
 
 #include "dhcp_config.h"
 
-#include "../utils/log.h"
 #include "../utils/allocs.h"
+#include "../utils/log.h"
 #include "../utils/os.h"
 #include "../utils/squeue.h"
 

--- a/src/dns/command_mapper.c
+++ b/src/dns/command_mapper.c
@@ -8,11 +8,11 @@
  * @brief File containing the implementation of the command mapper.
  */
 
-#include <inttypes.h>
 #include <stdbool.h>
+#include <inttypes.h>
 
-#include "command_mapper.h"
 #include "../utils/hash.h"
+#include "command_mapper.h"
 
 void free_command_mapper(hmap_command_conn **hmap) {
   hmap_command_conn *current, *tmp;

--- a/src/dns/command_mapper.h
+++ b/src/dns/command_mapper.h
@@ -11,14 +11,14 @@
 #ifndef COMMAND_MAPPER_H
 #define COMMAND_MAPPER_H
 
-#include <inttypes.h>
 #include <stdbool.h>
+#include <inttypes.h>
 #include <utarray.h>
 #include <uthash.h>
 
 #include "../utils/allocs.h"
-#include "../utils/os.h"
 #include "../utils/hashmap.h"
+#include "../utils/os.h"
 
 /**
  * @brief Command mapper connection structure

--- a/src/dns/mcast.c
+++ b/src/dns/mcast.c
@@ -8,21 +8,21 @@
  * @brief File containing the implementation of mDNS utils.
  */
 
-#include <stdlib.h>
 #include <stdio.h>
-#include <string.h>
-#include <errno.h>
-#include <unistd.h>
-#include <sys/types.h>
-#include <sys/ioctl.h>
-#include <netinet/in.h>
-#include <net/if.h>
-#include <syslog.h>
-#include <fcntl.h>
+#include <stdlib.h>
 #include <sys/socket.h>
+#include <netinet/in.h>
 #include <arpa/inet.h>
-#include <signal.h>
+#include <errno.h>
+#include <fcntl.h>
 #include <inttypes.h>
+#include <net/if.h>
+#include <signal.h>
+#include <string.h>
+#include <sys/ioctl.h>
+#include <sys/types.h>
+#include <syslog.h>
+#include <unistd.h>
 
 #include "../utils/log.h"
 #include "../utils/sockctl.h"

--- a/src/dns/mdns_list.h
+++ b/src/dns/mdns_list.h
@@ -13,8 +13,8 @@
 
 #include <stdio.h>
 #include <stdlib.h>
-#include <string.h>
 #include <inttypes.h>
+#include <string.h>
 
 #include <list.h>
 

--- a/src/dns/mdns_mapper.c
+++ b/src/dns/mdns_mapper.c
@@ -8,8 +8,8 @@
  * @brief File containing the implementation of the mdns mapper utils.
  */
 
-#include "mdns_list.h"
 #include "mdns_mapper.h"
+#include "mdns_list.h"
 
 #include "../utils/os.h"
 

--- a/src/dns/mdns_mapper.h
+++ b/src/dns/mdns_mapper.h
@@ -16,8 +16,8 @@
 
 #include "mdns_list.h"
 
-#include "../utils/os.h"
 #include "../capture/middlewares/header_middleware/mdns_decoder.h"
+#include "../utils/os.h"
 
 /**
  * @brief MDNS connection structure

--- a/src/dns/mdns_service.c
+++ b/src/dns/mdns_service.c
@@ -10,36 +10,36 @@
 
 #include <stdint.h>
 #include <stdio.h>
-#include <string.h>
-#include <syslog.h>
-#include <errno.h>
-#include <unistd.h>
-#include <fcntl.h>
 #include <sys/socket.h>
-#include <sys/ioctl.h>
 #include <netinet/in.h>
 #include <arpa/inet.h>
-#include <signal.h>
+#include <errno.h>
+#include <fcntl.h>
 #include <inttypes.h>
 #include <pthread.h>
+#include <signal.h>
+#include <string.h>
+#include <sys/ioctl.h>
+#include <syslog.h>
+#include <unistd.h>
 
-#include <uthash.h>
-#include "../utils/ifaceu.h"
-#include "../utils/net.h"
-#include "../utils/log.h"
 #include <eloop.h>
-#include "../utils/sockctl.h"
-#include "../utils/squeue.h"
+#include <uthash.h>
+#include "../capture/middlewares/header_middleware/mdns_decoder.h"
+#include "../capture/middlewares/header_middleware/packet_queue.h"
+#include "../capture/pcap_service.h"
+#include "../supervisor/cmd_processor.h"
+#include "../supervisor/supervisor_config.h"
 #include "../utils/hashmap.h"
 #include "../utils/iface_mapper.h"
-#include "../capture/middlewares/header_middleware/mdns_decoder.h"
-#include "../capture/pcap_service.h"
-#include "../capture/middlewares/header_middleware/packet_queue.h"
-#include "../supervisor/supervisor_config.h"
-#include "../supervisor/cmd_processor.h"
+#include "../utils/ifaceu.h"
+#include "../utils/log.h"
+#include "../utils/net.h"
+#include "../utils/sockctl.h"
+#include "../utils/squeue.h"
 
-#include "mdns_service.h"
 #include "mcast.h"
+#include "mdns_service.h"
 
 #define MDNS_PORT 5353
 #define MDNS_ADDR4 (uint32_t)0xE00000FB /* 224.0.0.251 */

--- a/src/dns/mdns_service.h
+++ b/src/dns/mdns_service.h
@@ -11,11 +11,11 @@
 #ifndef MDNS_SERVICE_H
 #define MDNS_SERVICE_H
 
-#include "dns_config.h"
-#include "reflection_list.h"
-#include "mdns_mapper.h"
-#include "command_mapper.h"
 #include "../utils/iface_mapper.h"
+#include "command_mapper.h"
+#include "dns_config.h"
+#include "mdns_mapper.h"
+#include "reflection_list.h"
 
 /**
  * @brief The mDNS context.

--- a/src/dns/reflection_list.c
+++ b/src/dns/reflection_list.c
@@ -8,10 +8,10 @@
  * @brief File containing the implementation of reflection list structures.
  */
 
-#include <stdlib.h>
 #include <stdio.h>
-#include <syslog.h>
+#include <stdlib.h>
 #include <string.h>
+#include <syslog.h>
 
 #include "../utils/allocs.h"
 #include "../utils/log.h"

--- a/src/dns/reflection_list.h
+++ b/src/dns/reflection_list.h
@@ -12,9 +12,9 @@
 #define REFLECTION_LIST_H
 
 #include <stdbool.h>
-#include <sys/types.h>
 #include <sys/socket.h>
 #include <net/if.h>
+#include <sys/types.h>
 
 #include <list.h>
 

--- a/src/edgesec.c
+++ b/src/edgesec.c
@@ -8,29 +8,29 @@
  * @brief File containing the edgesec tool implementations.
  */
 
+#include <stdarg.h>
+#include <stdbool.h>
 #include <stdio.h>
 #include <stdlib.h>
-#include <stdarg.h>
-#include <signal.h>
-#include <fcntl.h>
-#include <ctype.h>
-#include <unistd.h>
-#include <stdbool.h>
-#include <errno.h>
-#include <sys/types.h>
 #include <sys/socket.h>
+#include <ctype.h>
+#include <errno.h>
+#include <fcntl.h>
 #include <libgen.h>
 #include <pthread.h>
+#include <signal.h>
+#include <sys/types.h>
+#include <unistd.h>
 
-#include "version.h"
-#include "utils/log.h"
-#include "utils/allocs.h"
-#include "utils/os.h"
-#include "utils/iface.h"
 #include <eloop.h>
+#include "config.h"
 #include "dhcp/dhcp_config.h"
 #include "runctl.h"
-#include "config.h"
+#include "utils/allocs.h"
+#include "utils/iface.h"
+#include "utils/log.h"
+#include "utils/os.h"
+#include "version.h"
 
 #define OPT_STRING ":c:f:mdvh"
 #define USAGE_STRING "\t%s [-c filename] [-f filename] [-m] [-d] [-h] [-v]\n"

--- a/src/firewall/firewall_config.h
+++ b/src/firewall/firewall_config.h
@@ -11,13 +11,13 @@
 #ifndef FIREWALL_CONFIG_H
 #define FIREWALL_CONFIG_H
 
-#include <inttypes.h>
 #include <stdbool.h>
+#include <inttypes.h>
 
 #include <utarray.h>
-#include "../utils/os.h"
 #include "../utils/hashmap.h"
 #include "../utils/iface_mapper.h"
+#include "../utils/os.h"
 
 #ifdef WITH_UCI_SERVICE
 #include "../utils/uci_wrt.h"

--- a/src/firewall/firewall_service.c
+++ b/src/firewall/firewall_service.c
@@ -8,22 +8,20 @@
  * @brief File containing the implementation of the firewall service commands.
  */
 
-#include <inttypes.h>
 #include <stdbool.h>
 #include <errno.h>
+#include <fcntl.h>
+#include <inttypes.h>
+#include <libgen.h>
+#include <signal.h>
 #include <sys/stat.h>
 #include <sys/types.h>
 #include <sys/wait.h>
-#include <stdbool.h>
-#include <errno.h>
-#include <signal.h>
 #include <unistd.h>
-#include <libgen.h>
-#include <fcntl.h>
 
+#include "../utils/allocs.h"
 #include "../utils/hashmap.h"
 #include "../utils/log.h"
-#include "../utils/allocs.h"
 #include "../utils/os.h"
 
 #ifdef WITH_UCI_SERVICE

--- a/src/firewall/firewall_service.h
+++ b/src/firewall/firewall_service.h
@@ -11,8 +11,8 @@
 #ifndef FIREWALL_SERVICE_H
 #define FIREWALL_SERVICE_H
 
-#include <inttypes.h>
 #include <stdbool.h>
+#include <inttypes.h>
 #include <utarray.h>
 
 #include "../supervisor/supervisor_config.h"

--- a/src/radius/radius.c
+++ b/src/radius/radius.c
@@ -13,18 +13,18 @@
  */
 
 #include <stddef.h>
-#include <sys/un.h>
 #include <sys/socket.h>
 #include <netinet/in.h>
 #include <arpa/inet.h>
+#include <sys/un.h>
 
-#include "wpabuf.h"
-#include "radius.h"
 #include "md5.h"
 #include "md5_internal.h"
+#include "radius.h"
+#include "wpabuf.h"
 
-#include "utils/log.h"
 #include "utils/allocs.h"
+#include "utils/log.h"
 #include "utils/os.h"
 
 /**

--- a/src/radius/radius.h
+++ b/src/radius/radius.h
@@ -16,9 +16,9 @@
 #define RADIUS_H
 
 #include <stdint.h>
+#include <arpa/inet.h>
 #include <sys/types.h>
 #include <unistd.h>
-#include <arpa/inet.h>
 
 #include "utils/allocs.h"
 #include "utils/os.h"

--- a/src/radius/radius_config.h
+++ b/src/radius/radius_config.h
@@ -11,8 +11,8 @@
 #ifndef RADIUS_CONFIG_H
 #define RADIUS_CONFIG_H
 
-#include "../utils/os.h"
 #include "../utils/net.h"
+#include "../utils/os.h"
 
 #define RADIUS_SECRET_LEN 255
 

--- a/src/radius/radius_server.c
+++ b/src/radius/radius_server.c
@@ -12,18 +12,17 @@
  * @brief RADIUS authentication server.
  */
 
+#include <stdbool.h>
 #include <stdint.h>
+#include <sys/socket.h>
+#include <arpa/inet.h>
 #include <sys/types.h>
 #include <unistd.h>
-#include <arpa/inet.h>
-#include <stdbool.h>
-#include <sys/types.h>
-#include <sys/socket.h>
 
-#include "../utils/log.h"
-#include "../utils/allocs.h"
-#include "../utils/net.h"
 #include "../supervisor/mac_mapper.h"
+#include "../utils/allocs.h"
+#include "../utils/log.h"
+#include "../utils/net.h"
 
 #include "radius.h"
 #include "radius_server.h"

--- a/src/radius/radius_server.h
+++ b/src/radius/radius_server.h
@@ -20,13 +20,13 @@
 #include <unistd.h>
 // On FreeBSD, you must include `<sys/socket.h>` and `<netinet/in.h>` before
 // `<netinet/if_ether.h>`
+#include <stdbool.h>
 #include <sys/socket.h>
 #include <netinet/in.h>
 #include <netinet/if_ether.h>
-#include <stdbool.h>
 
-#include "../utils/os.h"
 #include <eloop.h>
+#include "../utils/os.h"
 #include "radius_config.h"
 
 /**

--- a/src/radius/radius_service.c
+++ b/src/radius/radius_service.c
@@ -8,15 +8,15 @@
  * @brief File containing the implementation of the radius service.
  */
 
+#include <stdbool.h>
+#include <errno.h>
+#include <fcntl.h>
+#include <libgen.h>
+#include <signal.h>
 #include <sys/stat.h>
 #include <sys/types.h>
 #include <sys/wait.h>
-#include <stdbool.h>
-#include <errno.h>
-#include <signal.h>
 #include <unistd.h>
-#include <libgen.h>
-#include <fcntl.h>
 
 #include <eloop.h>
 #include "radius_server.h"

--- a/src/radius/radius_service.h
+++ b/src/radius/radius_service.h
@@ -11,8 +11,8 @@
 #ifndef RADIUS_SERVICE_H
 #define RADIUS_SERVICE_H
 
-#include "../supervisor/supervisor.h"
 #include <eloop.h>
+#include "../supervisor/supervisor.h"
 
 #include "radius_server.h"
 

--- a/src/radius/wpabuf.c
+++ b/src/radius/wpabuf.c
@@ -12,15 +12,15 @@
  * @brief Dynamic data buffer.
  */
 
-#include <stdio.h>
 #include <stddef.h>
 #include <stdint.h>
+#include <stdio.h>
 #include <stdlib.h>
 #include <assert.h>
-#include <signal.h>
-#include <sys/select.h>
 #include <errno.h>
+#include <signal.h>
 #include <string.h>
+#include <sys/select.h>
 
 /* According to earlier standards */
 #include <sys/time.h>
@@ -29,8 +29,8 @@
 
 #include "wpabuf.h"
 
-#include "utils/log.h"
 #include "utils/allocs.h"
+#include "utils/log.h"
 #include "utils/os.h"
 
 static void wpabuf_overflow(const struct wpabuf *buf, size_t len) {

--- a/src/radius/wpabuf.h
+++ b/src/radius/wpabuf.h
@@ -12,11 +12,11 @@
 #ifndef WPABUF_H
 #define WPABUF_H
 
-#include <endian.h>
 #include <byteswap.h>
+#include <endian.h>
 
-#include "utils/log.h"
 #include "utils/allocs.h"
+#include "utils/log.h"
 #include "utils/os.h"
 
 #ifndef WPA_BYTE_SWAP_DEFINED

--- a/src/recap.c
+++ b/src/recap.c
@@ -8,31 +8,31 @@
  * @brief A tool to run the capture with an input pcap file
  */
 
-#include <sqlite3.h>
+#include <stdarg.h>
+#include <stdbool.h>
 #include <stdio.h>
 #include <stdlib.h>
-#include <stdarg.h>
-#include <signal.h>
-#include <fcntl.h>
 #include <ctype.h>
-#include <unistd.h>
-#include <stdbool.h>
 #include <errno.h>
-#include <sys/types.h>
-#include <libgen.h>
+#include <fcntl.h>
 #include <inttypes.h>
+#include <libgen.h>
 #include <pcap.h>
+#include <signal.h>
+#include <sqlite3.h>
+#include <sys/types.h>
+#include <unistd.h>
 
 #include <eloop.h>
 
-#include "version.h"
-#include "utils/os.h"
-#include "capture/middlewares/header_middleware/sqlite_header.h"
+#include "capture/capture_service.h"
 #include "capture/middlewares/header_middleware/packet_decoder.h"
 #include "capture/middlewares/header_middleware/packet_queue.h"
+#include "capture/middlewares/header_middleware/sqlite_header.h"
 #include "capture/middlewares/protobuf_middleware/protobuf_middleware.h"
-#include "capture/capture_service.h"
+#include "utils/os.h"
 #include "utils/sqliteu.h"
+#include "version.h"
 
 #define PCAP_MAGIC_VALUE 0xa1b2c3d4
 #define QUEUE_PROCESS_INTERVAL 100 * 1000 // In microseconds

--- a/src/runctl.c
+++ b/src/runctl.c
@@ -8,32 +8,32 @@
  * @brief File containing the definition of the service runners.
  */
 
+#include <stdarg.h>
+#include <stdbool.h>
 #include <stdio.h>
 #include <stdlib.h>
-#include <stdarg.h>
-#include <fcntl.h>
 #include <ctype.h>
-#include <unistd.h>
-#include <stdbool.h>
+#include <fcntl.h>
 #include <libgen.h>
-#include <utarray.h>
 #include <pthread.h>
+#include <unistd.h>
+#include <utarray.h>
 
-#include "utils/log.h"
-#include "utils/hashmap.h"
-#include "utils/allocs.h"
-#include "utils/os.h"
-#include "utils/net.h"
 #include <eloop.h>
+#include "utils/allocs.h"
+#include "utils/hashmap.h"
+#include "utils/iface.h"
 #include "utils/iface_mapper.h"
 #include "utils/ifaceu.h"
-#include "utils/iface.h"
+#include "utils/log.h"
+#include "utils/net.h"
+#include "utils/os.h"
 
 #include "capture/capture_service.h"
 
-#include "supervisor/supervisor.h"
 #include "supervisor/network_commands.h"
 #include "supervisor/sqlite_macconn_writer.h"
+#include "supervisor/supervisor.h"
 #ifdef WITH_RADIUS_SERVICE
 #include "radius/radius_service.h"
 #endif
@@ -47,8 +47,8 @@
 
 #include "firewall/firewall_service.h"
 
-#include "runctl.h"
 #include "config.h"
+#include "runctl.h"
 
 static const UT_icd mac_conn_icd = {sizeof(struct mac_conn), NULL, NULL, NULL};
 static const UT_icd config_ifinfo_icd = {sizeof(config_ifinfo_t), NULL, NULL,

--- a/src/runctl.h
+++ b/src/runctl.h
@@ -10,8 +10,8 @@
 #ifndef ENGINE_H
 #define ENGINE_H
 
-#include <inttypes.h>
 #include <stdbool.h>
+#include <inttypes.h>
 
 #include "config.h"
 #include "supervisor/supervisor_config.h"

--- a/src/sqlhook.c
+++ b/src/sqlhook.c
@@ -1,12 +1,12 @@
 // Set the environment variable ENV_DB_KEY=dbpath:dbprefix
 // Use SELECT load_extension("./src/libsqlhook.so"); to load the extension
-#include <libgen.h>
 #include <stdio.h>
 #include <stdlib.h>
-#include <errno.h>
 #include <sys/socket.h>
-#include <arpa/inet.h>
 #include <netinet/in.h>
+#include <arpa/inet.h>
+#include <errno.h>
+#include <libgen.h>
 #include <sqlite3ext.h> /* Do not use <sqlite3.h>! */
 #include <utarray.h>
 

--- a/src/supervisor/bridge_list.c
+++ b/src/supervisor/bridge_list.c
@@ -9,8 +9,8 @@
  */
 
 #include "utils/allocs.h"
-#include "utils/os.h"
 #include "utils/log.h"
+#include "utils/os.h"
 
 #include "bridge_list.h"
 

--- a/src/supervisor/cmd_processor.c
+++ b/src/supervisor/cmd_processor.c
@@ -8,14 +8,14 @@
  * @brief File containing the implementation of the command processor functions.
  */
 
-#include <sys/un.h>
-#include <sys/types.h>
 #include <stdbool.h>
 #include <stdint.h>
-#include <stdlib.h>
 #include <stdio.h>
+#include <stdlib.h>
 #include <errno.h>
 #include <inttypes.h>
+#include <sys/types.h>
+#include <sys/un.h>
 
 #include "cmd_processor.h"
 #include "mac_mapper.h"
@@ -26,10 +26,10 @@
 #include "system_commands.h"
 
 #include "utils/allocs.h"
-#include "utils/os.h"
+#include "utils/base64.h"
 #include "utils/log.h"
 #include "utils/net.h"
-#include "utils/base64.h"
+#include "utils/os.h"
 #include "utils/sockctl.h"
 
 bool process_domain_buffer(char *domain_buffer, size_t domain_buffer_len,

--- a/src/supervisor/cmd_processor.h
+++ b/src/supervisor/cmd_processor.h
@@ -11,9 +11,9 @@
 #ifndef CMD_PROCESSOR_H
 #define CMD_PROCESSOR_H
 
-#include <sys/un.h>
-#include <sys/types.h>
 #include <stdbool.h>
+#include <sys/types.h>
+#include <sys/un.h>
 
 #include <utarray.h>
 #include "../utils/sockctl.h"

--- a/src/supervisor/crypt_commands.c
+++ b/src/supervisor/crypt_commands.c
@@ -11,19 +11,19 @@
 #include <libgen.h>
 
 #include "mac_mapper.h"
-#include "supervisor.h"
-#include "sqlite_macconn_writer.h"
 #include "network_commands.h"
+#include "sqlite_macconn_writer.h"
+#include "supervisor.h"
 
+#include <eloop.h>
 #include "../ap/ap_config.h"
 #include "../ap/ap_service.h"
-#include "../crypt/crypt_service.h"
 #include "../capture/capture_service.h"
+#include "../crypt/crypt_service.h"
 #include "../utils/allocs.h"
-#include "../utils/os.h"
-#include "../utils/log.h"
 #include "../utils/base64.h"
-#include <eloop.h>
+#include "../utils/log.h"
+#include "../utils/os.h"
 
 int put_crypt_cmd(struct supervisor_context *context, char *key, char *value) {
   struct crypt_pair pair = {key, NULL, 0};

--- a/src/supervisor/crypt_commands.h
+++ b/src/supervisor/crypt_commands.h
@@ -11,8 +11,8 @@
 #ifndef CRYPT_COMMANDS_H
 #define CRYPT_COMMANDS_H
 
-#include <inttypes.h>
 #include <stdbool.h>
+#include <inttypes.h>
 
 /**
  * @brief PUT_CRYPT command

--- a/src/supervisor/mac_mapper.c
+++ b/src/supervisor/mac_mapper.c
@@ -10,12 +10,12 @@
 #include <stdbool.h>
 
 #include "utils/allocs.h"
+#include "utils/log.h"
 #include "utils/net.h"
 #include "utils/os.h"
-#include "utils/log.h"
 
-#include "mac_mapper.h"
 #include "bridge_list.h"
+#include "mac_mapper.h"
 
 int get_mac_mapper(hmap_mac_conn **hmap, uint8_t mac_addr[ETHER_ADDR_LEN],
                    struct mac_conn_info *info) {

--- a/src/supervisor/mac_mapper.h
+++ b/src/supervisor/mac_mapper.h
@@ -11,8 +11,8 @@
 #ifndef MAC_MAPPER_H
 #define MAC_MAPPER_H
 
-#include <inttypes.h>
 #include <stdbool.h>
+#include <inttypes.h>
 #include <utarray.h>
 #include <uthash.h>
 
@@ -21,8 +21,8 @@
 #include "../ap/ap_config.h"
 
 #include "../utils/allocs.h"
-#include "../utils/os.h"
 #include "../utils/hashmap.h"
+#include "../utils/os.h"
 
 #define MAX_DEVICE_LABEL_SIZE 255
 

--- a/src/supervisor/network_commands.c
+++ b/src/supervisor/network_commands.c
@@ -10,25 +10,25 @@
 #include <libgen.h>
 
 #include "mac_mapper.h"
+#include "network_commands.h"
+#include "sqlite_macconn_writer.h"
 #include "supervisor.h"
 #include "supervisor_utils.h"
-#include "sqlite_macconn_writer.h"
-#include "network_commands.h"
 
 #include "../ap/ap_config.h"
 #include "../ap/ap_service.h"
 #ifdef WITH_CRYPTO_SERVICE
 #include "../crypt/crypt_service.h"
 #endif
+#include <eloop.h>
 #include "../capture/capture_service.h"
 #include "../dhcp/dhcp_service.h"
+#include "../firewall/firewall_service.h"
 #include "../utils/allocs.h"
-#include "../utils/os.h"
+#include "../utils/base64.h"
 #include "../utils/log.h"
 #include "../utils/net.h"
-#include "../utils/base64.h"
-#include <eloop.h>
-#include "../firewall/firewall_service.h"
+#include "../utils/os.h"
 
 #define ANALYSER_FILTER_FORMAT                                                 \
   "\"ether dst " MACSTR " or ether src " MACSTR "\""

--- a/src/supervisor/network_commands.h
+++ b/src/supervisor/network_commands.h
@@ -11,14 +11,14 @@
 #ifndef NETWORK_COMMANDS_H
 #define NETWORK_COMMANDS_H
 
-#include <inttypes.h>
 #include <stdbool.h>
+#include <inttypes.h>
 
 #define TICKET_PASSPHRASE_SIZE 16
 #define TICKET_TIMEOUT 60 // In seconds
 
-#include "supervisor_config.h"
 #include "../ap/ap_config.h"
+#include "supervisor_config.h"
 
 /**
  * @brief Frees an allocated ticket

--- a/src/supervisor/sqlite_macconn_writer.c
+++ b/src/supervisor/sqlite_macconn_writer.c
@@ -9,18 +9,18 @@
  * utilities.
  */
 
+#include <stdint.h>
 #include <stdio.h>
 #include <stdlib.h>
-#include <string.h>
-#include <stdint.h>
 #include <sqlite3.h>
+#include <string.h>
 
 #include "sqlite_macconn_writer.h"
 
 #include "../utils/allocs.h"
-#include "../utils/os.h"
-#include "../utils/net.h"
 #include "../utils/log.h"
+#include "../utils/net.h"
+#include "../utils/os.h"
 #include "../utils/sqliteu.h"
 
 void free_sqlite_macconn_db(sqlite3 *db) {

--- a/src/supervisor/subscriber_events.c
+++ b/src/supervisor/subscriber_events.c
@@ -8,16 +8,16 @@
  * @brief File containing the implementation of the subscriber events structure.
  */
 
-#include <sys/un.h>
-#include <inttypes.h>
 #include <stdbool.h>
+#include <inttypes.h>
+#include <sys/un.h>
 #include <utarray.h>
 
-#include "supervisor_config.h"
 #include "subscriber_events.h"
+#include "supervisor_config.h"
 
-#include "../utils/sockctl.h"
 #include "../utils/log.h"
+#include "../utils/sockctl.h"
 
 #define MAX_SEND_EVENTS_BUF_SIZE 4096
 

--- a/src/supervisor/subscriber_events.h
+++ b/src/supervisor/subscriber_events.h
@@ -11,9 +11,9 @@
 #ifndef SUBSCRIBER_EVENTS_H
 #define SUBSCRIBER_EVENTS_H
 
-#include <sys/un.h>
-#include <inttypes.h>
 #include <stdbool.h>
+#include <inttypes.h>
+#include <sys/un.h>
 
 #include "supervisor_config.h"
 

--- a/src/supervisor/supervisor.c
+++ b/src/supervisor/supervisor.c
@@ -9,20 +9,20 @@
  */
 
 #include <stdbool.h>
-#include <unistd.h>
-#include <sys/un.h>
 #include <sys/socket.h>
-#include <sys/ioctl.h>
 #include <libgen.h>
+#include <sys/ioctl.h>
+#include <sys/un.h>
 #include <time.h>
+#include <unistd.h>
 #include <utarray.h>
 
 #include "subscriber_events.h"
 
-#include "../utils/log.h"
-#include "../utils/allocs.h"
-#include "../utils/os.h"
 #include <eloop.h>
+#include "../utils/allocs.h"
+#include "../utils/log.h"
+#include "../utils/os.h"
 #include "../utils/sockctl.h"
 
 #include "../capture/capture_service.h"

--- a/src/supervisor/supervisor_config.h
+++ b/src/supervisor/supervisor_config.h
@@ -14,15 +14,15 @@
 #include <stdbool.h>
 #include <sqlite3.h>
 
-#include "../ap/ap_config.h"
-#include "../dhcp/dhcp_config.h"
-#include "../dns/dns_config.h"
-#include "../utils/iface_mapper.h"
-#include "../utils/iface.h"
 #include <eloop.h>
+#include "../ap/ap_config.h"
 #include "../capture/capture_config.h"
 #include "../crypt/crypt_config.h"
+#include "../dhcp/dhcp_config.h"
+#include "../dns/dns_config.h"
 #include "../firewall/firewall_service.h"
+#include "../utils/iface.h"
+#include "../utils/iface_mapper.h"
 
 #include "mac_mapper.h"
 

--- a/src/supervisor/supervisor_utils.c
+++ b/src/supervisor/supervisor_utils.c
@@ -14,8 +14,8 @@
 #include "../crypt/crypt_service.h"
 #endif
 
-#include "../utils/os.h"
 #include "../utils/hash.h"
+#include "../utils/os.h"
 
 #include "sqlite_macconn_writer.h"
 #include "supervisor_config.h"

--- a/src/supervisor/system_commands.c
+++ b/src/supervisor/system_commands.c
@@ -7,28 +7,28 @@
  * SPDX-License-Identifier: LGPL-3.0-or-later
  * @brief File containing the implementation of the system commands.
  */
-#include <sys/un.h>
 #include <libgen.h>
+#include <sys/un.h>
 #include <utarray.h>
 
-#include "system_commands.h"
 #include "mac_mapper.h"
+#include "network_commands.h"
+#include "sqlite_macconn_writer.h"
+#include "subscriber_events.h"
 #include "supervisor.h"
 #include "supervisor_utils.h"
-#include "sqlite_macconn_writer.h"
-#include "network_commands.h"
-#include "subscriber_events.h"
+#include "system_commands.h"
 
+#include <eloop.h>
 #include "../ap/ap_config.h"
 #include "../ap/ap_service.h"
 #include "../capture/capture_service.h"
 #include "../utils/allocs.h"
-#include "../utils/os.h"
-#include "../utils/log.h"
 #include "../utils/base64.h"
-#include <eloop.h>
-#include "../utils/sockctl.h"
 #include "../utils/iface_mapper.h"
+#include "../utils/log.h"
+#include "../utils/os.h"
+#include "../utils/sockctl.h"
 
 int set_ip_cmd(struct supervisor_context *context, uint8_t *mac_addr,
                char *ip_addr, enum DHCP_IP_TYPE ip_type) {

--- a/src/supervisor/system_commands.h
+++ b/src/supervisor/system_commands.h
@@ -11,9 +11,9 @@
 #ifndef SYSTEM_COMMANDS_H
 #define SYSTEM_COMMANDS_H
 
-#include <sys/un.h>
-#include <inttypes.h>
 #include <stdbool.h>
+#include <inttypes.h>
+#include <sys/un.h>
 
 #include "../utils/sockctl.h"
 #include "supervisor_config.h"

--- a/src/utils/allocs.c
+++ b/src/utils/allocs.c
@@ -8,14 +8,13 @@
  * @brief File containing the implementation of the allocs functionalities.
  */
 
-#include <stddef.h>
-#include <sys/types.h>
-#include <stdlib.h>
-#include <unistd.h>
+#include <stdarg.h>
+#include <stdbool.h>
 #include <stddef.h>
 #include <stdint.h>
-#include <stdbool.h>
-#include <stdarg.h>
+#include <stdlib.h>
+#include <sys/types.h>
+#include <unistd.h>
 
 #include "allocs.h"
 

--- a/src/utils/allocs.h
+++ b/src/utils/allocs.h
@@ -10,15 +10,14 @@
 #ifndef ALLOCS_H
 #define ALLOCS_H
 
-#include <stddef.h>
-#include <sys/types.h>
-#include <stdlib.h>
-#include <unistd.h>
+#include <stdarg.h>
+#include <stdbool.h>
 #include <stddef.h>
 #include <stdint.h>
-#include <stdbool.h>
-#include <stdarg.h>
+#include <stdlib.h>
 #include <string.h>
+#include <sys/types.h>
+#include <unistd.h>
 
 /**
  * @brief Allocate and zero memory

--- a/src/utils/base64.c
+++ b/src/utils/base64.c
@@ -9,8 +9,8 @@
 #include <stdint.h>
 
 #include "allocs.h"
-#include "os.h"
 #include "base64.h"
+#include "os.h"
 
 static const unsigned char base64_table[65] =
     "ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789+/";

--- a/src/utils/cryptou.c
+++ b/src/utils/cryptou.c
@@ -9,23 +9,23 @@
  */
 
 #include <stdint.h>
-#include <openssl/evp.h>
-#include <openssl/sha.h>
+#include <openssl/conf.h>
 #include <openssl/crypto.h>
 #include <openssl/err.h>
-#include <openssl/rand.h>
+#include <openssl/evp.h>
 #include <openssl/pem.h>
-#include <openssl/conf.h>
-#include <openssl/x509v3.h>
+#include <openssl/rand.h>
 #include <openssl/rsa.h>
+#include <openssl/sha.h>
+#include <openssl/x509v3.h>
 #ifndef OPENSSL_NO_ENGINE
 #include <openssl/engine.h>
 #endif
 #include "cryptou.h"
 
 #include "../utils/allocs.h"
-#include "../utils/os.h"
 #include "../utils/log.h"
+#include "../utils/os.h"
 
 int crypto_geniv(uint8_t *buf, int iv_size) { return RAND_bytes(buf, iv_size); }
 

--- a/src/utils/cryptou.h
+++ b/src/utils/cryptou.h
@@ -11,8 +11,8 @@
 #ifndef CRYPTOU_H
 #define CRYPTOU_H
 
-#include <stdint.h>
 #include <stddef.h>
+#include <stdint.h>
 #include <sys/types.h>
 
 #define AES_BLOCK_SIZE 16

--- a/src/utils/hash.c
+++ b/src/utils/hash.c
@@ -7,8 +7,8 @@
  * SPDX-License-Identifier: LGPL-3.0-or-later
  * @brief File containing the implementation of the hash functions.
  */
-#include <string.h>
 #include "hash.h"
+#include <string.h>
 
 static uint32_t md_mix(uint32_t block, uint32_t state) {
   return (state * block) ^ ((state << 3) + (block >> 2));

--- a/src/utils/hashmap.c
+++ b/src/utils/hashmap.c
@@ -23,8 +23,8 @@
 
 #include <stdbool.h>
 
-#include "log.h"
 #include "hashmap.h"
+#include "log.h"
 
 const char *hmap_str_keychar_get(const hmap_str_keychar *hmap,
                                  const char *keyptr) {

--- a/src/utils/iface.c
+++ b/src/utils/iface.c
@@ -9,28 +9,28 @@
  */
 
 #define _GNU_SOURCE /* To get defns of NI_MAXSERV and NI_MAXHOST */
-#include <errno.h>
+#include <stdbool.h>
 #include <stdio.h>
 #include <stdlib.h>
+#include <arpa/inet.h>
+#include <errno.h>
+#include <fcntl.h>
+#include <fnmatch.h>
 #include <string.h>
 #include <sys/stat.h>
-#include <fcntl.h>
 #include <unistd.h>
-#include <stdbool.h>
-#include <fnmatch.h>
-#include <arpa/inet.h>
 
 #include <sys/socket.h>
-#include <netdb.h>
 #include <ifaddrs.h>
+#include <netdb.h>
 
 #include "allocs.h"
-#include "os.h"
-#include "log.h"
 #include "iface.h"
-#include "ifaceu.h"
-#include "net.h"
 #include "iface_mapper.h"
+#include "ifaceu.h"
+#include "log.h"
+#include "net.h"
+#include "os.h"
 
 #ifdef WITH_NETLINK_SERVICE
 #include "nl.h"

--- a/src/utils/iface.h
+++ b/src/utils/iface.h
@@ -11,9 +11,9 @@
 #ifndef IFACE_H_
 #define IFACE_H_
 
-#include <inttypes.h>
 #include <stdbool.h>
 #include <netinet/in.h>
+#include <inttypes.h>
 #include <net/ethernet.h>
 #include <net/if.h>
 

--- a/src/utils/iface_mapper.c
+++ b/src/utils/iface_mapper.c
@@ -8,23 +8,23 @@
  * @brief File containing the implementation of the interface mapper utilities.
  */
 
-#include <errno.h>
+#include <stdbool.h>
 #include <stdio.h>
 #include <stdlib.h>
+#include <arpa/inet.h>
+#include <errno.h>
+#include <fcntl.h>
+#include <fnmatch.h>
 #include <string.h>
 #include <sys/stat.h>
-#include <fcntl.h>
 #include <unistd.h>
-#include <stdbool.h>
-#include <fnmatch.h>
-#include <arpa/inet.h>
 
 #include "allocs.h"
-#include "os.h"
-#include "log.h"
 #include "iface_mapper.h"
 #include "ifaceu.h"
+#include "log.h"
 #include "net.h"
+#include "os.h"
 
 int get_if_mapper(hmap_if_conn **hmap, in_addr_t subnet, char *ifname) {
   hmap_if_conn *s;

--- a/src/utils/iface_mapper.h
+++ b/src/utils/iface_mapper.h
@@ -11,18 +11,18 @@
 #ifndef IFACE_MAPPER_H_
 #define IFACE_MAPPER_H_
 
-#include <net/if.h>
-#include <inttypes.h>
 #include <stdbool.h>
-#include <pthread.h>
 #include <netinet/in.h>
+#include <inttypes.h>
 #include <net/ethernet.h>
+#include <net/if.h>
+#include <pthread.h>
 
 #include <utarray.h>
 #include <uthash.h>
 #include "allocs.h"
-#include "os.h"
 #include "net.h"
+#include "os.h"
 
 #define LINK_TYPE_LEN 64
 

--- a/src/utils/ifaceu.c
+++ b/src/utils/ifaceu.c
@@ -8,12 +8,12 @@
  * @brief File containing the implementation of the network interface utilities.
  */
 
-#include <errno.h>
+#include <stdbool.h>
 #include <stdio.h>
 #include <stdlib.h>
-#include <string.h>
-#include <stdbool.h>
+#include <errno.h>
 #include <net/if.h>
+#include <string.h>
 
 #include "log.h"
 

--- a/src/utils/ifaceu.h
+++ b/src/utils/ifaceu.h
@@ -11,11 +11,11 @@
 #ifndef IFACEU_H_
 #define IFACEU_H_
 
-#include <errno.h>
+#include <stdbool.h>
 #include <stdio.h>
 #include <stdlib.h>
+#include <errno.h>
 #include <string.h>
-#include <stdbool.h>
 
 /**
  * @brief if_nametoindex from net/if.h

--- a/src/utils/ipgen.c
+++ b/src/utils/ipgen.c
@@ -8,16 +8,16 @@
  * @brief File containing the definition of the ip generic interface utilities.
  */
 
-#include <errno.h>
+#include <stdbool.h>
 #include <stdio.h>
 #include <stdlib.h>
+#include <errno.h>
 #include <string.h>
-#include <stdbool.h>
 
 #include "allocs.h"
 #include "log.h"
-#include "os.h"
 #include "net.h"
+#include "os.h"
 
 #include "ipgen.h"
 

--- a/src/utils/ipgen.h
+++ b/src/utils/ipgen.h
@@ -11,11 +11,11 @@
 #ifndef IPGEN_H_
 #define IPGEN_H_
 
-#include <errno.h>
+#include <stdbool.h>
 #include <stdio.h>
 #include <stdlib.h>
+#include <errno.h>
 #include <string.h>
-#include <stdbool.h>
 
 #include "os.h"
 

--- a/src/utils/iptables.c
+++ b/src/utils/iptables.c
@@ -9,17 +9,17 @@
  */
 
 #include <stdbool.h>
-#include <stdlib.h>
-#include <limits.h>
 #include <stdio.h>
+#include <stdlib.h>
 #include <errno.h>
+#include <limits.h>
 
-#include "iptables.h"
 #include "allocs.h"
-#include "os.h"
-#include "log.h"
 #include "iface_mapper.h"
+#include "iptables.h"
+#include "log.h"
 #include "net.h"
+#include "os.h"
 
 struct iptables_columns {
   long num;

--- a/src/utils/iptables.h
+++ b/src/utils/iptables.h
@@ -11,8 +11,8 @@
 #ifndef IPTABLES_H_
 #define IPTABLES_H_
 
-#include <inttypes.h>
 #include <stdbool.h>
+#include <inttypes.h>
 #include <utarray.h>
 
 #include "allocs.h"

--- a/src/utils/log.c
+++ b/src/utils/log.c
@@ -26,18 +26,18 @@
  * @brief File containing the implementation of the logging functions.
  */
 
-#include <stdio.h>
 #include <stdarg.h>
-#include <stdlib.h>
-#include <unistd.h>
-#include <inttypes.h>
-#include <errno.h>
 #include <stdbool.h>
-#include <time.h>
-#include <sys/time.h>
-#include <sys/stat.h>
-#include <syslog.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <errno.h>
+#include <inttypes.h>
 #include <string.h>
+#include <sys/stat.h>
+#include <sys/time.h>
+#include <syslog.h>
+#include <time.h>
+#include <unistd.h>
 
 #include "log.h"
 #include "time.h"

--- a/src/utils/log.h
+++ b/src/utils/log.h
@@ -14,11 +14,11 @@
 #ifndef LOG_H
 #define LOG_H
 
-#include <stdio.h>
 #include <stdarg.h>
-#include <string.h>
-#include <inttypes.h>
 #include <stdbool.h>
+#include <stdio.h>
+#include <inttypes.h>
+#include <string.h>
 
 #define LOG_VERSION "0.1.0"
 #define __FILENAME__ strrchr("/" __FILE__, '/') + 1

--- a/src/utils/net.c
+++ b/src/utils/net.c
@@ -8,15 +8,15 @@
  * @brief File containing the implementation of the network utilities.
  */
 
-#include <inttypes.h>
 #include <stdbool.h>
 #include <netinet/in.h>
 #include <arpa/inet.h>
 #include <errno.h>
+#include <inttypes.h>
 
 #include "allocs.h"
-#include "os.h"
 #include "net.h"
+#include "os.h"
 
 bool validate_ipv4_string(const char *ip) {
   struct sockaddr_in sa;

--- a/src/utils/net.h
+++ b/src/utils/net.h
@@ -11,9 +11,9 @@
 #ifndef NET_H_
 #define NET_H_
 
-#include <inttypes.h>
 #include <stdbool.h>
 #include <netinet/in.h>
+#include <inttypes.h>
 #include <net/ethernet.h>
 
 #include <utarray.h>

--- a/src/utils/nl.c
+++ b/src/utils/nl.c
@@ -8,41 +8,41 @@
  * @brief File containing the implementation of the netlink utilities.
  */
 
-#include <errno.h>
+#include <stdbool.h>
 #include <stdio.h>
 #include <stdlib.h>
-#include <string.h>
-#include <sys/types.h>
-#include <sys/stat.h>
+#include <arpa/inet.h>
+#include <errno.h>
 #include <fcntl.h>
-#include <unistd.h>
-#include <stdbool.h>
 #include <fnmatch.h>
 #include <linux/netlink.h>
 #include <linux/nl80211.h>
-#include <arpa/inet.h>
+#include <string.h>
+#include <sys/stat.h>
+#include <sys/types.h>
+#include <unistd.h>
 
-#include <netlink/genl/genl.h>
-#include <netlink/genl/family.h>
-#include <netlink/genl/ctrl.h>
-#include <netlink/msg.h>
 #include <netlink/attr.h>
+#include <netlink/genl/ctrl.h>
+#include <netlink/genl/family.h>
+#include <netlink/genl/genl.h>
+#include <netlink/msg.h>
 
 #include "libnetlink.h"
 #include "ll_map.h"
-#include "utils.h"
 #include "rt_names.h"
+#include "utils.h"
 
 #include "linux/if_addr.h"
 #include "linux/if_infiniband.h"
 
 #include "allocs.h"
-#include "os.h"
-#include "log.h"
-#include "nl.h"
-#include "net.h"
 #include "iface_mapper.h"
 #include "ifaceu.h"
+#include "log.h"
+#include "net.h"
+#include "nl.h"
+#include "os.h"
 
 static int ifindex = 0;
 struct rtnl_handle rth = {.fd = -1};

--- a/src/utils/nl.h
+++ b/src/utils/nl.h
@@ -11,12 +11,12 @@
 #ifndef NL_H_
 #define NL_H_
 
-#include <net/if.h>
-#include <net/ethernet.h>
-#include <netinet/if_ether.h>
-#include "linux/rtnetlink.h"
-#include <utarray.h>
 #include <stdbool.h>
+#include <net/ethernet.h>
+#include <net/if.h>
+#include <netinet/if_ether.h>
+#include <utarray.h>
+#include "linux/rtnetlink.h"
 
 #ifdef DEBUG_LIBNL
 #define NL_CB_TYPE NL_CB_DEBUG

--- a/src/utils/os.c
+++ b/src/utils/os.c
@@ -11,29 +11,29 @@
 
 #define _GNU_SOURCE
 #include <stdint.h>
-#include <time.h>
-#include <stdlib.h>
-#include <unistd.h>
-#include <signal.h>
-#include <sys/time.h>
-#include <sys/wait.h>
-#include <sys/types.h>
-#include <sys/stat.h>
-#include <errno.h>
 #include <stdio.h>
-#include <limits.h>
+#include <stdlib.h>
+#include <errno.h>
 #include <libgen.h>
+#include <limits.h>
+#include <signal.h>
+#include <sys/stat.h>
+#include <sys/time.h>
+#include <sys/types.h>
+#include <sys/wait.h>
+#include <time.h>
+#include <unistd.h>
 // #include <string.h>
 #include <stdbool.h>
-#include <dirent.h>
 #include <ctype.h>
+#include <dirent.h>
 #include <fcntl.h>
 #include <uuid/uuid.h>
 
-#include "hashmap.h"
 #include "allocs.h"
-#include "os.h"
+#include "hashmap.h"
 #include "log.h"
+#include "os.h"
 
 #define MAX_64BIT_DIGITS 19
 

--- a/src/utils/os.h
+++ b/src/utils/os.h
@@ -11,16 +11,15 @@
 #ifndef OS_H
 #define OS_H
 
-#include <stddef.h>
-#include <sys/time.h> // required for `struct timeval`
-#include <sys/types.h>
-#include <sys/stat.h>
-#include <stdlib.h>
-#include <unistd.h>
+#include <stdarg.h>
+#include <stdbool.h>
 #include <stddef.h>
 #include <stdint.h>
-#include <stdbool.h>
-#include <stdarg.h>
+#include <stdlib.h>
+#include <sys/stat.h>
+#include <sys/time.h> // required for `struct timeval`
+#include <sys/types.h>
+#include <unistd.h>
 #include <utarray.h>
 
 #include "hashmap.h"

--- a/src/utils/sockctl.c
+++ b/src/utils/sockctl.c
@@ -9,20 +9,20 @@
  */
 
 #include <stdio.h>
-#include <sys/un.h>
 #include <sys/socket.h>
 #include <ctype.h>
 #include <errno.h>
-#include <sys/ioctl.h>
-#include <limits.h> // for PATH_MAX
 #include <libgen.h> // for dirname()
+#include <limits.h> // for PATH_MAX
+#include <sys/ioctl.h>
+#include <sys/un.h>
 
 #include "sockctl.h"
 
 #include "allocs.h"
-#include "os.h"
 #include "log.h"
 #include "net.h"
+#include "os.h"
 
 #define SOCK_EXTENSION ".sock"
 #define TMP_UNIX_SOCK_FOLDER_PREFIX "/tmp/edgesec/tmp-unix-socks."

--- a/src/utils/sockctl.h
+++ b/src/utils/sockctl.h
@@ -11,9 +11,9 @@
 #ifndef SOCKCTL_H
 #define SOCKCTL_H
 
-#include <sys/un.h>
-#include <sys/types.h>
 #include <netinet/in.h>
+#include <sys/types.h>
+#include <sys/un.h>
 
 enum SOCKET_TYPE {
   SOCKET_TYPE_NONE = 0,

--- a/src/utils/sqliteu.c
+++ b/src/utils/sqliteu.c
@@ -9,8 +9,8 @@
  */
 #include <stdio.h>
 #include <stdlib.h>
-#include <string.h>
 #include <sqlite3.h>
+#include <string.h>
 
 #include "../utils/log.h"
 

--- a/src/utils/sqliteu.h
+++ b/src/utils/sqliteu.h
@@ -13,8 +13,8 @@
 
 #include <stdio.h>
 #include <stdlib.h>
-#include <string.h>
 #include <sqlite3.h>
+#include <string.h>
 
 /**
  * @brief Executes and sqlite query statement

--- a/src/utils/squeue.c
+++ b/src/utils/squeue.c
@@ -12,8 +12,8 @@
 #include "squeue.h"
 
 #include "allocs.h"
-#include "os.h"
 #include "log.h"
+#include "os.h"
 
 struct string_queue *init_string_queue(ssize_t max_length) {
   struct string_queue *queue;

--- a/src/utils/uci_wrt.c
+++ b/src/utils/uci_wrt.c
@@ -8,18 +8,18 @@
  * @brief File containing the implementation of the uci utilities.
  */
 
-#include <inttypes.h>
 #include <arpa/inet.h>
+#include <inttypes.h>
 #include <string.h>
 #include <uci.h>
 
 #include "uci_wrt.h"
 
-#include "iface_mapper.h"
-#include "squeue.h"
 #include "allocs.h"
+#include "iface_mapper.h"
 #include "log.h"
 #include "net.h"
+#include "squeue.h"
 
 #define IFNAME_EXPR ".ifname="
 #define IPADDR_EXPR ".ipaddr="

--- a/tests/ap/test_ap_service.c
+++ b/tests/ap/test_ap_service.c
@@ -1,29 +1,29 @@
 
 #define _GNU_SOURCE
 
-#include <sys/types.h>
-#include <sys/stat.h>
-#include <fcntl.h>
-#include <stdio.h>
-#include <stdlib.h>
+#include <setjmp.h>
 #include <stdarg.h>
 #include <stddef.h>
-#include <string.h>
-#include <inttypes.h>
-#include <unistd.h>
-#include <setjmp.h>
 #include <stdint.h>
+#include <stdio.h>
+#include <stdlib.h>
 #include <cmocka.h>
+#include <fcntl.h>
+#include <inttypes.h>
+#include <string.h>
+#include <sys/stat.h>
+#include <sys/types.h>
+#include <unistd.h>
 
-#include "supervisor/supervisor_config.h"
-#include "utils/log.h"
-#include "utils/allocs.h"
-#include "utils/os.h"
-#include "utils/iface.h"
 #include <eloop.h>
-#include "ap/ap_service.h"
 #include "ap/ap_config.h"
+#include "ap/ap_service.h"
 #include "ap/hostapd.h"
+#include "supervisor/supervisor_config.h"
+#include "utils/allocs.h"
+#include "utils/iface.h"
+#include "utils/log.h"
+#include "utils/os.h"
 
 bool __wrap_generate_vlan_conf(char *vlan_file, char *interface) {
   (void)vlan_file;

--- a/tests/ap/test_hostapd.c
+++ b/tests/ap/test_hostapd.c
@@ -1,25 +1,25 @@
 #define _GNU_SOURCE
 
-#include <sys/types.h>
-#include <sys/stat.h>
-#include <fcntl.h>
-#include <stdio.h>
-#include <stdlib.h>
+#include <setjmp.h>
 #include <stdarg.h>
 #include <stddef.h>
-#include <string.h>
-#include <inttypes.h>
-#include <unistd.h>
-#include <setjmp.h>
 #include <stdint.h>
+#include <stdio.h>
+#include <stdlib.h>
 #include <cmocka.h>
+#include <fcntl.h>
+#include <inttypes.h>
+#include <string.h>
+#include <sys/stat.h>
+#include <sys/types.h>
+#include <unistd.h>
 
-#include "utils/log.h"
-#include "utils/allocs.h"
-#include "utils/os.h"
-#include "utils/iface.h"
 #include "ap/ap_config.h"
 #include "ap/hostapd.h"
+#include "utils/allocs.h"
+#include "utils/iface.h"
+#include "utils/log.h"
+#include "utils/os.h"
 
 // seems to be hard coded in hostapd.c
 #define WITH_HOSTAPD_UCI

--- a/tests/capture/middlewares/test_header_middleware.c
+++ b/tests/capture/middlewares/test_header_middleware.c
@@ -1,22 +1,22 @@
 #define _GNU_SOURCE
 
-#include <sys/types.h>
-#include <sys/stat.h>
-#include <fcntl.h>
+#include <setjmp.h>
+#include <stdarg.h>
+#include <stdint.h>
 #include <stdio.h>
 #include <stdlib.h>
-#include <stdarg.h>
-#include <string.h>
-#include <inttypes.h>
-#include <unistd.h>
-#include <setjmp.h>
-#include <stdint.h>
 #include <cmocka.h>
+#include <fcntl.h>
+#include <inttypes.h>
+#include <string.h>
+#include <sys/stat.h>
+#include <sys/types.h>
+#include <unistd.h>
 
-#include "utils/log.h"
-#include "utils/sqliteu.h"
 #include "capture/middlewares/header_middleware/header_middleware.h"
 #include "capture/middlewares/header_middleware/sqlite_header.h"
+#include "utils/log.h"
+#include "utils/sqliteu.h"
 
 extern int __real_sqlite3_open(const char *filename, sqlite3 **ppDb);
 

--- a/tests/capture/middlewares/test_packet_queue.c
+++ b/tests/capture/middlewares/test_packet_queue.c
@@ -1,20 +1,20 @@
 #define _GNU_SOURCE
 
-#include <sys/types.h>
-#include <sys/stat.h>
-#include <fcntl.h>
+#include <setjmp.h>
+#include <stdarg.h>
+#include <stdint.h>
 #include <stdio.h>
 #include <stdlib.h>
-#include <stdarg.h>
-#include <string.h>
-#include <inttypes.h>
-#include <unistd.h>
-#include <setjmp.h>
-#include <stdint.h>
 #include <cmocka.h>
+#include <fcntl.h>
+#include <inttypes.h>
+#include <string.h>
+#include <sys/stat.h>
+#include <sys/types.h>
+#include <unistd.h>
 
-#include "utils/log.h"
 #include "capture/middlewares/header_middleware/packet_queue.h"
+#include "utils/log.h"
 
 static void test_push_packet_queue(void **state) {
   (void)state; /* unused */

--- a/tests/capture/middlewares/test_pcap_queue.c
+++ b/tests/capture/middlewares/test_pcap_queue.c
@@ -1,22 +1,22 @@
 #define _GNU_SOURCE
 
-#include <sys/types.h>
-#include <sys/stat.h>
-#include <fcntl.h>
+#include <setjmp.h>
+#include <stdarg.h>
+#include <stdint.h>
 #include <stdio.h>
 #include <stdlib.h>
-#include <stdarg.h>
-#include <string.h>
-#include <inttypes.h>
-#include <unistd.h>
-#include <setjmp.h>
-#include <stdint.h>
 #include <cmocka.h>
+#include <fcntl.h>
+#include <inttypes.h>
+#include <string.h>
+#include <sys/stat.h>
+#include <sys/types.h>
+#include <unistd.h>
 
-#include "utils/allocs.h"
-#include "utils/os.h"
-#include "utils/log.h"
 #include "capture/middlewares/pcap_middleware/pcap_queue.h"
+#include "utils/allocs.h"
+#include "utils/log.h"
+#include "utils/os.h"
 
 static void test_push_pcap_queue(void **state) {
   (void)state; /* unused */

--- a/tests/capture/middlewares/test_protobuf_utils.c
+++ b/tests/capture/middlewares/test_protobuf_utils.c
@@ -1,24 +1,24 @@
 #define _GNU_SOURCE
 
-#include <sys/types.h>
-#include <sys/stat.h>
-#include <fcntl.h>
+#include <setjmp.h>
+#include <stdarg.h>
+#include <stdint.h>
 #include <stdio.h>
 #include <stdlib.h>
-#include <stdarg.h>
-#include <string.h>
-#include <inttypes.h>
-#include <unistd.h>
-#include <setjmp.h>
-#include <stdint.h>
 #include <cmocka.h>
+#include <fcntl.h>
+#include <inttypes.h>
+#include <string.h>
+#include <sys/stat.h>
+#include <sys/types.h>
+#include <unistd.h>
 
-#include "utils/os.h"
-#include "utils/log.h"
-#include "utils/allocs.h"
 #include "capture/middlewares/protobuf_middleware/eth.pb-c.h"
-#include "capture/middlewares/protobuf_middleware/sync.pb-c.h"
 #include "capture/middlewares/protobuf_middleware/protobuf_utils.h"
+#include "capture/middlewares/protobuf_middleware/sync.pb-c.h"
+#include "utils/allocs.h"
+#include "utils/log.h"
+#include "utils/os.h"
 
 uint64_t timestamp = 999;
 char *id = "id";

--- a/tests/capture/middlewares/test_sqlite_header.c
+++ b/tests/capture/middlewares/test_sqlite_header.c
@@ -1,25 +1,25 @@
 #define _GNU_SOURCE
 
-#include <sys/types.h>
-#include <sys/stat.h>
-#include <fcntl.h>
+#include <setjmp.h>
+#include <stdarg.h>
+#include <stdint.h>
 #include <stdio.h>
 #include <stdlib.h>
-#include <stdarg.h>
-#include <string.h>
-#include <inttypes.h>
-#include <unistd.h>
-#include <setjmp.h>
-#include <stdint.h>
 #include <cmocka.h>
+#include <fcntl.h>
+#include <inttypes.h>
 #include <pthread.h>
 #include <sqlite3.h>
+#include <string.h>
+#include <sys/stat.h>
+#include <sys/types.h>
+#include <unistd.h>
 
-#include "utils/log.h"
-#include "utils/sqliteu.h"
+#include "capture/capture_service.h"
 #include "capture/middlewares/header_middleware/header_middleware.h"
 #include "capture/middlewares/header_middleware/sqlite_header.h"
-#include "capture/capture_service.h"
+#include "utils/log.h"
+#include "utils/sqliteu.h"
 
 char *test_capture_db = "file::memory:?cache=shared";
 

--- a/tests/capture/middlewares/test_sqlite_pcap.c
+++ b/tests/capture/middlewares/test_sqlite_pcap.c
@@ -1,23 +1,23 @@
 #define _GNU_SOURCE
 
-#include <sys/types.h>
-#include <sys/stat.h>
-#include <fcntl.h>
+#include <setjmp.h>
+#include <stdarg.h>
+#include <stdint.h>
 #include <stdio.h>
 #include <stdlib.h>
-#include <stdarg.h>
-#include <string.h>
-#include <inttypes.h>
-#include <unistd.h>
-#include <setjmp.h>
-#include <stdint.h>
 #include <cmocka.h>
+#include <fcntl.h>
+#include <inttypes.h>
 #include <pthread.h>
+#include <string.h>
+#include <sys/stat.h>
+#include <sys/types.h>
+#include <unistd.h>
 
+#include "capture/capture_service.h"
+#include "capture/middlewares/pcap_middleware/sqlite_pcap.h"
 #include "utils/log.h"
 #include "utils/sqliteu.h"
-#include "capture/middlewares/pcap_middleware/sqlite_pcap.h"
-#include "capture/capture_service.h"
 
 char *test_capture_db = "/tmp/test_pcap.sqlite";
 

--- a/tests/capture/test_capture_service.c
+++ b/tests/capture/test_capture_service.c
@@ -1,25 +1,25 @@
 #define _GNU_SOURCE
 
-#include <sys/types.h>
-#include <sys/stat.h>
-#include <fcntl.h>
+#include <setjmp.h>
+#include <stdarg.h>
+#include <stdint.h>
 #include <stdio.h>
 #include <stdlib.h>
-#include <stdarg.h>
-#include <string.h>
-#include <inttypes.h>
-#include <unistd.h>
-#include <setjmp.h>
-#include <stdint.h>
 #include <cmocka.h>
+#include <fcntl.h>
+#include <inttypes.h>
 #include <pthread.h>
+#include <string.h>
+#include <sys/stat.h>
+#include <sys/types.h>
+#include <unistd.h>
 
-#include "utils/log.h"
 #include <eloop.h>
 #include "capture/capture_service.h"
-#include "capture/middlewares_list.h"
 #include "capture/middlewares/header_middleware/packet_decoder.h"
+#include "capture/middlewares_list.h"
 #include "capture/pcap_service.h"
+#include "utils/log.h"
 
 static const UT_icd tp_list_icd = {sizeof(struct tuple_packet), NULL, NULL,
                                    NULL};

--- a/tests/crypt/test_crypt_service.c
+++ b/tests/crypt/test_crypt_service.c
@@ -1,21 +1,21 @@
 #define _GNU_SOURCE
 
-#include <sys/types.h>
-#include <sys/stat.h>
-#include <fcntl.h>
+#include <setjmp.h>
+#include <stdarg.h>
+#include <stdint.h>
 #include <stdio.h>
 #include <stdlib.h>
-#include <stdarg.h>
-#include <string.h>
-#include <inttypes.h>
-#include <unistd.h>
-#include <setjmp.h>
-#include <stdint.h>
 #include <cmocka.h>
+#include <fcntl.h>
+#include <inttypes.h>
+#include <string.h>
+#include <sys/stat.h>
+#include <sys/types.h>
+#include <unistd.h>
 
+#include "crypt/crypt_service.h"
 #include "utils/log.h"
 #include "utils/sqliteu.h"
-#include "crypt/crypt_service.h"
 
 extern int __real_crypto_decrypt(uint8_t *in, int in_size, uint8_t *key,
                                  uint8_t *iv, uint8_t *out);

--- a/tests/crypt/test_sqlite_crypt_writer.c
+++ b/tests/crypt/test_sqlite_crypt_writer.c
@@ -1,21 +1,21 @@
 #define _GNU_SOURCE
 
-#include <sys/types.h>
-#include <sys/stat.h>
-#include <fcntl.h>
+#include <setjmp.h>
+#include <stdarg.h>
+#include <stdint.h>
 #include <stdio.h>
 #include <stdlib.h>
-#include <stdarg.h>
-#include <string.h>
-#include <inttypes.h>
-#include <unistd.h>
-#include <setjmp.h>
-#include <stdint.h>
 #include <cmocka.h>
+#include <fcntl.h>
+#include <inttypes.h>
+#include <string.h>
+#include <sys/stat.h>
+#include <sys/types.h>
+#include <unistd.h>
 
+#include "crypt/sqlite_crypt_writer.h"
 #include "utils/log.h"
 #include "utils/sqliteu.h"
-#include "crypt/sqlite_crypt_writer.h"
 
 extern int __real_sqlite3_open(const char *filename, sqlite3 **ppDb);
 

--- a/tests/dhcp/test_dhcp_service.c
+++ b/tests/dhcp/test_dhcp_service.c
@@ -1,22 +1,22 @@
 #define _GNU_SOURCE
 
+#include <setjmp.h>
+#include <stdarg.h>
+#include <stdbool.h>
+#include <stdint.h>
 #include <stdio.h>
 #include <stdlib.h>
-#include <stdarg.h>
-#include <fcntl.h>
-#include <ctype.h>
-#include <unistd.h>
-#include <stdbool.h>
-#include <errno.h>
-#include <libgen.h>
-#include <setjmp.h>
-#include <stdint.h>
 #include <cmocka.h>
+#include <ctype.h>
+#include <errno.h>
+#include <fcntl.h>
+#include <libgen.h>
+#include <unistd.h>
 
-#include "utils/log.h"
-#include "dhcp/dnsmasq.h"
 #include "dhcp/dhcp_config.h"
 #include "dhcp/dhcp_service.h"
+#include "dhcp/dnsmasq.h"
+#include "utils/log.h"
 
 char *dhcp_bin_path = "/tmp/sbin/dnsmasq";
 char *dnsmasq_proc_name = "dnsmasq";

--- a/tests/dhcp/test_dnsmasq.c
+++ b/tests/dhcp/test_dnsmasq.c
@@ -1,21 +1,21 @@
 #define _GNU_SOURCE
 
+#include <setjmp.h>
+#include <stdarg.h>
+#include <stdbool.h>
+#include <stdint.h>
 #include <stdio.h>
 #include <stdlib.h>
-#include <stdarg.h>
-#include <fcntl.h>
-#include <ctype.h>
-#include <unistd.h>
-#include <stdbool.h>
-#include <errno.h>
-#include <libgen.h>
-#include <setjmp.h>
-#include <stdint.h>
 #include <cmocka.h>
+#include <ctype.h>
+#include <errno.h>
+#include <fcntl.h>
+#include <libgen.h>
+#include <unistd.h>
 
-#include "utils/log.h"
-#include "dhcp/dnsmasq.h"
 #include "dhcp/dhcp_config.h"
+#include "dhcp/dnsmasq.h"
+#include "utils/log.h"
 
 static const UT_icd config_dhcpinfo_icd = {sizeof(config_dhcpinfo_t), NULL,
                                            NULL, NULL};

--- a/tests/dns/test_command_mapper.c
+++ b/tests/dns/test_command_mapper.c
@@ -1,21 +1,21 @@
 #define _GNU_SOURCE
 
+#include <setjmp.h>
+#include <stdarg.h>
+#include <stdbool.h>
+#include <stdint.h>
 #include <stdio.h>
 #include <stdlib.h>
-#include <stdarg.h>
-#include <fcntl.h>
-#include <ctype.h>
-#include <unistd.h>
-#include <stdbool.h>
-#include <errno.h>
-#include <libgen.h>
-#include <setjmp.h>
-#include <stdint.h>
 #include <cmocka.h>
+#include <ctype.h>
+#include <errno.h>
+#include <fcntl.h>
+#include <libgen.h>
+#include <unistd.h>
 
+#include "dns/command_mapper.h"
 #include "utils/log.h"
 #include "utils/os.h"
-#include "dns/command_mapper.h"
 
 static void test_put_command_mapper(void **state) {
   (void)state;

--- a/tests/dns/test_mdns_list.c
+++ b/tests/dns/test_mdns_list.c
@@ -1,21 +1,21 @@
 #define _GNU_SOURCE
 
+#include <setjmp.h>
+#include <stdarg.h>
+#include <stdbool.h>
+#include <stdint.h>
 #include <stdio.h>
 #include <stdlib.h>
-#include <stdarg.h>
-#include <fcntl.h>
-#include <ctype.h>
-#include <unistd.h>
-#include <stdbool.h>
-#include <errno.h>
-#include <libgen.h>
-#include <setjmp.h>
-#include <stdint.h>
 #include <cmocka.h>
+#include <ctype.h>
+#include <errno.h>
+#include <fcntl.h>
+#include <libgen.h>
+#include <unistd.h>
 
+#include "dns/mdns_list.h"
 #include "utils/log.h"
 #include "utils/os.h"
-#include "dns/mdns_list.h"
 
 static void test_push_mdns_list(void **state) {
   (void)state; /* unused */

--- a/tests/dns/test_mdns_mapper.c
+++ b/tests/dns/test_mdns_mapper.c
@@ -1,21 +1,21 @@
 #define _GNU_SOURCE
 
+#include <setjmp.h>
+#include <stdarg.h>
+#include <stdbool.h>
+#include <stdint.h>
 #include <stdio.h>
 #include <stdlib.h>
-#include <stdarg.h>
-#include <fcntl.h>
-#include <ctype.h>
-#include <unistd.h>
-#include <stdbool.h>
-#include <errno.h>
-#include <libgen.h>
-#include <setjmp.h>
-#include <stdint.h>
 #include <cmocka.h>
+#include <ctype.h>
+#include <errno.h>
+#include <fcntl.h>
+#include <libgen.h>
+#include <unistd.h>
 
+#include "dns/mdns_mapper.h"
 #include "utils/log.h"
 #include "utils/os.h"
-#include "dns/mdns_mapper.h"
 
 static void test_put_mdns_answer_mapper(void **state) {
   (void)state; /* unused */

--- a/tests/dns/test_mdns_service.c
+++ b/tests/dns/test_mdns_service.c
@@ -1,23 +1,23 @@
 #define _GNU_SOURCE
 
+#include <setjmp.h>
+#include <stdarg.h>
+#include <stdbool.h>
+#include <stdint.h>
 #include <stdio.h>
 #include <stdlib.h>
-#include <stdarg.h>
-#include <fcntl.h>
-#include <ctype.h>
-#include <unistd.h>
-#include <stdbool.h>
-#include <errno.h>
-#include <libgen.h>
-#include <setjmp.h>
-#include <stdint.h>
 #include <cmocka.h>
+#include <ctype.h>
+#include <errno.h>
+#include <fcntl.h>
+#include <libgen.h>
+#include <unistd.h>
 
+#include <eloop.h>
+#include "capture/pcap_service.h"
+#include "dns/mdns_service.h"
 #include "utils/log.h"
 #include "utils/os.h"
-#include "dns/mdns_service.h"
-#include "capture/pcap_service.h"
-#include <eloop.h>
 
 int __wrap_run_pcap(char *interface, bool immediate, bool promiscuous,
                     int timeout, char *filter, bool nonblock,

--- a/tests/dns/test_reflection_list.c
+++ b/tests/dns/test_reflection_list.c
@@ -1,22 +1,22 @@
 #define _GNU_SOURCE
 
+#include <setjmp.h>
+#include <stdarg.h>
+#include <stdbool.h>
+#include <stdint.h>
 #include <stdio.h>
 #include <stdlib.h>
-#include <stdarg.h>
-#include <fcntl.h>
-#include <ctype.h>
-#include <unistd.h>
-#include <stdbool.h>
-#include <errno.h>
-#include <libgen.h>
-#include <setjmp.h>
-#include <stdint.h>
-#include <cmocka.h>
 #include <sys/socket.h>
+#include <cmocka.h>
+#include <ctype.h>
+#include <errno.h>
+#include <fcntl.h>
+#include <libgen.h>
+#include <unistd.h>
 
+#include "dns/reflection_list.h"
 #include "utils/log.h"
 #include "utils/os.h"
-#include "dns/reflection_list.h"
 
 static void test_init_reflection_list(void **state) {
   (void)state;

--- a/tests/radius/ip_addr.h
+++ b/tests/radius/ip_addr.h
@@ -9,11 +9,11 @@
 #ifndef IP_ADDR_H
 #define IP_ADDR_H
 
+#include <stdbool.h>
 #include <stdint.h>
+#include <arpa/inet.h>
 #include <sys/types.h>
 #include <unistd.h>
-#include <arpa/inet.h>
-#include <stdbool.h>
 
 struct hostapd_ip_addr {
   int af; /* AF_INET / AF_INET6 */

--- a/tests/radius/radius_client.c
+++ b/tests/radius/radius_client.c
@@ -6,24 +6,24 @@
  * See README for more details.
  */
 
-#include <stdint.h>
-#include <sys/types.h>
-#include <unistd.h>
-#include <arpa/inet.h>
 #include <stdbool.h>
+#include <stdint.h>
 #include <sys/socket.h>
 #include <netinet/in.h>
-#include <netinet/if_ether.h>
+#include <arpa/inet.h>
 #include <errno.h>
+#include <netinet/if_ether.h>
+#include <sys/types.h>
+#include <unistd.h>
 
+#include <eloop.h>
 #include "radius/radius.h"
 #include "radius/wpabuf.h"
 #include "radius_client.h"
-#include <eloop.h>
 #include "utils/allocs.h"
-#include "utils/os.h"
-#include "utils/net.h"
 #include "utils/log.h"
+#include "utils/net.h"
+#include "utils/os.h"
 
 /* Defaults for RADIUS retransmit values (exponential backoff) */
 

--- a/tests/radius/radius_client.h
+++ b/tests/radius/radius_client.h
@@ -9,11 +9,11 @@
 #ifndef RADIUS_CLIENT_H
 #define RADIUS_CLIENT_H
 
+#include <stdbool.h>
 #include <stdint.h>
+#include <arpa/inet.h>
 #include <sys/types.h>
 #include <unistd.h>
-#include <arpa/inet.h>
-#include <stdbool.h>
 
 #include <eloop.h>
 #include "ip_addr.h"

--- a/tests/radius/test_radius_server.c
+++ b/tests/radius/test_radius_server.c
@@ -5,29 +5,28 @@
  * This software may be distributed under the terms of the BSD license.
  * See README for more details.
  */
-#include <sys/types.h>
-#include <unistd.h>
-#include <arpa/inet.h>
+#include <setjmp.h>
+#include <stdarg.h>
 #include <stdbool.h>
-#include <errno.h>
-#include <sys/stat.h>
-#include <fcntl.h>
+#include <stdint.h>
 #include <stdio.h>
 #include <stdlib.h>
-#include <stdarg.h>
-#include <string.h>
-#include <inttypes.h>
-#include <unistd.h>
-#include <setjmp.h>
-#include <stdint.h>
 #include <cmocka.h>
+#include <arpa/inet.h>
+#include <errno.h>
+#include <fcntl.h>
+#include <inttypes.h>
+#include <string.h>
+#include <sys/stat.h>
+#include <sys/types.h>
+#include <unistd.h>
 
 #include <eloop.h>
-#include "utils/allocs.h"
-#include "utils/os.h"
-#include "utils/log.h"
 #include "radius/radius.h"
 #include "radius/radius_server.h"
+#include "utils/allocs.h"
+#include "utils/log.h"
+#include "utils/os.h"
 
 #include "radius_client.h"
 

--- a/tests/supervisor/test_bridge_list.c
+++ b/tests/supervisor/test_bridge_list.c
@@ -1,21 +1,21 @@
 #define _GNU_SOURCE
 
-#include <sys/types.h>
-#include <sys/stat.h>
-#include <fcntl.h>
+#include <setjmp.h>
+#include <stdarg.h>
+#include <stdint.h>
 #include <stdio.h>
 #include <stdlib.h>
-#include <stdarg.h>
-#include <string.h>
-#include <inttypes.h>
-#include <unistd.h>
-#include <setjmp.h>
-#include <stdint.h>
 #include <cmocka.h>
+#include <fcntl.h>
+#include <inttypes.h>
+#include <string.h>
+#include <sys/stat.h>
+#include <sys/types.h>
+#include <unistd.h>
 
 #include "supervisor/bridge_list.h"
-#include "utils/net.h"
 #include "utils/log.h"
+#include "utils/net.h"
 
 static void test_add_bridge_mac(void **state) {
   (void)state; /* unused */

--- a/tests/supervisor/test_cmd_processor.c
+++ b/tests/supervisor/test_cmd_processor.c
@@ -1,25 +1,25 @@
 #define _GNU_SOURCE
 
-#include <sys/types.h>
-#include <sys/stat.h>
-#include <fcntl.h>
+#include <setjmp.h>
+#include <stdarg.h>
+#include <stdint.h>
 #include <stdio.h>
 #include <stdlib.h>
-#include <stdarg.h>
-#include <string.h>
-#include <inttypes.h>
-#include <unistd.h>
-#include <setjmp.h>
-#include <stdint.h>
 #include <cmocka.h>
+#include <fcntl.h>
+#include <inttypes.h>
+#include <string.h>
+#include <sys/stat.h>
+#include <sys/types.h>
+#include <unistd.h>
 
 #include "supervisor/cmd_processor.h"
 #include "supervisor/system_commands.h"
 
-#include "utils/hashmap.h"
-#include "utils/log.h"
-#include "utils/iptables.h"
 #include "runctl.h"
+#include "utils/hashmap.h"
+#include "utils/iptables.h"
+#include "utils/log.h"
 
 ssize_t __wrap_write_socket_data(int sock, char *data, size_t data_len,
                                  struct sockaddr_un *addr, int addr_len) {

--- a/tests/supervisor/test_mac_mapper.c
+++ b/tests/supervisor/test_mac_mapper.c
@@ -1,20 +1,20 @@
 #define _GNU_SOURCE
 
-#include <sys/types.h>
-#include <sys/stat.h>
-#include <fcntl.h>
+#include <setjmp.h>
+#include <stdarg.h>
+#include <stdint.h>
 #include <stdio.h>
 #include <stdlib.h>
-#include <stdarg.h>
-#include <string.h>
-#include <inttypes.h>
-#include <unistd.h>
-#include <setjmp.h>
-#include <stdint.h>
 #include <cmocka.h>
+#include <fcntl.h>
+#include <inttypes.h>
+#include <string.h>
+#include <sys/stat.h>
+#include <sys/types.h>
+#include <unistd.h>
 
-#include "utils/log.h"
 #include "supervisor/mac_mapper.h"
+#include "utils/log.h"
 
 static const UT_icd mac_conn_icd = {sizeof(struct mac_conn), NULL, NULL, NULL};
 

--- a/tests/supervisor/test_sockctl_server.c
+++ b/tests/supervisor/test_sockctl_server.c
@@ -1,28 +1,28 @@
 #define _GNU_SOURCE
 
-#include <sys/types.h>
-#include <sys/stat.h>
-#include <fcntl.h>
+#include <setjmp.h>
+#include <stdarg.h>
+#include <stdint.h>
 #include <stdio.h>
 #include <stdlib.h>
-#include <stdarg.h>
-#include <string.h>
-#include <inttypes.h>
-#include <unistd.h>
-#include <setjmp.h>
-#include <stdint.h>
-#include <cmocka.h>
-#include <sys/un.h>
 #include <sys/socket.h>
-#include <ctype.h>
+#include <cmocka.h>
 #include <arpa/inet.h>
+#include <ctype.h>
 #include <errno.h>
+#include <fcntl.h>
+#include <inttypes.h>
+#include <string.h>
+#include <sys/stat.h>
+#include <sys/types.h>
+#include <sys/un.h>
+#include <unistd.h>
 
-#include "utils/sockctl.h"
+#include "utils/allocs.h"
 #include "utils/hashmap.h"
 #include "utils/log.h"
-#include "utils/allocs.h"
 #include "utils/os.h"
+#include "utils/sockctl.h"
 
 #define TMP_PFX "tdoms"
 

--- a/tests/supervisor/test_sqlite_macconn_writer.c
+++ b/tests/supervisor/test_sqlite_macconn_writer.c
@@ -1,22 +1,22 @@
 #define _GNU_SOURCE
 
-#include <sys/types.h>
-#include <sys/stat.h>
-#include <fcntl.h>
+#include <setjmp.h>
+#include <stdarg.h>
+#include <stdint.h>
 #include <stdio.h>
 #include <stdlib.h>
-#include <stdarg.h>
-#include <string.h>
-#include <inttypes.h>
-#include <unistd.h>
-#include <setjmp.h>
-#include <stdint.h>
 #include <cmocka.h>
+#include <fcntl.h>
+#include <inttypes.h>
+#include <string.h>
+#include <sys/stat.h>
+#include <sys/types.h>
+#include <unistd.h>
 
+#include "supervisor/mac_mapper.h"
+#include "supervisor/sqlite_macconn_writer.h"
 #include "utils/log.h"
 #include "utils/sqliteu.h"
-#include "supervisor/sqlite_macconn_writer.h"
-#include "supervisor/mac_mapper.h"
 
 static const UT_icd mac_conn_icd = {sizeof(struct mac_conn), NULL, NULL, NULL};
 

--- a/tests/supervisor/test_supervisor.c
+++ b/tests/supervisor/test_supervisor.c
@@ -1,22 +1,22 @@
 #define _GNU_SOURCE
 
-#include <sys/types.h>
-#include <sys/stat.h>
-#include <fcntl.h>
+#include <setjmp.h>
+#include <stdarg.h>
+#include <stdint.h>
 #include <stdio.h>
 #include <stdlib.h>
-#include <stdarg.h>
-#include <string.h>
-#include <inttypes.h>
-#include <unistd.h>
-#include <setjmp.h>
-#include <stdint.h>
 #include <cmocka.h>
+#include <fcntl.h>
+#include <inttypes.h>
+#include <string.h>
+#include <sys/stat.h>
+#include <sys/types.h>
+#include <unistd.h>
 
-#include "utils/log.h"
+#include "supervisor/sqlite_macconn_writer.h"
 #include "supervisor/supervisor.h"
 #include "supervisor/supervisor_utils.h"
-#include "supervisor/sqlite_macconn_writer.h"
+#include "utils/log.h"
 
 #ifdef WITH_CRYPTO_SERVICE
 #include "crypt/crypt_service.h"

--- a/tests/supervisor/test_supervisor_utils.c
+++ b/tests/supervisor/test_supervisor_utils.c
@@ -1,20 +1,20 @@
 #define _GNU_SOURCE
 
-#include <sys/types.h>
-#include <sys/stat.h>
-#include <fcntl.h>
+#include <setjmp.h>
+#include <stdarg.h>
+#include <stdint.h>
 #include <stdio.h>
 #include <stdlib.h>
-#include <stdarg.h>
-#include <string.h>
-#include <inttypes.h>
-#include <unistd.h>
-#include <setjmp.h>
-#include <stdint.h>
 #include <cmocka.h>
+#include <fcntl.h>
+#include <inttypes.h>
+#include <string.h>
+#include <sys/stat.h>
+#include <sys/types.h>
+#include <unistd.h>
 
-#include "utils/log.h"
 #include "supervisor/supervisor_utils.h"
+#include "utils/log.h"
 
 static const UT_icd config_ifinfo_icd = {sizeof(config_ifinfo_t), NULL, NULL,
                                          NULL};

--- a/tests/system/test_system_checks.c
+++ b/tests/system/test_system_checks.c
@@ -1,22 +1,22 @@
 #define _GNU_SOURCE
 
-#include <sys/types.h>
-#include <sys/stat.h>
-#include <fcntl.h>
+#include <setjmp.h>
+#include <stdarg.h>
+#include <stdint.h>
 #include <stdio.h>
 #include <stdlib.h>
-#include <stdarg.h>
-#include <string.h>
-#include <inttypes.h>
-#include <unistd.h>
-#include <setjmp.h>
-#include <stdint.h>
 #include <cmocka.h>
+#include <fcntl.h>
+#include <inttypes.h>
+#include <string.h>
+#include <sys/stat.h>
+#include <sys/types.h>
+#include <unistd.h>
 
 #include "system_checks.h"
 #include "utils/hashmap.h"
-#include "utils/log.h"
 #include "utils/iw.h"
+#include "utils/log.h"
 
 static void test_check_systems_commands(void **state) {
   (void)state; /* unused */

--- a/tests/test_config.c
+++ b/tests/test_config.c
@@ -1,14 +1,14 @@
+#include <setjmp.h>
 #include <stdarg.h>
 #include <stddef.h>
-#include <setjmp.h>
 #include <stdint.h>
 #include <cmocka.h>
 
 #include "./utils/log.h"
 
-#include "./config.h"
 #include <libgen.h>
 #include <limits.h>
+#include "./config.h"
 
 static void test_load_configs(void **state) {
   (void)state; /* unused */

--- a/tests/test_edgesec.c
+++ b/tests/test_edgesec.c
@@ -1,31 +1,31 @@
 #define _GNU_SOURCE
 
-#include <sys/types.h>
-#include <sys/stat.h>
-#include <fcntl.h>
+#include <setjmp.h>
+#include <stdarg.h>
+#include <stdint.h>
 #include <stdio.h>
 #include <stdlib.h>
-#include <stdarg.h>
-#include <string.h>
-#include <inttypes.h>
-#include <unistd.h>
-#include <setjmp.h>
-#include <stdint.h>
 #include <cmocka.h>
-#include <pthread.h>
-#include <sys/ioctl.h>
 #include <arpa/inet.h>
+#include <fcntl.h>
+#include <inttypes.h>
+#include <pthread.h>
 #include <signal.h>
+#include <string.h>
+#include <sys/ioctl.h>
+#include <sys/stat.h>
+#include <sys/types.h>
+#include <unistd.h>
 
-#include "runctl.h"
 #include "config.h"
+#include "runctl.h"
 
-#include "utils/sockctl.h"
+#include "ap/ap_service.h"
+#include "radius/radius.h"
+#include "radius/radius_client.h"
 #include "supervisor/cmd_processor.h"
 #include "supervisor/system_commands.h"
-#include "ap/ap_service.h"
-#include "radius/radius_client.h"
-#include "radius/radius.h"
+#include "utils/sockctl.h"
 
 #define AP_CTRL_IFACE_PATH "/tmp/wifi0"
 #define SUPERVISOR_CONTROL_PATH "/tmp/edgesec-control-server"

--- a/tests/test_runctl.c
+++ b/tests/test_runctl.c
@@ -1,26 +1,26 @@
 #define _GNU_SOURCE
 
-#include <sys/types.h>
-#include <sys/stat.h>
-#include <fcntl.h>
+#include <setjmp.h>
+#include <stdarg.h>
+#include <stdint.h>
 #include <stdio.h>
 #include <stdlib.h>
-#include <stdarg.h>
-#include <string.h>
-#include <inttypes.h>
-#include <unistd.h>
-#include <setjmp.h>
-#include <stdint.h>
 #include <cmocka.h>
+#include <fcntl.h>
+#include <inttypes.h>
+#include <string.h>
+#include <sys/stat.h>
+#include <sys/types.h>
+#include <unistd.h>
 
-#include "supervisor/sqlite_macconn_writer.h"
+#include <utarray.h>
 #include "crypt/crypt_service.h"
+#include "supervisor/sqlite_macconn_writer.h"
 #include "utils/hashmap.h"
 #include "utils/log.h"
-#include <utarray.h>
 
-#include "supervisor/supervisor_config.h"
 #include "runctl.h"
+#include "supervisor/supervisor_config.h"
 
 static const UT_icd config_ifinfo_icd = {sizeof(config_ifinfo_t), NULL, NULL,
                                          NULL};

--- a/tests/utils/test_eloop.c
+++ b/tests/utils/test_eloop.c
@@ -1,14 +1,14 @@
+#include <setjmp.h>
 #include <stdarg.h>
 #include <stddef.h>
-#include <setjmp.h>
 #include <stdint.h>
 #include <cmocka.h>
 
-#include <sys/socket.h>
-#include <sys/un.h>
 #include <stdio.h>
-#include <string.h>
+#include <sys/socket.h>
 #include <limits.h>
+#include <string.h>
+#include <sys/un.h>
 
 #include <eloop.h>
 #include "utils/allocs.h"

--- a/tests/utils/test_eloop_handles_null.c
+++ b/tests/utils/test_eloop_handles_null.c
@@ -1,6 +1,6 @@
+#include <setjmp.h>
 #include <stdarg.h>
 #include <stddef.h>
-#include <setjmp.h>
 #include <stdint.h>
 #include <cmocka.h>
 

--- a/tests/utils/test_eloop_threaded.c
+++ b/tests/utils/test_eloop_threaded.c
@@ -8,19 +8,19 @@
  * @brief Tests for eloop when using multi-threading.
  */
 
+#include <setjmp.h>
 #include <stdarg.h>
 #include <stddef.h>
-#include <setjmp.h>
 #include <stdint.h>
 #include <cmocka.h>
 
-#include <sys/types.h>
 #include <sys/socket.h>
-#include <arpa/inet.h>
 #include <netinet/in.h>
+#include <arpa/inet.h>
+#include <eloop.h>
+#include <sys/types.h>
 #include <threads.h>
 #include <utarray.h>
-#include <eloop.h>
 
 #include "utils/log.h"
 #include "utils/sockctl.h"

--- a/tests/utils/test_hashmap.c
+++ b/tests/utils/test_hashmap.c
@@ -1,20 +1,20 @@
 #define _GNU_SOURCE
 
-#include <sys/types.h>
-#include <sys/stat.h>
-#include <fcntl.h>
+#include <setjmp.h>
+#include <stdarg.h>
+#include <stdint.h>
 #include <stdio.h>
 #include <stdlib.h>
-#include <stdarg.h>
-#include <string.h>
-#include <inttypes.h>
-#include <unistd.h>
-#include <setjmp.h>
-#include <stdint.h>
 #include <cmocka.h>
+#include <fcntl.h>
+#include <inttypes.h>
+#include <string.h>
+#include <sys/stat.h>
+#include <sys/types.h>
+#include <unistd.h>
 
-#include "utils/log.h"
 #include "utils/hashmap.h"
+#include "utils/log.h"
 
 static void test_hashmap_str_keychar(void **state) {
   (void)state; /* unused */

--- a/tests/utils/test_iface_mapper.c
+++ b/tests/utils/test_iface_mapper.c
@@ -1,21 +1,21 @@
 #define _GNU_SOURCE
 
-#include <sys/types.h>
-#include <sys/stat.h>
-#include <fcntl.h>
+#include <setjmp.h>
+#include <stdarg.h>
+#include <stdbool.h>
+#include <stdint.h>
 #include <stdio.h>
 #include <stdlib.h>
-#include <stdarg.h>
-#include <string.h>
-#include <inttypes.h>
-#include <unistd.h>
-#include <stdbool.h>
-#include <setjmp.h>
-#include <stdint.h>
 #include <cmocka.h>
+#include <fcntl.h>
+#include <inttypes.h>
+#include <string.h>
+#include <sys/stat.h>
+#include <sys/types.h>
+#include <unistd.h>
 
-#include "utils/log.h"
 #include "utils/iface_mapper.h"
+#include "utils/log.h"
 #include "utils/net.h"
 
 static const UT_icd config_ifinfo_icd = {sizeof(config_ifinfo_t), NULL, NULL,

--- a/tests/utils/test_ifaceu.c
+++ b/tests/utils/test_ifaceu.c
@@ -1,13 +1,13 @@
 #include <stdbool.h>
 
+#include <setjmp.h>
 #include <stdarg.h>
 #include <stddef.h>
-#include <setjmp.h>
 #include <stdint.h>
 #include <cmocka.h>
 
-#include "utils/log.h"
 #include "utils/ifaceu.h"
+#include "utils/log.h"
 
 #ifdef __FreeBSD__
 static const char LOCALHOST_INTERFACE[] = "lo0";

--- a/tests/utils/test_log_err.c
+++ b/tests/utils/test_log_err.c
@@ -1,11 +1,11 @@
-#include <sys/types.h>
-#include <sys/stat.h>
-#include <fcntl.h>
+#include <stdarg.h>
 #include <stdio.h>
 #include <stdlib.h>
-#include <stdarg.h>
 #include <errno.h>
+#include <fcntl.h>
 #include <limits.h>
+#include <sys/stat.h>
+#include <sys/types.h>
 
 #include "utils/log.h"
 

--- a/tests/utils/test_log_level.c
+++ b/tests/utils/test_log_level.c
@@ -1,6 +1,6 @@
+#include <stdarg.h>
 #include <stdio.h>
 #include <stdlib.h>
-#include <stdarg.h>
 #include <fcntl.h>
 
 #include "utils/log.h"

--- a/tests/utils/test_log_thread_safe.c
+++ b/tests/utils/test_log_thread_safe.c
@@ -1,7 +1,7 @@
 #define _GNU_SOURCE
+#include <stdarg.h>
 #include <stdio.h>
 #include <stdlib.h>
-#include <stdarg.h>
 #include <fcntl.h>
 #include <pthread.h>
 #include <string.h>

--- a/tests/utils/test_minIni.c
+++ b/tests/utils/test_minIni.c
@@ -1,18 +1,18 @@
 #define _GNU_SOURCE
 
-#include <sys/types.h>
-#include <sys/stat.h>
-#include <fcntl.h>
+#include <setjmp.h>
+#include <stdarg.h>
+#include <stdint.h>
 #include <stdio.h>
 #include <stdlib.h>
-#include <stdarg.h>
-#include <string.h>
-#include <inttypes.h>
-#include <unistd.h>
-#include <setjmp.h>
-#include <stdint.h>
 #include <cmocka.h>
+#include <fcntl.h>
+#include <inttypes.h>
 #include <minIni.h>
+#include <string.h>
+#include <sys/stat.h>
+#include <sys/types.h>
+#include <unistd.h>
 
 #include "utils/log.h"
 

--- a/tests/utils/test_net.c
+++ b/tests/utils/test_net.c
@@ -1,18 +1,18 @@
 #define _GNU_SOURCE
 
-#include <sys/types.h>
-#include <sys/stat.h>
-#include <fcntl.h>
+#include <setjmp.h>
+#include <stdarg.h>
+#include <stdbool.h>
+#include <stdint.h>
 #include <stdio.h>
 #include <stdlib.h>
-#include <stdarg.h>
-#include <string.h>
-#include <inttypes.h>
-#include <unistd.h>
-#include <stdbool.h>
-#include <setjmp.h>
-#include <stdint.h>
 #include <cmocka.h>
+#include <fcntl.h>
+#include <inttypes.h>
+#include <string.h>
+#include <sys/stat.h>
+#include <sys/types.h>
+#include <unistd.h>
 
 #include "utils/log.h"
 #include "utils/net.h"

--- a/tests/utils/test_nl.c
+++ b/tests/utils/test_nl.c
@@ -1,6 +1,6 @@
+#include <setjmp.h>
 #include <stdarg.h>
 #include <stddef.h>
-#include <setjmp.h>
 #include <stdint.h>
 #include <cmocka.h>
 

--- a/tests/utils/test_os.c
+++ b/tests/utils/test_os.c
@@ -1,24 +1,24 @@
 #define _GNU_SOURCE
 
-#include <sys/types.h>
-#include <sys/stat.h>
-#include <errno.h>
-#include <fcntl.h>
+#include <setjmp.h>
+#include <stdarg.h>
+#include <stdint.h>
 #include <stdio.h>
 #include <stdlib.h>
-#include <stdarg.h>
-#include <string.h>
-#include <inttypes.h>
-#include <unistd.h>
-#include <setjmp.h>
-#include <stdint.h>
 #include <cmocka.h>
+#include <errno.h>
+#include <fcntl.h>
+#include <inttypes.h>
+#include <string.h>
+#include <sys/stat.h>
+#include <sys/types.h>
+#include <unistd.h>
 
 #include <limits.h>
 
+#include "utils/allocs.h"
 #include "utils/log.h"
 #include "utils/os.h"
-#include "utils/allocs.h"
 
 #include "tmpdir.h"
 

--- a/tests/utils/test_sqliteu.c
+++ b/tests/utils/test_sqliteu.c
@@ -1,6 +1,6 @@
+#include <setjmp.h>
 #include <stdarg.h>
 #include <stddef.h>
-#include <setjmp.h>
 #include <stdint.h>
 #include <cmocka.h>
 

--- a/tests/utils/test_squeue.c
+++ b/tests/utils/test_squeue.c
@@ -1,8 +1,8 @@
 #define _GNU_SOURCE
 
+#include <setjmp.h>
 #include <stdarg.h>
 #include <stddef.h>
-#include <setjmp.h>
 #include <stdint.h>
 #include <cmocka.h>
 

--- a/tests/utils/test_uci_wrt.c
+++ b/tests/utils/test_uci_wrt.c
@@ -1,22 +1,22 @@
 #define _GNU_SOURCE
 
-#include <sys/types.h>
-#include <sys/stat.h>
-#include <fcntl.h>
+#include <setjmp.h>
+#include <stdarg.h>
+#include <stdbool.h>
+#include <stdint.h>
 #include <stdio.h>
 #include <stdlib.h>
-#include <stdarg.h>
-#include <string.h>
-#include <inttypes.h>
-#include <unistd.h>
-#include <stdbool.h>
-#include <setjmp.h>
-#include <stdint.h>
 #include <cmocka.h>
+#include <fcntl.h>
+#include <inttypes.h>
+#include <string.h>
+#include <sys/stat.h>
+#include <sys/types.h>
+#include <unistd.h>
 
+#include "utils/iface_mapper.h"
 #include "utils/log.h"
 #include "utils/uci_wrt.h"
-#include "utils/iface_mapper.h"
 
 static void test_uwrt_init_context(void **state) {
   (void)state;

--- a/tests/utils/test_utarray.c
+++ b/tests/utils/test_utarray.c
@@ -1,8 +1,8 @@
 #define _GNU_SOURCE
 
+#include <setjmp.h>
 #include <stdarg.h>
 #include <stddef.h>
-#include <setjmp.h>
 #include <stdint.h>
 #include <cmocka.h>
 

--- a/tests/utils/test_wrap_log_error.c
+++ b/tests/utils/test_wrap_log_error.c
@@ -1,6 +1,6 @@
+#include <setjmp.h>
 #include <stdarg.h>
 #include <stddef.h>
-#include <setjmp.h>
 #include <stdint.h>
 #include <cmocka.h>
 

--- a/tests/utils/tmpdir.c
+++ b/tests/utils/tmpdir.c
@@ -1,7 +1,7 @@
 #define _XOPEN_SOURCE 700 /* mkdtemp() is part of POSIX 700 spec*/
+#include <setjmp.h>
 #include <stdarg.h>
 #include <stddef.h>
-#include <setjmp.h>
 #include <stdint.h>
 #include <cmocka.h>
 // used to delete directory recursively

--- a/tests/utils/wrap_log_error.c
+++ b/tests/utils/wrap_log_error.c
@@ -1,6 +1,6 @@
+#include <setjmp.h>
 #include <stdarg.h>
 #include <stddef.h>
-#include <setjmp.h>
 #include <stdint.h>
 #include <cmocka.h>
 


### PR DESCRIPTION
This PR activates the `#include` sorting part of `clang-format`, since in C and C++, **compiling behaviour might change when `#include` order is changed** (e.g. `cmocka.h` must be `#include`-d after `<stdint.h>`