### PR TITLE
Add `cmake-preset` for Linux

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -7,6 +7,11 @@ repos:
     -   id: trailing-whitespace
     -   id: end-of-file-fixer
     -   id: check-yaml
+    -   id: check-json
+        exclude: .vscode/ # vscode .json files have comments
+    -   id: pretty-format-json
+        files: CMakePresets.json
+        args: ['--no-sort-keys', '--autofix']
     -   id: check-added-large-files
     -   id: check-merge-conflict
     -   id: check-case-conflict # in case somebody is using Windows

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,5 +1,5 @@
-cmake_minimum_required(VERSION 3.11.0)
-# 3.11 required for FetchContent
+# required by FindMNL.cmake
+cmake_minimum_required(VERSION 3.13.0)
 
 option(CROSS_COMPILE_EDGESEC "Cross compile the EDGESec" ON)
 

--- a/CMakePresets.json
+++ b/CMakePresets.json
@@ -1,0 +1,61 @@
+{
+  "version": 3,
+  "cmakeMinimumRequired": {
+    "major": 3,
+    "minor": 13,
+    "patch": 0
+  },
+  "configurePresets": [
+    {
+      "name": "default",
+      "displayName": "Default Config",
+      "description": "Default build",
+      "binaryDir": "${sourceDir}/build/${presetName}",
+      "cacheVariables": {
+        "CMAKE_BUILD_TYPE": {
+          "type": "STRING",
+          "value": "Debug"
+        }
+      }
+    },
+    {
+      "name": "linux",
+      "inherits": "default",
+      "displayName": "Linux",
+      "description": "Default build for Linux (uses netlink)",
+      "cacheVariables": {
+        "CROSS_COMPILE_EDGESEC": false,
+        "BUILD_MNL_LIB": true,
+        "BUILD_NETLINK_LIB": true,
+        "BUILD_NL_LIB": true,
+        "USE_NETLINK_SERVICE": true,
+        "USE_UCI_SERVICE": false,
+        "BUILD_HOSTAPD": true,
+        "LIB_MAKEFLAGS": {
+          "type": "STRING",
+          "value": "-j$(shell nproc)"
+        }
+      }
+    }
+  ],
+  "buildPresets": [
+    {
+      "name": "default",
+      "configurePreset": "default"
+    },
+    {
+      "name": "linux",
+      "configurePreset": "linux"
+    }
+  ],
+  "testPresets": [
+    {
+      "name": "default",
+      "configurePreset": "default"
+    },
+    {
+      "name": "linux",
+      "configurePreset": "linux"
+    }
+  ]
+}

--- a/README.md
+++ b/README.md
@@ -1,9 +1,19 @@
 # EDGESec
+
 [![GitHub Pages](https://github.com/nqminds/EDGESec/actions/workflows/docs.yml/badge.svg)](https://github.com/nqminds/EDGESec/actions/workflows/docs.yml)
 [![Build Debian Packages](https://github.com/nqminds/EDGESec/actions/workflows/create-debs.yml/badge.svg)](https://github.com/nqminds/EDGESec/actions/workflows/create-debs.yml)
 
+EDGESec defines a new architecture and toolset for edge based routers addressing
+fundamental security weaknesses that impact current IP and IoT router implementations.
+
+For more information, please see the EDGESec website: [https://nqminds.github.io/EDGESec](https://nqminds.github.io/EDGESec/)
+
 ## EDGESec toolset documentation
 
-[https://nqminds.github.io/EDGESec](https://nqminds.github.io/EDGESec/)
+Website: <https://nqminds.github.io/EDGESec>
 
-This includes installation instructions at: [https://nqminds.github.io/EDGESec/docs/installation](https://nqminds.github.io/EDGESec/docs/installation)
+Quick links:
+
+- [Compile from source](https://nqminds.github.io/EDGESec/docs/compilation)
+- [Install (pre-built binaries)](https://nqminds.github.io/EDGESec/docs/installation]
+- [Supported Devices](https://nqminds.github.io/EDGESec/docs/devices)

--- a/docs/docusaurus/docs/compilation.md
+++ b/docs/docusaurus/docs/compilation.md
@@ -39,6 +39,16 @@ sudo apt install -y "${build_dependencies[@]}" "${runtime_dependencies[@]}"
 
 Compiling EDGESec is done with CMake.
 
+If you have CMake v3.22+, you can use the following `cmake-presets` to compile EDGESec:
+
+```bash
+cmake --preset linux # configure EDGESec for Linux
+cmake --build --preset linux -j4 # build EDGESec for Linux using 4 threads
+ctest --preset linux # test EDGESec for Linux
+```
+
+For older versions of CMake, or for manual configuration, please see the next headings for more details.
+
 ### Configure
 
 Configure `cmake` in the `build/` directory by running the following:


### PR DESCRIPTION
Currently, manually defining all the different EDGESec defines for each platform is quite complicated.

The new [cmake-presets](https://cmake.org/cmake/help/latest/manual/cmake-presets.7.html) feature in new versions of CMake makes this a lot easier, by allowing us to pre-define some presets.

Essentially, as long as you have CMake v3.22.0 or greater, you can do the following to configure/build/test easily:

```bash
cmake --preset linux # configure EDGESec for Linux in a ./build/linux folder
cmake --build --preset linux -j4 # build EDGESec for Linux using 4 threads
ctest --preset linux # test EDGESec for Linux
```