### PR TITLE
Add copyright info for `src/utils` and `src/radius`

### DIFF
--- a/debian/copyright
+++ b/debian/copyright
@@ -19,14 +19,116 @@ Copyright: 2000-2022 Kitware, Inc. and Contributors
 License: BSD-3-clause
 Source: https://gitlab.kitware.com/cmake/cmake/-/blob/master/Source/Modules/FindLibUUID.cmake
 
-Files: lib/mnl-*/*
-Copyright: 2010-2021, Pablo Neira Ayuso <pablo@netfilter.org>
-           2010-2021, other contributing authors
-License: LGPL-2.1+
-
 Files: lib/netlink/*
 Copyright: 2010, see individual files for details
 License: GPL-2+
+
+Files: src/radius/md5.* src/radius/md5_internal.*
+Copyright: 2003-2005, Jouni Malinen <j@w1.fi>
+License: BSD-3-clause
+
+Files: src/radius/radius.* src/radius/radius_server.* src/radius/wpabuf.*
+Copyright: 2002-2019, Jouni Malinen <j@w1.fi>
+           2021-2022, NquiringMinds Ltd.
+License: BSD-3-clause
+
+Files: src/utils/eloop.*
+Copyright: 2002-2006, Jouni Malinen <j@w1.fi>
+           2022, NquiringMinds Ltd.
+License: BSD-3-clause
+
+Files: src/utils/log.*
+Copyright: 2017, rxi
+           2021-2022, NquiringMinds Ltd.
+License: Expat
+
+Files: src/utils/minIni.* src/utils/minGlue.h
+Copyright: 2008-2017, CompuPhase
+License: Apache-2.0
+
+Files: src/utils/nl80211.h
+Copyright: 2006-2010, Johannes Berg <johannes@sipsolutions.net>
+           2008, Michael Wu <flamingice@sourmilk.net>
+           2008, Luis Carlos Cobo <luisca@cozybit.com>
+           2008, Michael Buesch <m@bues.ch>
+           2008,, 2009 Luis R. Rodriguez <lrodriguez@atheros.com>
+           2008, Jouni Malinen <jouni.malinen@atheros.com>
+           2008, Colin McCabe <colin@cozybit.com>
+           2015-2017,	Intel Deutschland GmbH
+           2018-2019, Intel Corporation
+License: ISC
+
+Files: src/utils/utarray.h src/utils/uthash.h
+Copyright: 2003-2018, Troy D. Hanson
+License: BSD-1-Clause
+
+License: BSD-1-Clause
+ Redistribution and use in source and binary forms, with or without
+ modification, are permitted provided that the following conditions are met:
+
+     * Redistributions of source code must retain the above copyright
+       notice, this list of conditions and the following disclaimer.
+
+ THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS
+ IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED
+ TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A
+ PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER
+ OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,
+ EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
+ PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR
+ PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF
+ LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING
+ NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+ SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+License: ISC
+ Permission to use, copy, modify, and /or distribute this software for any
+ purpose with or without fee is hereby granted, provided that the above
+ copyright notice and this permission notice appear in all copies.
+
+ THE SOFTWARE IS PROVIDED "AS IS" AND THE AUTHOR DISCLAIMS ALL WARRANTIES
+ WITH REGARD TO THIS SOFTWARE INCLUDING ALL IMPLIED WARRANTIES OF
+ MERCHANTABILITY AND FITNESS. IN NO EVENT SHALL THE AUTHOR BE LIABLE FOR
+ ANY SPECIAL, DIRECT, INDIRECT, OR CONSEQUENTIAL DAMAGES OR ANY DAMAGES
+ WHATSOEVER RESULTING FROM LOSS OF USE, DATA OR PROFITS, WHETHER IN AN
+ ACTION OF CONTRACT, NEGLIGENCE OR OTHER TORTIOUS ACTION, ARISING OUT OF
+ OR IN CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.
+
+License: Apache-2
+ Licensed under the Apache License, Version 2.0 (the "License");
+ you may not use this file except in compliance with the License.
+ You may obtain a copy of the License at
+
+ http://www.apache.org/licenses/LICENSE-2.0
+
+ Unless required by applicable law or agreed to in writing, software
+ distributed under the License is distributed on an "AS IS" BASIS,
+ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ See the License for the specific language governing permissions and
+ limitations under the License.
+
+ On Debian systems, the full text of the Apache 2.0 License can be found in
+ the file `/usr/share/common-licenses/Apache-2.0'.
+
+License: Expat
+ Permission is hereby granted, free of charge, to any person obtaining
+ a copy of this software and associated documentation files (the
+ "Software"), to deal in the Software without restriction, including
+ without limitation the rights to use, copy, modify, merge, publish,
+ distribute, sublicense, and/or sell copies of the Software, and to
+ permit persons to whom the Software is furnished to do so, subject to
+ the following conditions:
+
+ The above copyright notice and this permission notice shall be included
+ in all copies or substantial portions of the Software.
+
+ THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+ EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+ MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.
+ IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY
+ CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT,
+ TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE
+ SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 
 License: BSD-3-clause
  Redistribution and use in source and binary forms, with or without


### PR DESCRIPTION
Adds copyright info and licensing info from files in `src/utils` and `src/radius`.