### PR TITLE
Fix failing `cmd_processor` tests

### DIFF
--- a/src/supervisor/cmd_processor.h
+++ b/src/supervisor/cmd_processor.h
@@ -313,7 +313,9 @@ ssize_t process_query_fingerprint_cmd(int sock,
  * @param client_addr The client address for replies
  * @param context The supervisor structure instance
  * @param cmd_arr The array of received commands
- * @return ssize_t Size of reply written data
+ * @return Size of reply written data.
+ * This would be the length of the passphrase.
+ * Returns `strlen(FAIL_REPLY)` on error.
  */
 ssize_t process_register_ticket_cmd(int sock,
                                     struct client_address *client_addr,

--- a/src/supervisor/crypt_commands.h
+++ b/src/supervisor/crypt_commands.h
@@ -42,9 +42,13 @@ int put_crypt_cmd(struct supervisor_context *context, char *key, char *value);
 /**
  * @brief GET_CRYPT command
  *
- * @param context The supervisor structure instance
- * @param key The crypt key
- * @param value The crypt output value
+ * Sets `value` to point new string containing the crypt output value.
+ * Please remember to `os_free()` the `value` when you're finished with using
+ * it.
+ *
+ * @param[in] context The supervisor structure instance
+ * @param[in] key The crypt key
+ * @param[out] value Pointer to crypt output value
  * @return 0 on success, -1 on failure
  */
 int get_crypt_cmd(struct supervisor_context *context, char *key, char **value);

--- a/src/utils/os.c
+++ b/src/utils/os.c
@@ -1362,20 +1362,25 @@ int get_commands_paths(char *commands[], UT_array *bin_path_arr,
   return 0;
 }
 
-char *string_append_char(char *str, char character) {
-  char *appended = NULL;
-
+char *string_append_char(const char *str, char character) {
   if (str == NULL) {
     log_error("str param is NULL");
     return NULL;
   }
+  size_t str_len = strlen(str);
 
-  if ((appended = os_zalloc(strlen(str) + 2)) == NULL) {
+  char *appended = os_malloc(str_len + 2);
+  if (appended == NULL) {
     log_errno("os_zalloc");
     return NULL;
   }
 
-  sprintf(appended, "%s%c", str, character);
+  // first copy the str, without NULL terminator
+  memcpy(appended, str, str_len);
+  // set the char to append
+  appended[str_len] = character;
+  // set the string NULL terminator
+  appended[str_len + 1] = 0;
 
   return appended;
 }

--- a/src/utils/os.h
+++ b/src/utils/os.h
@@ -594,9 +594,11 @@ int get_commands_paths(char *commands[], UT_array *bin_path_arr,
 /**
  * @brief Append a character to a string and return the new string
  *
+ * The returned pointer must be passed to `free()` to avoid a memory leak.
+ *
  * @param[in] str The string to append to
- * @param[in] character The character to append
- * @return char * the appended string on success, NULL on failure
+ * @param character The character to append
+ * @return The appended string on success, NULL on failure
  */
-char *string_append_char(char *str, char character);
+char *string_append_char(const char *str, char character);
 #endif /* OS_H */

--- a/tests/supervisor/test_cmd_processor.c
+++ b/tests/supervisor/test_cmd_processor.c
@@ -136,6 +136,9 @@ int __wrap_clear_bridges_cmd(struct supervisor_context *context,
   return 0;
 }
 
+// mock result to return from register_ticket_cmd
+#define MOCK_PASSPHRASE "mock-test-passphrase"
+
 uint8_t *__wrap_register_ticket_cmd(struct supervisor_context *context,
                                     uint8_t *mac_addr, char *label,
                                     int vlanid) {
@@ -145,7 +148,7 @@ uint8_t *__wrap_register_ticket_cmd(struct supervisor_context *context,
   check_expected(label);
   check_expected(vlanid);
 
-  return (uint8_t *)OK_REPLY;
+  return (uint8_t *)MOCK_PASSPHRASE;
 }
 
 int __wrap_clear_psk_cmd(struct supervisor_context *context,
@@ -168,12 +171,13 @@ int __wrap_put_crypt_cmd(struct supervisor_context *context, char *key,
   return 0;
 }
 
+#define MOCK_CRYPT_VALUE "mock-get-crypt-cmd-value"
 int __wrap_get_crypt_cmd(struct supervisor_context *context, char *key,
                          char **value) {
   (void)context;
 
   check_expected(key);
-  *value = os_strdup(OK_REPLY);
+  *value = os_strdup(MOCK_CRYPT_VALUE);
 
   return 0;
 }
@@ -219,6 +223,7 @@ int __wrap_gen_cert_cmd(struct supervisor_context *context, char *certid,
   return 0;
 }
 
+#define MOCK_ENCRYPT_BLOB_CMD "mock-encrypt-blob-cmd-success"
 char *__wrap_encrypt_blob_cmd(struct supervisor_context *context, char *keyid,
                               char *ivid, char *blob) {
   (void)context;
@@ -227,9 +232,10 @@ char *__wrap_encrypt_blob_cmd(struct supervisor_context *context, char *keyid,
   check_expected(ivid);
   check_expected(blob);
 
-  return os_strdup(OK_REPLY);
+  return os_strdup(MOCK_ENCRYPT_BLOB_CMD);
 }
 
+#define MOCK_DECRYPT_BLOB_CMD "mock-decrypt-blob-cmd-success"
 char *__wrap_decrypt_blob_cmd(struct supervisor_context *context, char *keyid,
                               char *ivid, char *blob) {
   (void)context;
@@ -238,9 +244,10 @@ char *__wrap_decrypt_blob_cmd(struct supervisor_context *context, char *keyid,
   check_expected(ivid);
   check_expected(blob);
 
-  return os_strdup(OK_REPLY);
+  return os_strdup(MOCK_DECRYPT_BLOB_CMD);
 }
 
+#define MOCK_SIGN_BLOB_CMD "mock-sign-blob-cmd-success"
 char *__wrap_sign_blob_cmd(struct supervisor_context *context, char *keyid,
                            char *blob) {
   (void)context;
@@ -248,7 +255,7 @@ char *__wrap_sign_blob_cmd(struct supervisor_context *context, char *keyid,
   check_expected(keyid);
   check_expected(blob);
 
-  return os_strdup(OK_REPLY);
+  return os_strdup(MOCK_SIGN_BLOB_CMD);
 }
 #endif
 
@@ -795,7 +802,7 @@ static void test_process_register_ticket_cmd(void **state) {
   expect_string(__wrap_register_ticket_cmd, label, "test");
   expect_value(__wrap_register_ticket_cmd, vlanid, 23);
   assert_int_equal(process_register_ticket_cmd(0, &claddr, NULL, cmd_arr),
-                   strlen(OK_REPLY));
+                   strlen(MOCK_PASSPHRASE "\n"));
   utarray_free(cmd_arr);
 
   utarray_new(cmd_arr, &ut_str_icd);
@@ -893,7 +900,7 @@ static void test_process_get_crypt_cmd(void **state) {
       split_string_array("GET_CRYPT 12345", CMD_DELIMITER, cmd_arr), -1);
   expect_string(__wrap_get_crypt_cmd, key, "12345");
   assert_int_equal(process_get_crypt_cmd(0, &claddr, NULL, cmd_arr),
-                   strlen(OK_REPLY));
+                   strlen(MOCK_CRYPT_VALUE "\n"));
   utarray_free(cmd_arr);
 
   utarray_new(cmd_arr, &ut_str_icd);
@@ -1065,7 +1072,7 @@ static void test_process_encrypt_blob(void **state) {
   expect_string(__wrap_encrypt_blob_cmd, ivid, "ivid");
   expect_string(__wrap_encrypt_blob_cmd, blob, "12345");
   assert_int_equal(process_encrypt_blob_cmd(0, &claddr, NULL, cmd_arr),
-                   strlen(OK_REPLY));
+                   strlen(MOCK_ENCRYPT_BLOB_CMD "\n"));
   utarray_free(cmd_arr);
 
   utarray_new(cmd_arr, &ut_str_icd);
@@ -1105,7 +1112,7 @@ static void test_process_decrypt_blob(void **state) {
   expect_string(__wrap_decrypt_blob_cmd, ivid, "ivid");
   expect_string(__wrap_decrypt_blob_cmd, blob, "12345");
   assert_int_equal(process_decrypt_blob_cmd(0, &claddr, NULL, cmd_arr),
-                   strlen(OK_REPLY));
+                   strlen(MOCK_DECRYPT_BLOB_CMD "\n"));
   utarray_free(cmd_arr);
 
   utarray_new(cmd_arr, &ut_str_icd);
@@ -1143,7 +1150,7 @@ static void test_process_sign_blob(void **state) {
   expect_string(__wrap_sign_blob_cmd, keyid, "keyid");
   expect_string(__wrap_sign_blob_cmd, blob, "12345");
   assert_int_equal(process_sign_blob_cmd(0, &claddr, NULL, cmd_arr),
-                   strlen(OK_REPLY));
+                   strlen(MOCK_SIGN_BLOB_CMD "\n"));
   utarray_free(cmd_arr);
 
   utarray_new(cmd_arr, &ut_str_icd);

--- a/tests/utils/test_os.c
+++ b/tests/utils/test_os.c
@@ -559,6 +559,13 @@ static void test_make_dirs_to_path(void **state) {
   assert_int_equal(ret, 0);
 }
 
+static void test_string_append_char(void **state) {
+  (void)state; /* unused */
+  const char input_str[] = "Hello World";
+  char *combined_str = string_append_char(input_str, "!");
+  assert_string_equal(combined_str, "Hello World!");
+}
+
 int main(int argc, char *argv[]) {
   (void)argc;
   (void)argv;


### PR DESCRIPTION
A lot of the mocked `cmd_processor` functions were mocked to return `OK_REPLY`.
Then, the tests were checking to make sure that exactly `strlen(OK_REPLY)` bytes were written.

However, https://github.com/nqminds/EDGESec/commit/260584216ba1eefd0bb9d7c2ca6c9e4dbc5a7a35 added a newline to many writes, so instead we need to check for `strlen(RESULT "\n")`.