### PR TITLE
Compile `hostapd` in compile step

### DIFF
--- a/lib/hostap/hostapd/.config.in
+++ b/lib/hostap/hostapd/.config.in
@@ -1,13 +1,8 @@
 # Example hostapd build time configuration
 #
-# This file lists the configuration options that are used when building the
-# hostapd binary. All lines starting with # are ignored. Configuration option
-# lines must be commented out complete, if they are not to be included, i.e.,
-# just setting VARIABLE=n is not disabling that variable.
-#
-# This file is included in Makefile, so variables like CFLAGS and LIBS can also
-# be modified from here. In most cass, these lines should use += in order not
-# to override previous values of the variables.
+# Automatically generated from CMake.
+CC="@CMAKE_C_COMPILER@"
+PKG_CONFIG="@PKG_CONFIG_EXECUTABLE@"
 
 # Driver interface for Host AP driver
 CONFIG_DRIVER_HOSTAP=y

--- a/lib/hostapd.cmake
+++ b/lib/hostapd.cmake
@@ -1,24 +1,21 @@
-# Find the hostapd program
+# Builds hostapd using ExternalProject
+
+# v3.14.0+ is required by BUILD_IN_SOURCE + SOURCE_SUBDIR together
+cmake_minimum_required(VERSION 3.14.0)
+include(ExternalProject)
+
 if (BUILD_HOSTAPD AND NOT (BUILD_ONLY_DOCS))
-  set(HOSTAPD_SOURCE_DIR "${CMAKE_SOURCE_DIR}/lib/hostap/hostapd")
+  set(HOSTAPD_SOURCE_DIR "${CMAKE_SOURCE_DIR}/lib/hostap")
   set(HOSTAPD_INSTALL_DIR "${CMAKE_CURRENT_BINARY_DIR}")
-  find_program(HOSTAPD NAMES hostapd PATHS "${HOSTAPD_INSTALL_DIR}" NO_DEFAULT_PATH)
-  if (HOSTAPD)
-    message("Found hostapd program: ${HOSTAPD}")
-  ELSE ()
-    message("Building hostapd...")
-    execute_process(
-      COMMAND make
-      WORKING_DIRECTORY "${HOSTAPD_SOURCE_DIR}"
-    )
-    execute_process(
-      COMMAND cp ./hostapd "${HOSTAPD_INSTALL_DIR}"
-      WORKING_DIRECTORY "${HOSTAPD_SOURCE_DIR}"
-    )
-    execute_process(
-      COMMAND make clean
-      WORKING_DIRECTORY "${HOSTAPD_SOURCE_DIR}"
-    )
-    find_program(HOSTAPD NAMES hostapd PATHS "${HOSTAPD_INSTALL_DIR}" NO_DEFAULT_PATH)
-  endif ()
+
+  ExternalProject_Add(
+    hostapd_externalproject
+    URL "${HOSTAPD_SOURCE_DIR}"
+    INSTALL_DIR "${HOSTAPD_INSTALL_DIR}"
+    BUILD_IN_SOURCE true
+    SOURCE_SUBDIR "hostapd" # we only care about hostapd, not the entire hostap dir
+    CONFIGURE_COMMAND "" # no configure command
+    INSTALL_COMMAND cmake -E copy <BINARY_DIR>/hostapd <INSTALL_DIR>/hostapd
+  )
+  set(HOSTAPD "${HOSTAPD_INSTALL_DIR}/hostapd")
 endif ()

--- a/lib/hostapd.cmake
+++ b/lib/hostapd.cmake
@@ -8,6 +8,14 @@ if (BUILD_HOSTAPD AND NOT (BUILD_ONLY_DOCS))
   set(HOSTAPD_SOURCE_DIR "${CMAKE_SOURCE_DIR}/lib/hostap")
   set(HOSTAPD_INSTALL_DIR "${CMAKE_CURRENT_BINARY_DIR}")
 
+  if (CMAKE_CROSSCOMPILING)
+    message(
+      FATAL_ERROR
+      "hostapd.cmake currently does not support cross-compiling. "
+      "Please disable BUILD_HOSTAPD in your cmake config to skip compiling hostapd."
+    )
+  endif()
+
   ExternalProject_Add(
     hostapd_externalproject
     URL "${HOSTAPD_SOURCE_DIR}"


### PR DESCRIPTION
Compiles `hostapd` in the compile step using `ExternalProject_Add`.

Hostapd was one of the major things slowing down the `cmake` configure step, since it uses an older make system that does not parallelise well.

Moving it into the build step means we can compile other libraries at the same time.

Side-note, I realised that `hostapd` didn't have any cross-compiling stuff built-in, so I set up some basic cross-compiling. I'm guessing we'd normally always use `hostapd` from `apt` or from `openwrt`, so it's not too important that `hostapd` works?