### PR TITLE
build: fix cmake library definitions

### DIFF
--- a/src/ap/CMakeLists.txt
+++ b/src/ap/CMakeLists.txt
@@ -2,6 +2,9 @@ include_directories (
   "${EDGESEC_SOURCE_DIR}/src"
 )
 
+add_library(ap_config INTERFACE) # header-only library
+target_link_libraries(ap_config INTERFACE allocs os radius_server)
+
 add_library(hostapd hostapd.c)
 if (USE_UCI_SERVICE)
   target_link_libraries(hostapd PRIVATE log os iface OpenWRT::UCI)

--- a/src/capture/CMakeLists.txt
+++ b/src/capture/CMakeLists.txt
@@ -12,6 +12,9 @@ if (USE_CAPTURE_SERVICE)
     "${PROJECT_BINARY_DIR}/middlewares.h"
   )
 
+  add_library(capture_config INTERFACE) # header only library
+  target_link_libraries(capture_config INTERFACE os)
+
   add_library(pcap_service pcap_service.c)
   target_link_libraries(pcap_service PRIVATE net log os PCAP::pcap)
 

--- a/src/dns/CMakeLists.txt
+++ b/src/dns/CMakeLists.txt
@@ -5,11 +5,15 @@ include_directories (
 add_library(command_mapper command_mapper.c)
 target_link_libraries(command_mapper PRIVATE os hash)
 
+# header-only library
+add_library(dns_config INTERFACE)
+target_link_libraries(dns_config INTERFACE utarray capture_config)
+
 add_library(mdns_list mdns_list.c)
 target_link_libraries(mdns_list PRIVATE os)
 
 add_library(mdns_mapper mdns_mapper.c)
-target_link_libraries(mdns_mapper PRIVATE mdns_list os)
+target_link_libraries(mdns_mapper PUBLIC mdns_decoder mdns_list os)
 
 add_library(mcast mcast.c)
 target_link_libraries(mcast PRIVATE os)
@@ -19,4 +23,9 @@ target_link_libraries(reflection_list PRIVATE os log)
 
 add_library(mdns_service mdns_service.c)
 target_include_directories(mdns_service PRIVATE SQLite::SQLite3)
-target_link_libraries(mdns_service PRIVATE iface_mapper packet_queue mdns_mapper PRIVATE command_mapper pcap_service reflection_list mcast mdns_decoder domain eloop squeue ifaceu net os log hashmap)
+target_link_libraries(mdns_service
+  PUBLIC dns_config reflection_list mdns_mapper command_mapper
+  PRIVATE
+    uthash ifaceu net log eloop domain squeue hashmap iface_mapper mdns_decoder
+    pcap_service packet_queue supervisor_config cmd_processor mcast
+)

--- a/src/dns/mdns_service.c
+++ b/src/dns/mdns_service.c
@@ -54,7 +54,6 @@
 #include "../supervisor/cmd_processor.h"
 
 #include "mdns_service.h"
-#include "reflection_list.h"
 #include "mcast.h"
 
 #define MDNS_PORT 5353

--- a/src/supervisor/CMakeLists.txt
+++ b/src/supervisor/CMakeLists.txt
@@ -15,11 +15,13 @@ add_library(sqlite_macconn_writer sqlite_macconn_writer.c)
 target_link_libraries(sqlite_macconn_writer PRIVATE sqliteu squeue log os SQLite::SQLite3)
 
 add_library(network_commands network_commands.c)
+target_link_libraries(network_commands
+  PUBLIC supervisor_config
+  PRIVATE capture_service dhcp_service ap_service sqlite_macconn_writer mac_mapper eloop firewall_service base64 net log os
+)
 if (USE_CRYPTO_SERVICE)
-  target_link_libraries(network_commands PRIVATE dhcp_service ap_service crypt_service sqlite_macconn_writer mac_mapper eloop firewall_service base64 net log os)
-else ()
-  target_link_libraries(network_commands PRIVATE dhcp_service ap_service sqlite_macconn_writer mac_mapper eloop firewall_service base64 net log os)
-endif ()
+  target_link_libraries(network_commands PRIVATE crypt_service)
+endif()
 
 if (USE_CRYPTO_SERVICE)
   add_library(crypt_commands crypt_commands.c)
@@ -27,7 +29,14 @@ if (USE_CRYPTO_SERVICE)
 endif ()
 
 add_library(system_commands system_commands.c)
-target_link_libraries(system_commands PRIVATE subscriber_events ap_service sqlite_macconn_writer mac_mapper eloop firewall_service iface_mapper base64 log os)
+target_link_libraries(system_commands
+  PUBLIC domain supervisor_config
+  PRIVATE
+    mac_mapper supervisor sqlite_macconn_writer network_commands subscriber_events
+    ap_config ap_service #../ap/*
+    capture_service #../capture/*
+    allocs os log base64 eloop domain utarray iface_mapper #../utils/*
+)
 
 add_library(cmd_processor cmd_processor.c)
 target_include_directories(cmd_processor PUBLIC ${LIBSQLITE_INCLUDE_DIR})

--- a/src/utils/CMakeLists.txt
+++ b/src/utils/CMakeLists.txt
@@ -64,3 +64,7 @@ target_link_libraries(sqliteu PUBLIC SQLite::SQLite3 PRIVATE log os)
 
 add_library(domain domain.c)
 target_link_libraries(domain PRIVATE log os)
+
+add_library(utarray INTERFACE) # header only lib
+add_library(uthash INTERFACE) # header only lib
+target_link_libraries(utarray INTERFACE allocs)

--- a/tests/supervisor/CMakeLists.txt
+++ b/tests/supervisor/CMakeLists.txt
@@ -57,11 +57,6 @@ set_tests_properties(test_mac_mapper
   PROPERTIES
   WILL_FAIL FALSE)
 
-add_test(NAME test_sqlite_fingerprint_writer COMMAND test_sqlite_fingerprint_writer)
-set_tests_properties(test_sqlite_fingerprint_writer
-  PROPERTIES
-  WILL_FAIL FALSE)
-
 add_test(NAME test_sqlite_macconn_writer COMMAND test_sqlite_macconn_writer)
 set_tests_properties(test_sqlite_macconn_writer
   PROPERTIES


### PR DESCRIPTION
Adds missing CMake library definitions.

I've added a CMake definition for some header-only libraries too, like ap_config.h and capture_config.h, as since they require utils/os.h, they need to link to the os.c lib.