### PR TITLE
Publish doxygen docs to nqminds.github.io/edgesec

### DIFF
--- a/.github/workflows/pages.yml
+++ b/.github/workflows/pages.yml
@@ -1,0 +1,33 @@
+# Workflow that always runs
+name: GitHub Pages
+
+# This action should run on every commit
+on: [push, pull_request]
+
+# A workflow run is made up of one or more jobs that can run sequentially or in parallel
+jobs:
+  # This workflow contains a single job called "build-docs"
+  build-docs:
+    # The type of runner that the job will run on
+    runs-on: ubuntu-latest
+    # Steps represent a sequence of tasks that will be executed as part of the job
+    steps:
+    # Checks-out your repository under $GITHUB_WORKSPACE, so your job can access it
+    # warning! This is a shallow clone, and has no git history for docs!
+    - uses: actions/checkout@v2
+    - name: Install Dependencies
+      run: sudo apt-get update && sudo apt-get install doxygen graphviz texinfo -y
+    - name: Configure
+      run: cmake . -B build/docs/ -DBUILD_ONLY_DOCS=true
+    - name: Build Docs
+      run: cmake --build build/docs/ --target=doxydocs
+    - name: publish docs (main-branch only)
+      if: github.ref == 'refs/heads/main'
+      uses: peaceiris/actions-gh-pages@v3
+      with:
+        github_token: ${{ secrets.GITHUB_TOKEN }}
+        publish_dir: ./build/docs/html
+        enable_jekyll: false
+        allow_empty_commit: false
+        force_orphan: true
+        publish_branch: gh-pages

--- a/docs/doxygen.cmake
+++ b/docs/doxygen.cmake
@@ -1,10 +1,14 @@
 cmake_minimum_required(VERSION 3.9.0) # required by FindDoxygen.cmake
 
 # check if Doxygen is installed
-find_package(Doxygen OPTIONAL_COMPONENTS dot)
+if (BUILD_ONLY_DOCS)
+  find_package(Doxygen REQUIRED dot)
+else ()
+  find_package(Doxygen OPTIONAL_COMPONENTS dot)
+endif()
 
 if (DOXYGEN_FOUND)
-    if (NOT DEFINED Doxygen::dot)
+    if (NOT TARGET Doxygen::dot)
         message(
           WARNING
           "dot is not installed, but is highly recommended to create directed graphs"
@@ -15,19 +19,23 @@ if (DOXYGEN_FOUND)
     # set(DOXYGEN_IMAGE_PATH "${PROJECT_SOURCE_DIR}/docs")
     # currently unused, set if we want to use the `@dotfile` command
     # set(DOXYGEN_DOTFILE_DIRS "${PROJECT_SOURCE_DIR}/docs")
-    set(DOXYGEN_OUTPUT_DIRECTORY "${PROJECT_SOURCE_DIR}/docs")
-    # the docusaurus folder has a node_modules folder, which is a bunch of mess
-    set(DOXYGEN_EXCLUDE_PATTERNS "${PROJECT_SOURCE_DIR}/docs/docusaurus")
+    # set(DOXYGEN_OUTPUT_DIRECTORY "${PROJECT_SOURCE_DIR}/docs")
 
     set(DOXYGEN_PROJECT_NAME "edgesec") # defaults to EDGESEC
     set(DOXYGEN_EXTRACT_ALL YES) # document even files missing `@file` command
 
-    # note the option ALL which allows to build the docs together with the application
-    doxygen_add_docs(doxydocs
-      "${PROJECT_SOURCE_DIR}/src" ${PROJECT_SOURCE_DIR}/docs
-      # ALL
-      COMMENT "Generating API documentation with Doxygen"
-    )
+    if (BUILD_ONLY_DOCS)
+      doxygen_add_docs(doxydocs
+        "${PROJECT_SOURCE_DIR}/src" "${PROJECT_SOURCE_DIR}/docs"
+        ALL # part of make all
+        COMMENT "Generating API documentation with Doxygen"
+      )
+    else ()
+      doxygen_add_docs(doxydocs
+        "${PROJECT_SOURCE_DIR}/src" "${PROJECT_SOURCE_DIR}/docs"
+        COMMENT "Generating API documentation with Doxygen"
+      )
+    endif()
 else ()
   message(WARNING "Doxygen need to be installed to generate the doxygen documentation")
 endif ()


### PR DESCRIPTION
Publish doxygen docs to GitHub Pages.

If the CMake variable `-DBUILD_ONLY_DOCS=ON`, then CMake throws an error if it can't find `doxygen` or graphviz's `dot` (used to create the directional graphs in doxygen).