### PR TITLE
refactor: make `sign_blob_cmd` args `const`

### DIFF
--- a/src/crypt/crypt_service.c
+++ b/src/crypt/crypt_service.c
@@ -402,7 +402,7 @@ void free_crypt_pair(struct crypt_pair *pair) {
   }
 }
 
-struct crypt_pair *get_crypt_pair(struct crypt_context *ctx, char *key) {
+struct crypt_pair *get_crypt_pair(struct crypt_context *ctx, const char *key) {
   struct crypt_pair *pair;
   struct store_row *row;
   uint8_t *enc_value;

--- a/src/crypt/crypt_service.h
+++ b/src/crypt/crypt_service.h
@@ -39,7 +39,7 @@
  *
  */
 struct crypt_pair {
-  char *key;          /**< The crypt key string. */
+  const char *key;    /**< The crypt key string. */
   uint8_t *value;     /**< The crypt value array. */
   ssize_t value_size; /**< The crypt value array size. */
 };
@@ -72,7 +72,7 @@ void free_crypt_service(struct crypt_context *ctx);
  * @param key The key string
  * @return struct crypt_pair* The returned pair, NULL on failure
  */
-struct crypt_pair *get_crypt_pair(struct crypt_context *ctx, char *key);
+struct crypt_pair *get_crypt_pair(struct crypt_context *ctx, const char *key);
 
 /**
  * @brief Inserts a key/value pair into the crypt

--- a/src/crypt/sqlite_crypt_writer.c
+++ b/src/crypt/sqlite_crypt_writer.c
@@ -212,7 +212,7 @@ void free_sqlite_store_row(struct store_row *row) {
   }
 }
 
-struct store_row *get_sqlite_store_row(sqlite3 *db, char *key) {
+struct store_row *get_sqlite_store_row(sqlite3 *db, const char *key) {
   struct store_row *row;
   sqlite3_stmt *res;
   int rc;

--- a/src/crypt/sqlite_crypt_writer.h
+++ b/src/crypt/sqlite_crypt_writer.h
@@ -60,10 +60,10 @@
  *
  */
 struct store_row {
-  char *key;   /**< The key */
-  char *value; /**< The stored value */
-  char *id;    /**< The key ID */
-  char *iv;    /**< The IV of the key */
+  const char *key; /**< The key */
+  char *value;     /**< The stored value */
+  char *id;        /**< The key ID */
+  char *iv;        /**< The IV of the key */
 };
 
 /**
@@ -118,7 +118,7 @@ int save_sqlite_secrets_entry(sqlite3 *db, struct secrets_row *row);
  * @param key The store column key
  * @return struct store_row* row value, NULL on failure
  */
-struct store_row *get_sqlite_store_row(sqlite3 *db, char *key);
+struct store_row *get_sqlite_store_row(sqlite3 *db, const char *key);
 
 /**
  * @brief Frees a store row entry

--- a/src/supervisor/crypt_commands.c
+++ b/src/supervisor/crypt_commands.c
@@ -356,8 +356,8 @@ char *decrypt_blob_cmd(struct supervisor_context *context, char *keyid,
   return decrypted_str;
 }
 
-char *sign_blob_cmd(struct supervisor_context *context, char *keyid,
-                    char *blob) {
+char *sign_blob_cmd(struct supervisor_context *context, const char *keyid,
+                    const char *blob) {
   struct crypt_pair *pair = NULL;
   uint8_t *blob_data = NULL, *signed_data = NULL;
   size_t blob_data_size;

--- a/src/supervisor/crypt_commands.h
+++ b/src/supervisor/crypt_commands.h
@@ -130,7 +130,7 @@ char *decrypt_blob_cmd(struct supervisor_context *context, char *keyid,
  * @param blob The blob base64 string to sign
  * @return char* the signed blob in base64, NULL on failure
  */
-char *sign_blob_cmd(struct supervisor_context *context, char *keyid,
-                    char *blob);
+char *sign_blob_cmd(struct supervisor_context *context, const char *keyid,
+                    const char *blob);
 
 #endif


### PR DESCRIPTION
The data pointed to by `keyid` and `blob` are read-only, so we should declare it as `const`.

We can always undo it if we need to, but C will warn us first.

Added while I was debugging https://github.com/nqminds/EDGESec/pull/162