### PR TITLE
Remove redundant CMake defines from debuild

### DIFF
--- a/debian/rules
+++ b/debian/rules
@@ -31,8 +31,6 @@ override_dh_auto_configure:
 		 -DBUILD_NL_LIB=ON\
 		 -DUSE_NETLINK_SERVICE=ON\
 		 -DUSE_UCI_SERVICE=OFF\
-		 -DUSE_PTHREAD_LIB=ON\
-		 -DUSE_M_LIB=ON\
 		 -DBUILD_HOSTAPD=ON\
 		 "-DLIB_MAKEFLAGS=--jobs=$(NUMJOBS)"
 


### PR DESCRIPTION
These are no longer used.