### PR TITLE
docs: improve Ubuntu/Debian dependency docs

### DIFF
--- a/docs/docusaurus/docs/compilation.md
+++ b/docs/docusaurus/docs/compilation.md
@@ -7,32 +7,15 @@ The codebase can be clone from the Github [repo](https://github.com/nqminds/edge
 
 ## Dependencies
 
-On Ubuntu, we need a C compiler, CMake, Doxygen, and libnl libraries:
+On Debian/Ubuntu, build dependencies are listed in the
+[`debian/control`](https://github.com/nqminds/EDGESec/blob/main/debian/control) file.
+
+You can use [`mk-build-deps`](https://manpages.ubuntu.com/manpages/focal/man1/mk-build-deps.1.html)
+to automatically install these build-dependencies.
 
 ```bash
-sudo apt update
-build_dependencies=(
-    cmake # build-tool
-    git # required to download dependencies
-    ca-certificates # required for git+https downloads
-    doxygen texinfo graphviz # documentation
-    build-essential # C and C++ compilers
-    libnl-genl-3-dev libnl-route-3-dev # netlink dependencies
-    autopoint gettext # required by libuuid
-    autoconf # required by compile_sqlite.sh
-    libtool-bin # required by autoconf somewhere
-    pkg-config # seems to be required by nDPI
-    libjson-c-dev # mystery requirement
-    flex bison # required by pcap
-    libssl-dev # required by hostapd only. We compile OpenSSL 3 for EDGESec
-    libcmocka-dev # cmocka, can be removed if -DBUILD_CMOCKA_LIB=ON
-    libmnl-dev # libmnl, can be removed if -DBUILD_LIBMNL_LIB=ON
-)
-runtime_dependencies=(
-    dnsmasq
-    jq # required by predictable wifi name script
-)
-sudo apt install -y "${build_dependencies[@]}" "${runtime_dependencies[@]}"
+sudo apt install devscripts # install mk-build-depends
+sudo mk-build-deps --install debian/control
 ```
 
 ## Compile & Build


### PR DESCRIPTION
Instead of duplicating the documentation for Ubuntu/Debian compilation dependencies, we can just use [`mk-build-deps`](https://manpages.ubuntu.com/manpages/focal/man1/mk-build-deps.1.html) to automatically install the dependencies listed in `debian/control`.