### PR TITLE
Fix process sign blob cmd typo

### DIFF
--- a/src/supervisor/CMakeLists.txt
+++ b/src/supervisor/CMakeLists.txt
@@ -44,10 +44,10 @@ target_link_libraries(system_commands
 
 add_library(cmd_processor cmd_processor.c)
 target_link_libraries(cmd_processor
-  PUBLIC utarray domain supervisor_config
+  PUBLIC utarray supervisor_config
   PRIVATE
     mac_mapper network_commands system_commands
-    allocs os log net base64 utarray domain # the ./utils/
+    allocs os log net base64 utarray # the ./utils/
 )
 if (USE_CRYPTO_SERVICE)
   target_link_libraries(cmd_processor PRIVATE crypt_commands)

--- a/src/supervisor/cmd_processor.c
+++ b/src/supervisor/cmd_processor.c
@@ -950,7 +950,7 @@ ssize_t process_sign_blob_cmd(int sock, struct client_address *client_addr,
     if (ptr != NULL && *ptr != NULL) {
       if (strlen(*ptr)) {
         if ((signed_str = sign_blob_cmd(context, keyid, *ptr)) != NULL) {
-          ret = write_newline_socket_data(sock, signed_str, client_address);
+          ret = write_newline_socket_data(sock, signed_str, client_addr);
           os_free(keyid);
           os_free(signed_str);
           return ret;


### PR DESCRIPTION
Minor typo fix for the compile errors on the `main` branch, see errors https://github.com/nqminds/EDGESec/runs/6902926349?check_suite_focus=true

It looks like there are also tests that are broken, as sending `OK\n` now adds a newline and sends `OK\n\n`, but that can always be fixed later :) 
