### PR TITLE
CI improvements now that we're a public repo

### DIFF
--- a/.github/workflows/create-debs.yml
+++ b/.github/workflows/create-debs.yml
@@ -4,7 +4,6 @@ on:
       - created
       - edited # can remove once CI is confirmed working
   push:
-    branches: [ main ]
   pull_request:
     branches: [ main ]
 

--- a/.github/workflows/create-debs.yml
+++ b/.github/workflows/create-debs.yml
@@ -14,8 +14,8 @@ name: Build Debian Packages
 jobs:
   build:
     name: Build Debian Package
-    # building a deb is super slow, so do it on our self-hosted machines
-    runs-on: [self-hosted, linux]
+    # building a deb is super slow, but we're a public repo now, so it's free!!
+    runs-on: [ubuntu-20.04]
     strategy:
       matrix:
         architecture: [arm64, amd64]

--- a/.github/workflows/create-debs.yml
+++ b/.github/workflows/create-debs.yml
@@ -7,7 +7,7 @@ on:
     branches: [ main ]
   pull_request:
     branches: [ main ]
-  
+
 
 name: Build Debian Packages
 
@@ -62,9 +62,9 @@ jobs:
         uses: actions/upload-artifact@v2
         with:
           name: edgesec-built-debs
-          # only store .debs for one day to save space
+          # EDGESec is a public repo, so storage is free
           # we can always rerun action to regenerate them
-          retention-days: 1
+          retention-days: 7
           path: |
             /var/cache/pbuilder/result/*.deb
       - name: Upload debs as Release Assets
@@ -76,10 +76,10 @@ jobs:
           script: |
             const fs = require('fs').promises;
             const {basename} = require("path");
-            
+
             const globber = await glob.create("/var/cache/pbuilder/result/*.deb");
             const files = await globber.glob();
-            
+
             for (const filePath of files) {
               console.log(`Uploading ${filePath}`);
               const filePromise = fs.readFile(filePath);


### PR DESCRIPTION
Now that we're a public repo, GitHub Actions CI is now free, so we can increase some of our limits since we're not paying for it anymore.

This includes:
  - Boosting `.deb` artifact retention to 7 days
  - Running CI on GitHub's public runners.
    - Each run is slightly slower, but we get basically infinite runs in parallel. Plus, they're much more secure since they're not on our local virtual machines.
  - Since we get infinite runs in parallel, I've set up CI to run on every `git push`, not just when a PR should be merged.