### PR TITLE
Lock uci/ubox dependencies to specific git commit

### DIFF
--- a/lib/uci.cmake
+++ b/lib/uci.cmake
@@ -16,7 +16,7 @@ if (USE_UCI_SERVICE AND NOT (BUILD_ONLY_DOCS))
       FetchContent_Declare(
         libubox
         GIT_REPOSITORY https://git.openwrt.org/project/libubox.git
-        GIT_SHALLOW true
+        GIT_TAG f2d6752901f2f2d8612fb43e10061570c9198af1 # master as of 2022-02-10
         GIT_PROGRESS true
       )
       FetchContent_Populate(libubox)
@@ -48,7 +48,7 @@ if (USE_UCI_SERVICE AND NOT (BUILD_ONLY_DOCS))
       FetchContent_Declare(
         libuci
         GIT_REPOSITORY https://git.openwrt.org/project/uci.git
-        GIT_SHALLOW true
+        GIT_TAG f84f49f00fb70364f58b4cce72f1796a7190d370 # master as of 2021-10-22
         GIT_PROGRESS true
       )
       FetchContent_Populate(libuci)


### PR DESCRIPTION
Locks the libuci/lububox dependencies to a specific git commit.

This is to make repeatable builds, as any future commits in these repos won't change the behaviour.

Unfortunately, git still uses SHA1 hashes, so attacks such as SHAttered can still be used to do supply-side attacks, even with a commit hash.

I've disabled `GIT_SHALLOW`, since is not possible when `GIT_TAG` for a commit. However, I think these repos are pretty small, so it shouldn't take much longer to `git pull` everything.

GitWeb, which is what the OpenWRT repos use, supports `.tar.gz` downloads (https://git.openwrt.org/?p=project/libubox.git;a=snapshot;h=1087eaf77ae2f5e25d58b4550608f6c65de7d15d;sf=tgz), but they're built on demand, which means we can't use a URL_HASH to make sure that we're always downloading the same file.