### PR TITLE
Ignore large redundant dirs in pdebuild

### DIFF
--- a/debian/source/local-options
+++ b/debian/source/local-options
@@ -1,0 +1,4 @@
+# Ignore the build/ directory, as otherwise compression takes forever (it can be 600 MB+)
+tar-ignore = "build"
+# Docusaurus directory might be 1 GiB+ with large node_modules
+tar-ignore = "docs/docusaurus"


### PR DESCRIPTION
The `build/` dir and `docs/docusaurus/` dir may be almost 2 GiB large in total (`build/` was 600 MiB on my PC, while `docs/docusaurus` was 1.1 GiB), so they should be ignored when creating a `tar.gz` file for a `.deb`

(especially since these are compressed using `gzip -9`, which is both slow, and single-threaded only)