### PR TITLE
ci: builds `--prefix linux` and `--prefix openwrt/mvebu/cortexa9` using GitHub Actions

### DIFF
--- a/.github/workflows/create-debs.yml
+++ b/.github/workflows/create-debs.yml
@@ -7,11 +7,63 @@ on:
   pull_request:
     branches: [ main ]
 
-
-name: Build Debian Packages
+name: Build
 
 jobs:
   build:
+    name: Compile Locally
+    strategy:
+      matrix:
+        cmake-preset: [linux, openwrt/mvebu/cortexa9]
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v2
+      - name: Install Dependencies
+        shell: bash # we're using bash arrays here
+        run: |
+          build_dependencies=(
+            cmake # build-tool
+            git # required to download dependencies
+            ca-certificates # required for git+https downloads
+            doxygen texinfo graphviz # documentation
+            build-essential # C and C++ compilers
+            libnl-genl-3-dev libnl-route-3-dev # netlink dependencies
+            autopoint gettext # required by libuuid
+            autoconf # required by compile_sqlite.sh
+            libtool-bin # required by autoconf somewhere
+            pkg-config # seems to be required by nDPI
+            libjson-c-dev # mystery requirement
+            flex bison # required by pcap
+            libssl-dev # required by hostapd only. We compile OpenSSL 3 for EDGESec
+            libcmocka-dev # cmocka, can be removed if -DBUILD_CMOCKA_LIB=ON
+            libmnl-dev # libmnl, can be removed if -DBUILD_LIBMNL_LIB=ON
+          )
+          sudo apt install -y "${build_dependencies[@]}"
+      - name: Configure
+        run: |
+          cmake -B build/ --preset "${{ matrix.cmake-preset }}"
+      - name: Build
+        run: |
+          cmake --build build/ --jobs="$(nproc)" --preset "${{ matrix.cmake-preset }}"
+      - name: Test
+        run: |
+          if ctest --list-presets | grep -s "${{ matrix.cmake-preset }}"; then
+            ctest --test-dir build/ --preset "${{ matrix.cmake-preset }}"
+          fi
+      - name: Install to ${{ runner.temp }}/edgesec-${{ matrix.cmake-preset }}/
+        run: |
+          cmake --install build/ "${{ runner.temp }}/edgesec-${{ matrix.cmake-preset }}"
+      - name: Archive Install Output
+        uses: actions/upload-artifact@v2
+        with:
+          name: edgesec-built-lib-"${{ matrix.cmake-preset }}"
+          # EDGESec is a public repo, so storage is free
+          # we can always rerun action to regenerate them
+          retention-days: 7
+          path: |
+            ${{ runner.temp }}/edgesec-${{ matrix.cmake-preset }}/
+  build-deb:
     name: Build Debian Package
     # building a deb is super slow, but we're a public repo now, so it's free!!
     runs-on: [ubuntu-20.04]

--- a/.github/workflows/create-debs.yml
+++ b/.github/workflows/create-debs.yml
@@ -45,7 +45,8 @@ jobs:
           cmake -B build/ --preset "${{ matrix.cmake-preset }}"
       - name: Build
         run: |
-          cmake --build build/ --jobs="$(nproc)" --preset "${{ matrix.cmake-preset }}"
+          # can't use --preset "${{ matrix.cmake-preset }}" since we want to specify a custom build dir
+          cmake --build build/ --jobs="$(nproc)"
       - name: Test
         run: |
           if ctest --list-presets | grep -s "${{ matrix.cmake-preset }}"; then

--- a/.github/workflows/create-debs.yml
+++ b/.github/workflows/create-debs.yml
@@ -58,7 +58,7 @@ jobs:
       - name: Archive Install Output
         uses: actions/upload-artifact@v2
         with:
-          name: edgesec-built-lib-"${{ matrix.cmake-preset }}"
+          name: edgesec-build-${{ matrix.cmake-preset }}
           # EDGESec is a public repo, so storage is free
           # we can always rerun action to regenerate them
           retention-days: 7

--- a/.github/workflows/create-debs.yml
+++ b/.github/workflows/create-debs.yml
@@ -54,7 +54,7 @@ jobs:
           fi
       - name: Install to ${{ runner.temp }}/edgesec-${{ matrix.cmake-preset }}/
         run: |
-          cmake --install build/ "${{ runner.temp }}/edgesec-${{ matrix.cmake-preset }}"
+          cmake --install build/ --prefix "${{ runner.temp }}/edgesec-${{ matrix.cmake-preset }}"
       - name: Archive Install Output
         uses: actions/upload-artifact@v2
         with:

--- a/.github/workflows/create-debs.yml
+++ b/.github/workflows/create-debs.yml
@@ -46,7 +46,7 @@ jobs:
       - name: Build
         run: |
           # can't use --preset "${{ matrix.cmake-preset }}" since we want to specify a custom build dir
-          cmake --build build/ --jobs="$(nproc)"
+          cmake --build build/ --jobs="$(($(nproc) + 1))"
       - name: Test
         run: |
           if ctest --list-presets | grep -s "${{ matrix.cmake-preset }}"; then

--- a/.github/workflows/create-debs.yml
+++ b/.github/workflows/create-debs.yml
@@ -55,10 +55,17 @@ jobs:
       - name: Install to ${{ runner.temp }}/edgesec-${{ matrix.cmake-preset }}/
         run: |
           cmake --install build/ --prefix "${{ runner.temp }}/edgesec-${{ matrix.cmake-preset }}"
+      - name: Escape invalid chars in artifact name
+        id: escape_preset
+        run: |
+          preset='${{ matrix.cmake-preset }}'
+          # replace `/` with `-`
+          escaped_preset="${preset////-}"
+          echo "::set-output name=ESCAPED_CMAKE_PRESET::${escaped_preset}"
       - name: Archive Install Output
         uses: actions/upload-artifact@v2
         with:
-          name: edgesec-build-${{ matrix.cmake-preset }}
+          name: edgesec-build-${{ steps.escape_preset.outputs.ESCAPED_CMAKE_PRESET }}
           # EDGESec is a public repo, so storage is free
           # we can always rerun action to regenerate them
           retention-days: 7

--- a/.github/workflows/create-debs.yml
+++ b/.github/workflows/create-debs.yml
@@ -46,7 +46,7 @@ jobs:
       - name: Build
         run: |
           # can't use --preset "${{ matrix.cmake-preset }}" since we want to specify a custom build dir
-          cmake --build build/ --jobs="$(($(nproc) + 1))"
+          cmake --build build/ --parallel "$(($(nproc) + 1))"
       - name: Test
         run: |
           if ctest --list-presets | grep -s "${{ matrix.cmake-preset }}"; then


### PR DESCRIPTION
Builds `cmake --prefix linux` and `cmake --prefix openwrt/mvebu/cortexa9` using GitHub Actions.

This should hopefully catch any errors where we accidentally break Linux or OpenWRT suppot.

The output of the build is uploaded to GitHub Actions (stored for one week) as a temporary build artifact 
![image](https://user-images.githubusercontent.com/19716675/169992645-a1eccb05-6bf5-4482-85eb-7adddd065616.png)
