### PR TITLE
ci: add build/test preset for crypto service

### DIFF
--- a/.github/workflows/create-debs.yml
+++ b/.github/workflows/create-debs.yml
@@ -14,7 +14,10 @@ jobs:
     name: Compile Locally
     strategy:
       matrix:
-        cmake-preset: [linux, openwrt/mvebu/cortexa9]
+        cmake-preset:
+          - linux # Normal linux tests
+          - linux-with-crypt # Tests whether crypto service works
+          - openwrt/mvebu/cortexa9 # Tests whether OpenWRT ARM 32-bit target works
     runs-on: ubuntu-latest
     steps:
       - name: Checkout code

--- a/CMakePresets.json
+++ b/CMakePresets.json
@@ -36,6 +36,16 @@
       }
     },
     {
+      "name": "linux-with-crypt",
+      "inherits": "default",
+      "displayName": "Linux",
+      "description": "Build for Linux using encrypted crypto service",
+      "cacheVariables": {
+        "USE_CRYPTO_SERVICE": true,
+        "BUILD_OPENSSL_LIB": true
+      }
+    },
+    {
       "name": "openwrt/default",
       "inherits": "default",
       "displayName": "OpenWRT ARM32",
@@ -93,6 +103,10 @@
     {
       "name": "linux",
       "configurePreset": "linux"
+    },
+    {
+      "name": "linux-with-crypt",
+      "configurePreset": "linux-with-crypt"
     },
     {
       "name": "openwrt/default",


### PR DESCRIPTION
Currently, none of our CI attempts to build or run the crypto service.
This adds a preset for it, so that it is tested correctly.