### PR TITLE
build(ath79/generic): support ath79/generic

### DIFF
--- a/CMakeModules/CMakeToolchains/openwrt-21-ath79-generic.cmake
+++ b/CMakeModules/CMakeToolchains/openwrt-21-ath79-generic.cmake
@@ -1,0 +1,56 @@
+cmake_minimum_required(VERSION 3.9.0)
+
+set(CMAKE_SYSTEM_NAME               Linux) # OpenWRT
+set(CMAKE_SYSTEM_PROCESSOR          mips)
+
+# Without that flag CMake is not able to pass test compilation check
+set(CMAKE_TRY_COMPILE_TARGET_TYPE   STATIC_LIBRARY)
+
+# equivalent to $(TOPDIR) in OpenWRT Makefiles
+# downloaded from https://downloads.openwrt.org/releases/21.02.3/targets/ath79/generic
+if(NOT DEFINED openwrt_toolchain_location)
+    include(FetchContent)
+    # this is an awful way of doing this, is there not a better way, e.g. using a toolchain from "apt install?"
+    FetchContent_Declare(
+        openwrt_sdk_ath79_generic_21
+        URL https://downloads.openwrt.org/releases/21.02.3/targets/ath79/generic/openwrt-sdk-21.02.3-ath79-generic_gcc-8.4.0_musl.Linux-x86_64.tar.xz
+        # sha256 from https://downloads.openwrt.org/releases/21.02.3/targets/ath79/generic/sha256sums
+        URL_HASH SHA256=86fb6faa206e56c553538f438d16fe75476cc60c3b82413046a20a416479d8c6
+    )
+    FetchContent_Populate(openwrt_sdk_ath79_generic_21)
+    set(
+        openwrt_toolchain_location "${openwrt_sdk_ath79_generic_21_SOURCE_DIR}"
+        CACHE PATH "Path to OpenWRT SDK"
+    )
+endif(NOT DEFINED openwrt_toolchain_location)
+
+# Replace this if you download a newer version of the OpenWRT SDK
+set(gnu_target_name mips-openwrt-linux-musl)
+set(openwrt_toolchain_dir_name toolchain-mips_24kc_gcc-8.4.0_musl)
+set(openwrt_target_dir_name target-mips_24kc_musl)
+
+set(tools ${openwrt_toolchain_location}/staging_dir/${openwrt_toolchain_dir_name})
+set(CMAKE_SYSROOT ${openwrt_toolchain_location}/staging_dir/${openwrt_target_dir_name})
+set(CMAKE_STAGING_PREFIX "${CMAKE_SYSROOT}")
+set(ENV{STAGING_DIR} "${CMAKE_STAGING_PREFIX}")
+# need to add staging prefix to path, as dependencies use autoconf ./configure to find compilers
+set(ENV{PATH} "$ENV{PATH}:${tools}/bin")
+
+set(CMAKE_LIBRARY_ARCHITECTURE "${gnu_target_name}")
+
+set(CROSS_COMPILE_PREFIX ${tools}/bin/${gnu_target_name}-) # used by lib/openssl.cmake only
+
+set(CMAKE_AR                        ${tools}/bin/${gnu_target_name}-ar${CMAKE_EXECUTABLE_SUFFIX})
+set(CMAKE_ASM_COMPILER              ${tools}/bin/${gnu_target_name}-gcc${CMAKE_EXECUTABLE_SUFFIX})
+set(CMAKE_C_COMPILER                ${tools}/bin/${gnu_target_name}-gcc${CMAKE_EXECUTABLE_SUFFIX})
+set(CMAKE_CXX_COMPILER              ${tools}/bin/${gnu_target_name}-g++${CMAKE_EXECUTABLE_SUFFIX})
+set(CMAKE_LINKER                    ${tools}/bin/${gnu_target_name}-ld${CMAKE_EXECUTABLE_SUFFIX})
+set(CMAKE_OBJCOPY                   ${tools}/bin/${gnu_target_name}-objcopy${CMAKE_EXECUTABLE_SUFFIX} CACHE INTERNAL "")
+set(CMAKE_RANLIB                    ${tools}/bin/${gnu_target_name}-ranlib${CMAKE_EXECUTABLE_SUFFIX} CACHE INTERNAL "")
+set(CMAKE_SIZE                      ${tools}/bin/${gnu_target_name}-size${CMAKE_EXECUTABLE_SUFFIX} CACHE INTERNAL "")
+set(CMAKE_STRIP                     ${tools}/bin/${gnu_target_name}-strip${CMAKE_EXECUTABLE_SUFFIX} CACHE INTERNAL "")
+
+set(CMAKE_FIND_ROOT_PATH_MODE_PROGRAM NEVER)
+# we use custom find_library() commands, so we can't use ONLY
+set(CMAKE_FIND_ROOT_PATH_MODE_LIBRARY BOTH)
+set(CMAKE_FIND_ROOT_PATH_MODE_INCLUDE BOTH)

--- a/CMakeModules/CMakeToolchains/openwrt-ath79-generic.cmake
+++ b/CMakeModules/CMakeToolchains/openwrt-ath79-generic.cmake
@@ -1,0 +1,56 @@
+cmake_minimum_required(VERSION 3.9.0)
+
+set(CMAKE_SYSTEM_NAME               Linux) # OpenWRT
+set(CMAKE_SYSTEM_PROCESSOR          mips)
+
+# Without that flag CMake is not able to pass test compilation check
+set(CMAKE_TRY_COMPILE_TARGET_TYPE   STATIC_LIBRARY)
+
+# equivalent to $(TOPDIR) in OpenWRT Makefiles
+# downloaded from https://downloads.openwrt.org/releases/19.07.10/targets/ath79/generic/
+if(NOT DEFINED openwrt_toolchain_location)
+    include(FetchContent)
+    # this is an awful way of doing this, is there not a better way, e.g. using a toolchain from "apt install?"
+    FetchContent_Declare(
+        openwrt_sdk_ath79_generic
+        URL https://downloads.openwrt.org/releases/19.07.10/targets/ath79/generic/openwrt-sdk-19.07.10-ath79-generic_gcc-7.5.0_musl.Linux-x86_64.tar.xz
+        # sha256 from https://downloads.openwrt.org/releases/19.07.10/targets/ath79/generic/sha256sums
+        URL_HASH SHA256=aaf12a88e4ff4cb89ff3a6dae31ff9fc16e70f0e735ada892185f00129dc1cde
+    )
+    FetchContent_Populate(openwrt_sdk_ath79_generic)
+    set(
+        openwrt_toolchain_location "${openwrt_sdk_ath79_generic_SOURCE_DIR}"
+        CACHE PATH "Path to OpenWRT SDK"
+    )
+endif(NOT DEFINED openwrt_toolchain_location)
+
+# Replace this if you download a newer version of the OpenWRT SDK
+set(gnu_target_name mips-openwrt-linux-musl)
+set(openwrt_toolchain_dir_name toolchain-mips_24kc_gcc-7.5.0_musl)
+set(openwrt_target_dir_name target-mips_24kc_musl)
+
+set(tools ${openwrt_toolchain_location}/staging_dir/${openwrt_toolchain_dir_name})
+set(CMAKE_SYSROOT ${openwrt_toolchain_location}/staging_dir/${openwrt_target_dir_name})
+set(CMAKE_STAGING_PREFIX "${CMAKE_SYSROOT}")
+set(ENV{STAGING_DIR} "${CMAKE_STAGING_PREFIX}")
+# need to add staging prefix to path, as dependencies use autoconf ./configure to find compilers
+set(ENV{PATH} "$ENV{PATH}:${tools}/bin")
+
+set(CMAKE_LIBRARY_ARCHITECTURE "${gnu_target_name}")
+
+set(CROSS_COMPILE_PREFIX ${tools}/bin/${gnu_target_name}-) # used by lib/openssl.cmake only
+
+set(CMAKE_AR                        ${tools}/bin/${gnu_target_name}-ar${CMAKE_EXECUTABLE_SUFFIX})
+set(CMAKE_ASM_COMPILER              ${tools}/bin/${gnu_target_name}-gcc${CMAKE_EXECUTABLE_SUFFIX})
+set(CMAKE_C_COMPILER                ${tools}/bin/${gnu_target_name}-gcc${CMAKE_EXECUTABLE_SUFFIX})
+set(CMAKE_CXX_COMPILER              ${tools}/bin/${gnu_target_name}-g++${CMAKE_EXECUTABLE_SUFFIX})
+set(CMAKE_LINKER                    ${tools}/bin/${gnu_target_name}-ld${CMAKE_EXECUTABLE_SUFFIX})
+set(CMAKE_OBJCOPY                   ${tools}/bin/${gnu_target_name}-objcopy${CMAKE_EXECUTABLE_SUFFIX} CACHE INTERNAL "")
+set(CMAKE_RANLIB                    ${tools}/bin/${gnu_target_name}-ranlib${CMAKE_EXECUTABLE_SUFFIX} CACHE INTERNAL "")
+set(CMAKE_SIZE                      ${tools}/bin/${gnu_target_name}-size${CMAKE_EXECUTABLE_SUFFIX} CACHE INTERNAL "")
+set(CMAKE_STRIP                     ${tools}/bin/${gnu_target_name}-strip${CMAKE_EXECUTABLE_SUFFIX} CACHE INTERNAL "")
+
+set(CMAKE_FIND_ROOT_PATH_MODE_PROGRAM NEVER)
+# we use custom find_library() commands, so we can't use ONLY
+set(CMAKE_FIND_ROOT_PATH_MODE_LIBRARY BOTH)
+set(CMAKE_FIND_ROOT_PATH_MODE_INCLUDE BOTH)

--- a/CMakePresets.json
+++ b/CMakePresets.json
@@ -65,6 +65,18 @@
         "lhs": "${hostSystemName}",
         "rhs": "Linux"
       }
+    },
+    {
+      "name": "openwrt/ath79/generic",
+      "inherits": "openwrt/default",
+      "displayName": "OpenWRT ath79/generic",
+      "description": "OpenWRT ath79/generic (uses uci)",
+      "toolchainFile": "${sourceDir}/CMakeModules/CMakeToolchains/openwrt-ath79-generic.cmake",
+      "condition": {
+        "type": "equals",
+        "lhs": "${hostSystemName}",
+        "rhs": "Linux"
+      }
     }
   ],
   "buildPresets": [
@@ -83,6 +95,10 @@
     {
       "name": "openwrt/mvebu/cortexa9",
       "configurePreset": "openwrt/mvebu/cortexa9"
+    },
+    {
+      "name": "openwrt/ath79/generic",
+      "configurePreset": "openwrt/ath79/generic"
     }
   ],
   "testPresets": [

--- a/CMakePresets.json
+++ b/CMakePresets.json
@@ -77,6 +77,13 @@
         "lhs": "${hostSystemName}",
         "rhs": "Linux"
       }
+    },
+    {
+      "name": "openwrt-21/ath79/generic",
+      "inherits": "openwrt/ath79/generic",
+      "displayName": "OpenWRT ath79/generic OpenWRT 21",
+      "description": "OpenWRT ath79/generic OpenWRT 21 (uses uci)",
+      "toolchainFile": "${sourceDir}/CMakeModules/CMakeToolchains/openwrt-21-ath79-generic.cmake"
     }
   ],
   "buildPresets": [
@@ -99,6 +106,10 @@
     {
       "name": "openwrt/ath79/generic",
       "configurePreset": "openwrt/ath79/generic"
+    },
+    {
+      "name": "openwrt-21/ath79/generic",
+      "configurePreset": "openwrt-21/ath79/generic"
     }
   ],
   "testPresets": [


### PR DESCRIPTION
Add support for compiling for ath79/generic on OpenWRT 19.07.10

Try it out with `cmake --preset openwrt/ath79/generic` and `cmake --build -j4 --preset openwrt/ath79/generic`

The https://openwrt.org/toh/hwdata/tp-link/tp-link_eap225-outdoor_v1 is not currently supported, as it requires at least OpenWRT 21.02.

I'm currently trying to download the OpenWRT 21.02 SDK, but the office internet is slow, so it's going to take a while.