### PR TITLE
chore: remove nqm-ssh-tunnel as a git submodule

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,3 +1,0 @@
-[submodule "deployment/ssh/nqm-ssh-tunnel"]
-	path = deployment/ssh/nqm-ssh-tunnel
-	url = ../../nqminds/nqm-ssh-tunnel.git

--- a/deployment/first-boot/README.md
+++ b/deployment/first-boot/README.md
@@ -21,6 +21,9 @@ Make sure you have installed the following:
 Setup:
 
 ```bash
+# clone nqm-ssh-tunnel (private NQMinds Git repo)
+(cd ../ssh && git clone https://github.com/nqminds/nqm-ssh-tunnel)
+
 # required for machinectl
 sudo apt install systemd-container -y
 # create ~/edgesec-deploy-key.pem yourself!


### PR DESCRIPTION
[nqm-ssh-tunnel](https://github.com/nqminds/nqm-ssh-tunnel) is a private NQMinds Git repo, and having it as a git submodule is breaking code that expects EDGESec to be fully public (e.g. using OpenWRT SDK to build EDGESec)