### PR TITLE
Fix wrong deb location for etc/edgesec/config.ini

### DIFF
--- a/CMakeModules/EdgesecInstallLocations.cmake
+++ b/CMakeModules/EdgesecInstallLocations.cmake
@@ -18,18 +18,19 @@ include(GNUInstallDirs)
 set(EDGESEC_bin_dir "${CMAKE_INSTALL_BINDIR}")
 set(EDGESEC_private_lib_dir "${CMAKE_INSTALL_LIBDIR}/${_project_lower}") # CACHE PATH "Directory of private EDGESec shared libs")
 set(EDGESEC_libexec_dir "${CMAKE_INSTALL_LIBEXECDIR}/${_project_lower}") # CACHE PATH "Directory of private EDGESec bins")
-set(EDGESEC_config_dir "${CMAKE_INSTALL_SYSCONFDIR}/${_project_lower}") # CACHE PATH "Directory of EDGESec config files")
+set(EDGESEC_SYSCONFDIR "${CMAKE_INSTALL_SYSCONFDIR}/${_project_lower}") # CACHE PATH "Directory of EDGESec config files")
 set(EDGESEC_log_dir "${CMAKE_INSTALL_LOCALSTATEDIR}/log/${_project_lower}") # CACHE PATH "Directory of EDGESec log files")
 set(EDGESEC_local_lib_dir "${CMAKE_INSTALL_LOCALSTATEDIR}/lib/${_project_lower}") # CACHE PATH "Directory of EDGESec persistant files (e.g. databases)")
 set(EDGESEC_runstate_dir "${CMAKE_INSTALL_RUNSTATEDIR}/${_project_lower}") # CACHE PATH "Directory of EDGESec run-state files (.pid and socket files)")
-set(EDGESEC_cert_location "${EDGESEC_config_dir}/CA/CA.pem") # CACHE FILEPATH "Path to edgesec certificate authority file")
+set(EDGESEC_cert_location "${EDGESEC_SYSCONFDIR}/CA/CA.pem") # CACHE FILEPATH "Path to edgesec certificate authority file")
 
 # Only needed for EDGESEC_full_bin_dir since CMAKE_FULL_INSTALL_BINDIR does not include DESTDIR
 # This is to add the actual path into config.ini
 
 # absolute paths! Required by config.ini
 # makes dirs like EDGESEC_full_libexec_dir
-foreach(dir in private_lib_dir libexec_dir config_dir log_dir local_lib_dir runstate_dir cert_location)
+foreach(dir in private_lib_dir libexec_dir SYSCONFDIR log_dir local_lib_dir runstate_dir cert_location)
+    # important, make sure `$dir` is exactly one of the special cases in https://cmake.org/cmake/help/latest/module/GNUInstallDirs.html#special-cases
     GNUInstallDirs_get_absolute_install_dir(
         EDGESEC_full_no_destdir_${dir} EDGESEC_${dir} ${dir}
     )

--- a/CMakeModules/EdgesecInstallLocations.cmake
+++ b/CMakeModules/EdgesecInstallLocations.cmake
@@ -4,6 +4,9 @@
 # so it can be used both during:
 # - configure step (e.g. cmake ..)
 # - install step (e.g. cmake --install ..)
+#
+# We can't use the default cmake `install()` syntax, since we need to know
+# the absolute paths to put as default vals in the `config.ini` file
 
 cmake_minimum_required(VERSION 3.7.0)
 
@@ -31,16 +34,12 @@ set(EDGESEC_cert_location "${EDGESEC_SYSCONFDIR}/CA/CA.pem") # CACHE FILEPATH "P
 # makes dirs like EDGESEC_full_libexec_dir
 foreach(dir in private_lib_dir libexec_dir SYSCONFDIR log_dir local_lib_dir runstate_dir cert_location)
     # important, make sure `$dir` is exactly one of the special cases in https://cmake.org/cmake/help/latest/module/GNUInstallDirs.html#special-cases
+    #
+    # DESTDIR is ignored.
+    # The install() command will automatically add $DESTDIR if needed,
+    # strings such as `config.ini`/`RPATH` should ignore `$DESTDIR`,
+    # see: https://www.gnu.org/prep/standards/html_node/DESTDIR.html
     GNUInstallDirs_get_absolute_install_dir(
-        EDGESEC_full_no_destdir_${dir} EDGESEC_${dir} ${dir}
+        EDGESEC_full_${dir} EDGESEC_${dir} ${dir}
     )
-    # FULL_PATH isn't actually always absolute due to destdir
-    set(with_destdir "$ENV{DESTDIR}${EDGESEC_full_no_destdir_${dir}}")
-    if (NOT IS_ABSOLUTE "${with_destdir}")
-        # make paths in config.ini absolute, so we can call them from different working dir
-        get_filename_component(with_destdir
-            "${with_destdir}"
-            ABSOLUTE)
-    endif()
-    set(EDGESEC_full_${dir} "${with_destdir}")
 endforeach()

--- a/CMakeModules/EdgesecInstallLocations.cmake
+++ b/CMakeModules/EdgesecInstallLocations.cmake
@@ -38,7 +38,7 @@ where ``path_name`` is one of:
   Directory of private EDGESec binaries/executables (``/usr/libexec/edgesec``)
   These are designed for use with EDGESec only, and may conflict with other OS
   binaries (e.g. ``hostapd``)
-``SYSCONFDIR``
+``config_dir``
   Directory of EDGESec config files, (``/etc/edgesec``)
 ``log_dir``
   Directory of EDGESec log files, (``/var/log/edgesec``)
@@ -75,7 +75,7 @@ _create_edgesec_path(private_lib_dir "${CMAKE_INSTALL_LIBDIR}/${_project_lower}"
 # Directory of private EDGESec binaries/executables
 _create_edgesec_path(libexec_dir "${CMAKE_INSTALL_LIBEXECDIR}/${_project_lower}" LIBEXECDIR)
 # Directory of EDGESec config files
-_create_edgesec_path(SYSCONFDIR "${CMAKE_INSTALL_SYSCONFDIR}/${_project_lower}" SYSCONFDIR)
+_create_edgesec_path(config_dir "${CMAKE_INSTALL_SYSCONFDIR}/${_project_lower}" SYSCONFDIR)
 # Directory of EDGESec log files
 _create_edgesec_path(log_dir "${CMAKE_INSTALL_LOCALSTATEDIR}/log/${_project_lower}" LOCALSTATEDIR)
 # Directory of EDGESec persistant files (e.g. databases)
@@ -83,4 +83,4 @@ _create_edgesec_path(local_lib_dir "${CMAKE_INSTALL_LOCALSTATEDIR}/lib/${_projec
 # Directory of EDGESec run-state files (.pid and socket files)
 _create_edgesec_path(runstate_dir "${CMAKE_INSTALL_RUNSTATEDIR}/${_project_lower}" RUNSTATEDIR)
 # Path to edgesec certificate authority file
-_create_edgesec_path(cert_location "${EDGESEC_SYSCONFDIR}/CA/CA.pem" SYSCONFDIR)
+_create_edgesec_path(cert_location "${EDGESEC_config_dir}/CA/CA.pem" SYSCONFDIR)

--- a/CMakeModules/InstallConfigFile.cmake
+++ b/CMakeModules/InstallConfigFile.cmake
@@ -33,5 +33,5 @@ foreach(required_var IN ITEMS CMAKE_INSTALL_PREFIX CMAKE_INSTALL_LIBDIR build_di
 endforeach()
 
 configure_file("config.ini.in" "${build_dir}/config.ini" ESCAPE_QUOTES @ONLY)
-# cannot use EDGESEC_full_config_dir, since that will add DESTDIR TWICE
-file(INSTALL "${build_dir}/config.ini" DESTINATION "${EDGESEC_full_no_destdir_config_dir}")
+# cannot use EDGESEC_full_SYSCONFDIR, since that will add DESTDIR TWICE
+file(INSTALL "${build_dir}/config.ini" DESTINATION "${EDGESEC_full_no_destdir_SYSCONFDIR}")

--- a/CMakeModules/InstallConfigFile.cmake
+++ b/CMakeModules/InstallConfigFile.cmake
@@ -33,4 +33,4 @@ foreach(required_var IN ITEMS CMAKE_INSTALL_PREFIX CMAKE_INSTALL_LIBDIR build_di
 endforeach()
 
 configure_file("config.ini.in" "${build_dir}/config.ini" ESCAPE_QUOTES @ONLY)
-file(INSTALL "${build_dir}/config.ini" DESTINATION "${EDGESEC_full_SYSCONFDIR}")
+file(INSTALL "${build_dir}/config.ini" DESTINATION "${EDGESEC_full_config_dir}")

--- a/CMakeModules/InstallConfigFile.cmake
+++ b/CMakeModules/InstallConfigFile.cmake
@@ -33,5 +33,4 @@ foreach(required_var IN ITEMS CMAKE_INSTALL_PREFIX CMAKE_INSTALL_LIBDIR build_di
 endforeach()
 
 configure_file("config.ini.in" "${build_dir}/config.ini" ESCAPE_QUOTES @ONLY)
-# cannot use EDGESEC_full_SYSCONFDIR, since that will add DESTDIR TWICE
-file(INSTALL "${build_dir}/config.ini" DESTINATION "${EDGESEC_full_no_destdir_SYSCONFDIR}")
+file(INSTALL "${build_dir}/config.ini" DESTINATION "${EDGESEC_full_SYSCONFDIR}")

--- a/config.ini.in
+++ b/config.ini.in
@@ -50,7 +50,7 @@ delim = 32
 
 [ap]
 apBinPath = "@EDGESEC_full_libexec_dir@/hostapd"
-apFilePath = "@EDGESEC_full_SYSCONFDIR@/hostapd.conf"
+apFilePath = "@EDGESEC_full_config_dir@/hostapd.conf"
 apLogPath = "@EDGESEC_full_log_dir@/hostapd.log"
 interface = "wlan1" # name of Wifi USB AP on Raspberry Pi
 device = "radio1"
@@ -68,7 +68,7 @@ rsnPairwise = "CCMP"
 ctrlInterface = "@EDGESEC_full_runstate_dir@/hostapd"
 macaddrAcl = 2
 dynamicVlan = 1
-vlanFile = "@EDGESEC_full_SYSCONFDIR@/hostapd.vlan"
+vlanFile = "@EDGESEC_full_config_dir@/hostapd.vlan"
 loggerStdout = -1
 loggerStdoutLevel = 0
 loggerSyslog = -1
@@ -100,8 +100,8 @@ mdnsFilter = "src net 10.0 and dst net 10.0"
 
 [dhcp]
 dhcpBinPath = "/usr/sbin/dnsmasq"
-dhcpConfigPath = "@EDGESEC_full_SYSCONFDIR@/dnsmasq.conf"
-dhcpScriptPath = "@EDGESEC_full_SYSCONFDIR@/dnsmasq_exec.sh"
+dhcpConfigPath = "@EDGESEC_full_config_dir@/dnsmasq.conf"
+dhcpScriptPath = "@EDGESEC_full_config_dir@/dnsmasq_exec.sh"
 dhcpLeasefilePath = "@EDGESEC_full_local_lib_dir@/db/dnsmasq.leases"
 dhcpRange0 = "0,10.0.0.2,10.0.0.254,255.255.255.0,24h"
 dhcpRange1 = "1,10.0.1.2,10.0.1.254,255.255.255.0,24h"

--- a/config.ini.in
+++ b/config.ini.in
@@ -50,7 +50,7 @@ delim = 32
 
 [ap]
 apBinPath = "@EDGESEC_full_libexec_dir@/hostapd"
-apFilePath = "@EDGESEC_full_config_dir@/hostapd.conf"
+apFilePath = "@EDGESEC_full_SYSCONFDIR@/hostapd.conf"
 apLogPath = "@EDGESEC_full_log_dir@/hostapd.log"
 interface = "wlan1" # name of Wifi USB AP on Raspberry Pi
 device = "radio1"
@@ -68,7 +68,7 @@ rsnPairwise = "CCMP"
 ctrlInterface = "@EDGESEC_full_runstate_dir@/hostapd"
 macaddrAcl = 2
 dynamicVlan = 1
-vlanFile = "@EDGESEC_full_config_dir@/hostapd.vlan"
+vlanFile = "@EDGESEC_full_SYSCONFDIR@/hostapd.vlan"
 loggerStdout = -1
 loggerStdoutLevel = 0
 loggerSyslog = -1
@@ -100,8 +100,8 @@ mdnsFilter = "src net 10.0 and dst net 10.0"
 
 [dhcp]
 dhcpBinPath = "/usr/sbin/dnsmasq"
-dhcpConfigPath = "@EDGESEC_full_config_dir@/dnsmasq.conf"
-dhcpScriptPath = "@EDGESEC_full_config_dir@/dnsmasq_exec.sh"
+dhcpConfigPath = "@EDGESEC_full_SYSCONFDIR@/dnsmasq.conf"
+dhcpScriptPath = "@EDGESEC_full_SYSCONFDIR@/dnsmasq_exec.sh"
 dhcpLeasefilePath = "@EDGESEC_full_local_lib_dir@/db/dnsmasq.leases"
 dhcpRange0 = "0,10.0.0.2,10.0.0.254,255.255.255.0,24h"
 dhcpRange1 = "1,10.0.1.2,10.0.1.254,255.255.255.0,24h"

--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,9 @@
+edgesec (0.9.9-alpha6) UNRELEASED; urgency=low
+
+  * Fixed missing `edgesec-common` `/etc/edgesec/config.ini` file
+
+ -- Alois Klink <alois@nquiringminds.com>  Fri, 22 Apr 2022 11:18:50 +0100
+
 edgesec (0.9.9-alpha5) UNRELEASED; urgency=low
 
   * Add `edgesec-mdnsf` package that creates the `mdnsf` executable.


### PR DESCRIPTION
Fixes a few bugs for the `config.ini` file in debian builds 

### [Fix wrong deb location for etc/edgesec/config.ini](https://github.com/nqminds/EDGESec/commit/8545709ac9bb506a1264f4c68fa8a100c49bc366)

Our config path was being installed as `/usr/etc/edgesec/config.ini`, when it should be `/etc/edgesec/config.ini`
(bug discovered in https://github.com/nqminds/EDGESec/pull/107)

This was because when calling the CMake macro, `GNUInstallDirs_get_absolute_install_dir`,
as we didn't specify it was a `SYSCONFDIR` (i.e. `/etc`), it automatically
prepended `usr/`, as stated in the CMake GNUInstallDirs special cases:
https://cmake.org/cmake/help/latest/module/GNUInstallDirs.html#special-cases

### [Remove extra $DESTDIR in some config.ini paths](https://github.com/nqminds/EDGESec/commit/7a275c55ebb77966e568a45eed6d5b77750e48e8)

According to the GNU coding standards,
the $DESTDIR environment variable should **NOT** be used
be stored in any file contents
https://www.gnu.org/prep/standards/html_node/DESTDIR.html

This was causing issues with the config.ini file in .deb builds.

```ini
# old wrong behaviour
apBinPath = "/build/edgesec-0.9.9-alpha.5/usr/libexec/edgesec/hostapd"
# new right behaviour
apBinPath = "/usr/libexec/edgesec/hostapd"
```

### [Remove /usr from .deb path following GNU rules](https://github.com/nqminds/EDGESec/commit/edd3824fd315c9843589ded466c131d7432dc755)

Some paths in config.ini weren't pointing to `/var/...`.
Instead, they were pointing to `/usr/var/...`, which goes against the GNU coding standards: https://www.gnu.org/prep/standards/html_node/Directory-Variables.html

This is because we weren't telling `GNUInstallDirs_get_absolute_install_dir` that these were `LOCALSTATEDIR`/`RUNSTATEDIR` paths.