### PR TITLE
Compress license header in files

### DIFF
--- a/src/ap/ap_config.h
+++ b/src/ap/ap_config.h
@@ -1,21 +1,11 @@
-/****************************************************************************
- * Copyright (C) 2020 by NQMCyber Ltd                                       *
- *                                                                          *
- * This file is part of EDGESec.                                            *
- *                                                                          *
- *   EDGESec is free software: you can redistribute it and/or modify it     *
- *   under the terms of the GNU Lesser General Public License as published  *
- *   by the Free Software Foundation, either version 3 of the License, or   *
- *   (at your option) any later version.                                    *
- *                                                                          *
- *   EDGESec is distributed in the hope that it will be useful,             *
- *   but WITHOUT ANY WARRANTY; without even the implied warranty of         *
- *   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the          *
- *   GNU Lesser General Public License for more details.                    *
- *                                                                          *
- *   You should have received a copy of the GNU Lesser General Public       *
- *   License along with EDGESec. If not, see <http://www.gnu.org/licenses/>.*
- ****************************************************************************/
+/**
+ * @file
+ * @author Alexandru Mereacre
+ * @date 2020
+ * @copyright
+ * SPDX-FileCopyrightText: © 2020 NQMCyber Ltd and edgesec contributors
+ * SPDX-License-Identifier: LGPL-3.0-or-later
+ */
 
 /**
  * @file ap_config.h

--- a/src/ap/ap_config.h
+++ b/src/ap/ap_config.h
@@ -5,10 +5,7 @@
  * @copyright
  * SPDX-FileCopyrightText: © 2020 NQMCyber Ltd and edgesec contributors
  * SPDX-License-Identifier: LGPL-3.0-or-later
- */
-
-/**
- * @file ap_config.h
+ *
  * @author Alexandru Mereacre
  * @brief File containing the definition of AP config structures.
  *

--- a/src/ap/ap_config.h
+++ b/src/ap/ap_config.h
@@ -6,7 +6,6 @@
  * SPDX-FileCopyrightText: © 2020 NQMCyber Ltd and edgesec contributors
  * SPDX-License-Identifier: LGPL-3.0-or-later
  *
- * @author Alexandru Mereacre
  * @brief File containing the definition of AP config structures.
  *
  * Defines the access point (AP) configuration structure used to configure the

--- a/src/ap/ap_config.h
+++ b/src/ap/ap_config.h
@@ -5,7 +5,6 @@
  * @copyright
  * SPDX-FileCopyrightText: © 2020 NQMCyber Ltd and edgesec contributors
  * SPDX-License-Identifier: LGPL-3.0-or-later
- *
  * @brief File containing the definition of AP config structures.
  *
  * Defines the access point (AP) configuration structure used to configure the

--- a/src/ap/ap_service.c
+++ b/src/ap/ap_service.c
@@ -1,21 +1,11 @@
-/****************************************************************************
- * Copyright (C) 2020 by NQMCyber Ltd                                       *
- *                                                                          *
- * This file is part of EDGESec.                                            *
- *                                                                          *
- *   EDGESec is free software: you can redistribute it and/or modify it     *
- *   under the terms of the GNU Lesser General Public License as published  *
- *   by the Free Software Foundation, either version 3 of the License, or   *
- *   (at your option) any later version.                                    *
- *                                                                          *
- *   EDGESec is distributed in the hope that it will be useful,             *
- *   but WITHOUT ANY WARRANTY; without even the implied warranty of         *
- *   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the          *
- *   GNU Lesser General Public License for more details.                    *
- *                                                                          *
- *   You should have received a copy of the GNU Lesser General Public       *
- *   License along with EDGESec. If not, see <http://www.gnu.org/licenses/>.*
- ****************************************************************************/
+/**
+ * @file
+ * @author Alexandru Mereacre
+ * @date 2020
+ * @copyright
+ * SPDX-FileCopyrightText: © 2020 NQMCyber Ltd and edgesec contributors
+ * SPDX-License-Identifier: LGPL-3.0-or-later
+ */
 
 /**
  * @file hostapd_service.c

--- a/src/ap/ap_service.c
+++ b/src/ap/ap_service.c
@@ -5,7 +5,6 @@
  * @copyright
  * SPDX-FileCopyrightText: © 2020 NQMCyber Ltd and edgesec contributors
  * SPDX-License-Identifier: LGPL-3.0-or-later
- *
  * @brief File containing the implementation of the hostapd service.
  *
  * Defines the functions to start and stop the acces point service (AP). It also

--- a/src/ap/ap_service.c
+++ b/src/ap/ap_service.c
@@ -5,10 +5,7 @@
  * @copyright
  * SPDX-FileCopyrightText: © 2020 NQMCyber Ltd and edgesec contributors
  * SPDX-License-Identifier: LGPL-3.0-or-later
- */
-
-/**
- * @file hostapd_service.c
+ *
  * @author Alexandru Mereacre
  * @brief File containing the implementation of the hostapd service.
  *

--- a/src/ap/ap_service.c
+++ b/src/ap/ap_service.c
@@ -6,7 +6,6 @@
  * SPDX-FileCopyrightText: © 2020 NQMCyber Ltd and edgesec contributors
  * SPDX-License-Identifier: LGPL-3.0-or-later
  *
- * @author Alexandru Mereacre
  * @brief File containing the implementation of the hostapd service.
  *
  * Defines the functions to start and stop the acces point service (AP). It also

--- a/src/ap/ap_service.h
+++ b/src/ap/ap_service.h
@@ -1,21 +1,11 @@
-/****************************************************************************
- * Copyright (C) 2020 by NQMCyber Ltd                                       *
- *                                                                          *
- * This file is part of EDGESec.                                            *
- *                                                                          *
- *   EDGESec is free software: you can redistribute it and/or modify it     *
- *   under the terms of the GNU Lesser General Public License as published  *
- *   by the Free Software Foundation, either version 3 of the License, or   *
- *   (at your option) any later version.                                    *
- *                                                                          *
- *   EDGESec is distributed in the hope that it will be useful,             *
- *   but WITHOUT ANY WARRANTY; without even the implied warranty of         *
- *   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the          *
- *   GNU Lesser General Public License for more details.                    *
- *                                                                          *
- *   You should have received a copy of the GNU Lesser General Public       *
- *   License along with EDGESec. If not, see <http://www.gnu.org/licenses/>.*
- ****************************************************************************/
+/**
+ * @file
+ * @author Alexandru Mereacre
+ * @date 2020
+ * @copyright
+ * SPDX-FileCopyrightText: © 2020 NQMCyber Ltd and edgesec contributors
+ * SPDX-License-Identifier: LGPL-3.0-or-later
+ */
 
 /**
  * @file ap_service.h

--- a/src/ap/ap_service.h
+++ b/src/ap/ap_service.h
@@ -5,7 +5,6 @@
  * @copyright
  * SPDX-FileCopyrightText: © 2020 NQMCyber Ltd and edgesec contributors
  * SPDX-License-Identifier: LGPL-3.0-or-later
- *
  * @brief File containing the definition of the ap service.
  *
  * Defines the functions to start and stop the acces point service (AP). It also

--- a/src/ap/ap_service.h
+++ b/src/ap/ap_service.h
@@ -5,10 +5,7 @@
  * @copyright
  * SPDX-FileCopyrightText: © 2020 NQMCyber Ltd and edgesec contributors
  * SPDX-License-Identifier: LGPL-3.0-or-later
- */
-
-/**
- * @file ap_service.h
+ *
  * @author Alexandru Mereacre
  * @brief File containing the definition of the ap service.
  *

--- a/src/ap/ap_service.h
+++ b/src/ap/ap_service.h
@@ -6,7 +6,6 @@
  * SPDX-FileCopyrightText: © 2020 NQMCyber Ltd and edgesec contributors
  * SPDX-License-Identifier: LGPL-3.0-or-later
  *
- * @author Alexandru Mereacre
  * @brief File containing the definition of the ap service.
  *
  * Defines the functions to start and stop the acces point service (AP). It also

--- a/src/ap/hostapd.c
+++ b/src/ap/hostapd.c
@@ -5,10 +5,7 @@
  * @copyright
  * SPDX-FileCopyrightText: © 2021 NQMCyber Ltd and edgesec contributors
  * SPDX-License-Identifier: LGPL-3.0-or-later
- */
-
-/**
- * @file hostapd.c
+ *
  * @author Alexandru Mereacre
  * @brief File containing the implementation of hostapd config generation
  * utilities.

--- a/src/ap/hostapd.c
+++ b/src/ap/hostapd.c
@@ -1,21 +1,11 @@
-/****************************************************************************
- * Copyright (C) 2021 by NQMCyber Ltd                                       *
- *                                                                          *
- * This file is part of EDGESec.                                            *
- *                                                                          *
- *   EDGESec is free software: you can redistribute it and/or modify it     *
- *   under the terms of the GNU Lesser General Public License as published  *
- *   by the Free Software Foundation, either version 3 of the License, or   *
- *   (at your option) any later version.                                    *
- *                                                                          *
- *   EDGESec is distributed in the hope that it will be useful,             *
- *   but WITHOUT ANY WARRANTY; without even the implied warranty of         *
- *   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the          *
- *   GNU Lesser General Public License for more details.                    *
- *                                                                          *
- *   You should have received a copy of the GNU Lesser General Public       *
- *   License along with EDGESec. If not, see <http://www.gnu.org/licenses/>.*
- ****************************************************************************/
+/**
+ * @file
+ * @author Alexandru Mereacre
+ * @date 2021
+ * @copyright
+ * SPDX-FileCopyrightText: © 2021 NQMCyber Ltd and edgesec contributors
+ * SPDX-License-Identifier: LGPL-3.0-or-later
+ */
 
 /**
  * @file hostapd.c

--- a/src/ap/hostapd.c
+++ b/src/ap/hostapd.c
@@ -5,7 +5,6 @@
  * @copyright
  * SPDX-FileCopyrightText: © 2021 NQMCyber Ltd and edgesec contributors
  * SPDX-License-Identifier: LGPL-3.0-or-later
- *
  * @brief File containing the implementation of hostapd config generation
  * utilities.
  *

--- a/src/ap/hostapd.c
+++ b/src/ap/hostapd.c
@@ -6,7 +6,6 @@
  * SPDX-FileCopyrightText: © 2021 NQMCyber Ltd and edgesec contributors
  * SPDX-License-Identifier: LGPL-3.0-or-later
  *
- * @author Alexandru Mereacre
  * @brief File containing the implementation of hostapd config generation
  * utilities.
  *

--- a/src/ap/hostapd.h
+++ b/src/ap/hostapd.h
@@ -5,7 +5,6 @@
  * @copyright
  * SPDX-FileCopyrightText: © 2021 NQMCyber Ltd and edgesec contributors
  * SPDX-License-Identifier: LGPL-3.0-or-later
- *
  * @brief File containing the definition of hostapd config generation utilities.
  *
  * Defines function that generate the hostapd daemon configuration file and

--- a/src/ap/hostapd.h
+++ b/src/ap/hostapd.h
@@ -5,10 +5,7 @@
  * @copyright
  * SPDX-FileCopyrightText: © 2021 NQMCyber Ltd and edgesec contributors
  * SPDX-License-Identifier: LGPL-3.0-or-later
- */
-
-/**
- * @file hostapd.h
+ *
  * @author Alexandru Mereacre
  * @brief File containing the definition of hostapd config generation utilities.
  *

--- a/src/ap/hostapd.h
+++ b/src/ap/hostapd.h
@@ -6,7 +6,6 @@
  * SPDX-FileCopyrightText: © 2021 NQMCyber Ltd and edgesec contributors
  * SPDX-License-Identifier: LGPL-3.0-or-later
  *
- * @author Alexandru Mereacre
  * @brief File containing the definition of hostapd config generation utilities.
  *
  * Defines function that generate the hostapd daemon configuration file and

--- a/src/ap/hostapd.h
+++ b/src/ap/hostapd.h
@@ -1,21 +1,11 @@
-/****************************************************************************
- * Copyright (C) 2021 by NQMCyber Ltd                                       *
- *                                                                          *
- * This file is part of EDGESec.                                            *
- *                                                                          *
- *   EDGESec is free software: you can redistribute it and/or modify it     *
- *   under the terms of the GNU Lesser General Public License as published  *
- *   by the Free Software Foundation, either version 3 of the License, or   *
- *   (at your option) any later version.                                    *
- *                                                                          *
- *   EDGESec is distributed in the hope that it will be useful,             *
- *   but WITHOUT ANY WARRANTY; without even the implied warranty of         *
- *   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the          *
- *   GNU Lesser General Public License for more details.                    *
- *                                                                          *
- *   You should have received a copy of the GNU Lesser General Public       *
- *   License along with EDGESec. If not, see <http://www.gnu.org/licenses/>.*
- ****************************************************************************/
+/**
+ * @file
+ * @author Alexandru Mereacre
+ * @date 2021
+ * @copyright
+ * SPDX-FileCopyrightText: © 2021 NQMCyber Ltd and edgesec contributors
+ * SPDX-License-Identifier: LGPL-3.0-or-later
+ */
 
 /**
  * @file hostapd.h

--- a/src/capture/capture_config.h
+++ b/src/capture/capture_config.h
@@ -6,7 +6,6 @@
  * SPDX-FileCopyrightText: © 2021 NQMCyber Ltd and edgesec contributors
  * SPDX-License-Identifier: LGPL-3.0-or-later
  *
- * @author Alexandru Mereacre
  * @brief File containing the definition of the capture config structures.
  *
  * Defines the function to generate the config parameters for the capture

--- a/src/capture/capture_config.h
+++ b/src/capture/capture_config.h
@@ -5,10 +5,7 @@
  * @copyright
  * SPDX-FileCopyrightText: © 2021 NQMCyber Ltd and edgesec contributors
  * SPDX-License-Identifier: LGPL-3.0-or-later
- */
-
-/**
- * @file capture_config.h
+ *
  * @author Alexandru Mereacre
  * @brief File containing the definition of the capture config structures.
  *

--- a/src/capture/capture_config.h
+++ b/src/capture/capture_config.h
@@ -5,7 +5,6 @@
  * @copyright
  * SPDX-FileCopyrightText: © 2021 NQMCyber Ltd and edgesec contributors
  * SPDX-License-Identifier: LGPL-3.0-or-later
- *
  * @brief File containing the definition of the capture config structures.
  *
  * Defines the function to generate the config parameters for the capture

--- a/src/capture/capture_config.h
+++ b/src/capture/capture_config.h
@@ -1,21 +1,11 @@
-/****************************************************************************
- * Copyright (C) 2021 by NQMCyber Ltd                                       *
- *                                                                          *
- * This file is part of EDGESec.                                            *
- *                                                                          *
- *   EDGESec is free software: you can redistribute it and/or modify it     *
- *   under the terms of the GNU Lesser General Public License as published  *
- *   by the Free Software Foundation, either version 3 of the License, or   *
- *   (at your option) any later version.                                    *
- *                                                                          *
- *   EDGESec is distributed in the hope that it will be useful,             *
- *   but WITHOUT ANY WARRANTY; without even the implied warranty of         *
- *   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the          *
- *   GNU Lesser General Public License for more details.                    *
- *                                                                          *
- *   You should have received a copy of the GNU Lesser General Public       *
- *   License along with EDGESec. If not, see <http://www.gnu.org/licenses/>.*
- ****************************************************************************/
+/**
+ * @file
+ * @author Alexandru Mereacre
+ * @date 2021
+ * @copyright
+ * SPDX-FileCopyrightText: © 2021 NQMCyber Ltd and edgesec contributors
+ * SPDX-License-Identifier: LGPL-3.0-or-later
+ */
 
 /**
  * @file capture_config.h

--- a/src/capture/capture_service.c
+++ b/src/capture/capture_service.c
@@ -1,21 +1,11 @@
-/****************************************************************************
- * Copyright (C) 2021 by NQMCyber Ltd                                       *
- *                                                                          *
- * This file is part of EDGESec.                                            *
- *                                                                          *
- *   EDGESec is free software: you can redistribute it and/or modify it     *
- *   under the terms of the GNU Lesser General Public License as published  *
- *   by the Free Software Foundation, either version 3 of the License, or   *
- *   (at your option) any later version.                                    *
- *                                                                          *
- *   EDGESec is distributed in the hope that it will be useful,             *
- *   but WITHOUT ANY WARRANTY; without even the implied warranty of         *
- *   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the          *
- *   GNU Lesser General Public License for more details.                    *
- *                                                                          *
- *   You should have received a copy of the GNU Lesser General Public       *
- *   License along with EDGESec. If not, see <http://www.gnu.org/licenses/>.*
- ****************************************************************************/
+/**
+ * @file
+ * @author Alexandru Mereacre
+ * @date 2021
+ * @copyright
+ * SPDX-FileCopyrightText: © 2021 NQMCyber Ltd and edgesec contributors
+ * SPDX-License-Identifier: LGPL-3.0-or-later
+ */
 /**
  * @file capture_service.c
  * @author Alexandru Mereacre

--- a/src/capture/capture_service.c
+++ b/src/capture/capture_service.c
@@ -8,7 +8,6 @@
  */
 /**
  * @file capture_service.c
- * @author Alexandru Mereacre
  * @brief File containing the implementation of the capture service.
  */
 

--- a/src/capture/capture_service.h
+++ b/src/capture/capture_service.h
@@ -5,7 +5,6 @@
  * @copyright
  * SPDX-FileCopyrightText: © 2021 NQMCyber Ltd and edgesec contributors
  * SPDX-License-Identifier: LGPL-3.0-or-later
- *
  * @brief File containing the definition of the capture service.
  */
 

--- a/src/capture/capture_service.h
+++ b/src/capture/capture_service.h
@@ -5,10 +5,7 @@
  * @copyright
  * SPDX-FileCopyrightText: © 2021 NQMCyber Ltd and edgesec contributors
  * SPDX-License-Identifier: LGPL-3.0-or-later
- */
-
-/**
- * @file capture_service.h
+ *
  * @author Alexandru Mereacre
  * @brief File containing the definition of the capture service.
  */

--- a/src/capture/capture_service.h
+++ b/src/capture/capture_service.h
@@ -1,21 +1,11 @@
-/****************************************************************************
- * Copyright (C) 2021 by NQMCyber Ltd                                       *
- *                                                                          *
- * This file is part of EDGESec.                                            *
- *                                                                          *
- *   EDGESec is free software: you can redistribute it and/or modify it     *
- *   under the terms of the GNU Lesser General Public License as published  *
- *   by the Free Software Foundation, either version 3 of the License, or   *
- *   (at your option) any later version.                                    *
- *                                                                          *
- *   EDGESec is distributed in the hope that it will be useful,             *
- *   but WITHOUT ANY WARRANTY; without even the implied warranty of         *
- *   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the          *
- *   GNU Lesser General Public License for more details.                    *
- *                                                                          *
- *   You should have received a copy of the GNU Lesser General Public       *
- *   License along with EDGESec. If not, see <http://www.gnu.org/licenses/>.*
- ****************************************************************************/
+/**
+ * @file
+ * @author Alexandru Mereacre
+ * @date 2021
+ * @copyright
+ * SPDX-FileCopyrightText: © 2021 NQMCyber Ltd and edgesec contributors
+ * SPDX-License-Identifier: LGPL-3.0-or-later
+ */
 
 /**
  * @file capture_service.h

--- a/src/capture/capture_service.h
+++ b/src/capture/capture_service.h
@@ -6,7 +6,6 @@
  * SPDX-FileCopyrightText: © 2021 NQMCyber Ltd and edgesec contributors
  * SPDX-License-Identifier: LGPL-3.0-or-later
  *
- * @author Alexandru Mereacre
  * @brief File containing the definition of the capture service.
  */
 

--- a/src/capture/middleware.h
+++ b/src/capture/middleware.h
@@ -1,21 +1,11 @@
-/****************************************************************************
- * Copyright (C) 2022 by NQMCyber Ltd                                       *
- *                                                                          *
- * This file is part of EDGESec.                                            *
- *                                                                          *
- *   EDGESec is free software: you can redistribute it and/or modify it     *
- *   under the terms of the GNU Lesser General Public License as published  *
- *   by the Free Software Foundation, either version 3 of the License, or   *
- *   (at your option) any later version.                                    *
- *                                                                          *
- *   EDGESec is distributed in the hope that it will be useful,             *
- *   but WITHOUT ANY WARRANTY; without even the implied warranty of         *
- *   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the          *
- *   GNU Lesser General Public License for more details.                    *
- *                                                                          *
- *   You should have received a copy of the GNU Lesser General Public       *
- *   License along with EDGESec. If not, see <http://www.gnu.org/licenses/>.*
- ****************************************************************************/
+/**
+ * @file
+ * @author Alexandru Mereacre
+ * @date 2022
+ * @copyright
+ * SPDX-FileCopyrightText: © 2022 NQMCyber Ltd and edgesec contributors
+ * SPDX-License-Identifier: LGPL-3.0-or-later
+ */
 
 /**
  * @file middleware.h

--- a/src/capture/middleware.h
+++ b/src/capture/middleware.h
@@ -5,10 +5,7 @@
  * @copyright
  * SPDX-FileCopyrightText: © 2022 NQMCyber Ltd and edgesec contributors
  * SPDX-License-Identifier: LGPL-3.0-or-later
- */
-
-/**
- * @file middleware.h
+ *
  * @author Alois Klink
  * @brief File containing the definition of a generic middleware.
  */

--- a/src/capture/middleware.h
+++ b/src/capture/middleware.h
@@ -1,12 +1,11 @@
 /**
  * @file
  * @author Alexandru Mereacre
+ * @author Alois Klink
  * @date 2022
  * @copyright
  * SPDX-FileCopyrightText: © 2022 NQMCyber Ltd and edgesec contributors
  * SPDX-License-Identifier: LGPL-3.0-or-later
- *
- * @author Alois Klink
  * @brief File containing the definition of a generic middleware.
  */
 
@@ -35,7 +34,7 @@ struct middleware_context {
  * You can then use the CMake function `edgesecAddCaptureMiddleware` to
  * add your middleware to the EDGESec capture service when building
  * EDGESec.
- * @author Alois Klink, Alexandru Mereacre
+ * @authors Alois Klink, Alexandru Mereacre
  */
 struct capture_middleware {
   /**

--- a/src/capture/middlewares/cleaner_middleware/cleaner_middleware.c
+++ b/src/capture/middlewares/cleaner_middleware/cleaner_middleware.c
@@ -5,7 +5,6 @@
  * @copyright
  * SPDX-FileCopyrightText: © 2021 NQMCyber Ltd and edgesec contributors
  * SPDX-License-Identifier: LGPL-3.0-or-later
- *
  * @brief File containing the implementation of the capture cleaner service
  * structures.
  *

--- a/src/capture/middlewares/cleaner_middleware/cleaner_middleware.c
+++ b/src/capture/middlewares/cleaner_middleware/cleaner_middleware.c
@@ -6,7 +6,6 @@
  * SPDX-FileCopyrightText: © 2021 NQMCyber Ltd and edgesec contributors
  * SPDX-License-Identifier: LGPL-3.0-or-later
  *
- * @author Alexandru Mereacre
  * @brief File containing the implementation of the capture cleaner service
  * structures.
  *

--- a/src/capture/middlewares/cleaner_middleware/cleaner_middleware.c
+++ b/src/capture/middlewares/cleaner_middleware/cleaner_middleware.c
@@ -5,10 +5,7 @@
  * @copyright
  * SPDX-FileCopyrightText: © 2021 NQMCyber Ltd and edgesec contributors
  * SPDX-License-Identifier: LGPL-3.0-or-later
- */
-
-/**
- * @file capture_cleaner.c
+ *
  * @author Alexandru Mereacre
  * @brief File containing the implementation of the capture cleaner service
  * structures.

--- a/src/capture/middlewares/cleaner_middleware/cleaner_middleware.c
+++ b/src/capture/middlewares/cleaner_middleware/cleaner_middleware.c
@@ -1,21 +1,11 @@
-/****************************************************************************
- * Copyright (C) 2021 by NQMCyber Ltd                                       *
- *                                                                          *
- * This file is part of EDGESec.                                            *
- *                                                                          *
- *   EDGESec is free software: you can redistribute it and/or modify it     *
- *   under the terms of the GNU Lesser General Public License as published  *
- *   by the Free Software Foundation, either version 3 of the License, or   *
- *   (at your option) any later version.                                    *
- *                                                                          *
- *   EDGESec is distributed in the hope that it will be useful,             *
- *   but WITHOUT ANY WARRANTY; without even the implied warranty of         *
- *   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the          *
- *   GNU Lesser General Public License for more details.                    *
- *                                                                          *
- *   You should have received a copy of the GNU Lesser General Public       *
- *   License along with EDGESec. If not, see <http://www.gnu.org/licenses/>.*
- ****************************************************************************/
+/**
+ * @file
+ * @author Alexandru Mereacre
+ * @date 2021
+ * @copyright
+ * SPDX-FileCopyrightText: © 2021 NQMCyber Ltd and edgesec contributors
+ * SPDX-License-Identifier: LGPL-3.0-or-later
+ */
 
 /**
  * @file capture_cleaner.c

--- a/src/capture/middlewares/cleaner_middleware/cleaner_middleware.h
+++ b/src/capture/middlewares/cleaner_middleware/cleaner_middleware.h
@@ -17,7 +17,7 @@
  * @brief Cleaner Middleware.
  * The cleaner middleware is designed to periodically remove the oldest
  * PCAP files when the use more than `CLEANER_STORE_SIZE` KiB.
- * @author Alexandru Mereacre, Alois Klink
+ * @authors Alexandru Mereacre, Alois Klink
  */
 extern struct capture_middleware cleaner_middleware;
 #endif

--- a/src/capture/middlewares/cleaner_middleware/cleaner_middleware.h
+++ b/src/capture/middlewares/cleaner_middleware/cleaner_middleware.h
@@ -6,7 +6,6 @@
  * SPDX-FileCopyrightText: © 2021 NQMCyber Ltd and edgesec contributors
  * SPDX-License-Identifier: LGPL-3.0-or-later
  *
- * @author Alexandru Mereacre
  * @brief File containing the definition of the middleware cleaner utilities.
  */
 

--- a/src/capture/middlewares/cleaner_middleware/cleaner_middleware.h
+++ b/src/capture/middlewares/cleaner_middleware/cleaner_middleware.h
@@ -1,21 +1,11 @@
-/****************************************************************************
- * Copyright (C) 2021 by NQMCyber Ltd                                       *
- *                                                                          *
- * This file is part of EDGESec.                                            *
- *                                                                          *
- *   EDGESec is free software: you can redistribute it and/or modify it     *
- *   under the terms of the GNU Lesser General Public License as published  *
- *   by the Free Software Foundation, either version 3 of the License, or   *
- *   (at your option) any later version.                                    *
- *                                                                          *
- *   EDGESec is distributed in the hope that it will be useful,             *
- *   but WITHOUT ANY WARRANTY; without even the implied warranty of         *
- *   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the          *
- *   GNU Lesser General Public License for more details.                    *
- *                                                                          *
- *   You should have received a copy of the GNU Lesser General Public       *
- *   License along with EDGESec. If not, see <http://www.gnu.org/licenses/>.*
- ****************************************************************************/
+/**
+ * @file
+ * @author Alexandru Mereacre
+ * @date 2021
+ * @copyright
+ * SPDX-FileCopyrightText: © 2021 NQMCyber Ltd and edgesec contributors
+ * SPDX-License-Identifier: LGPL-3.0-or-later
+ */
 
 /**
  * @file cleaner_middleware.h

--- a/src/capture/middlewares/cleaner_middleware/cleaner_middleware.h
+++ b/src/capture/middlewares/cleaner_middleware/cleaner_middleware.h
@@ -5,10 +5,7 @@
  * @copyright
  * SPDX-FileCopyrightText: © 2021 NQMCyber Ltd and edgesec contributors
  * SPDX-License-Identifier: LGPL-3.0-or-later
- */
-
-/**
- * @file cleaner_middleware.h
+ *
  * @author Alexandru Mereacre
  * @brief File containing the definition of the middleware cleaner utilities.
  */

--- a/src/capture/middlewares/cleaner_middleware/cleaner_middleware.h
+++ b/src/capture/middlewares/cleaner_middleware/cleaner_middleware.h
@@ -5,7 +5,6 @@
  * @copyright
  * SPDX-FileCopyrightText: © 2021 NQMCyber Ltd and edgesec contributors
  * SPDX-License-Identifier: LGPL-3.0-or-later
- *
  * @brief File containing the definition of the middleware cleaner utilities.
  */
 

--- a/src/capture/middlewares/header_middleware/dns_decoder.c
+++ b/src/capture/middlewares/header_middleware/dns_decoder.c
@@ -5,10 +5,7 @@
  * @copyright
  * SPDX-FileCopyrightText: © 2021 NQMCyber Ltd and edgesec contributors
  * SPDX-License-Identifier: LGPL-3.0-or-later
- */
-
-/**
- * @file dns_decoder.c
+ *
  * @author Alexandru Mereacre
  * @brief File containing the implementation of the dns packet decoder
  * utilities.

--- a/src/capture/middlewares/header_middleware/dns_decoder.c
+++ b/src/capture/middlewares/header_middleware/dns_decoder.c
@@ -5,7 +5,6 @@
  * @copyright
  * SPDX-FileCopyrightText: © 2021 NQMCyber Ltd and edgesec contributors
  * SPDX-License-Identifier: LGPL-3.0-or-later
- *
  * @brief File containing the implementation of the dns packet decoder
  * utilities.
  */

--- a/src/capture/middlewares/header_middleware/dns_decoder.c
+++ b/src/capture/middlewares/header_middleware/dns_decoder.c
@@ -1,21 +1,11 @@
-/****************************************************************************
- * Copyright (C) 2021 by NQMCyber Ltd                                       *
- *                                                                          *
- * This file is part of EDGESec.                                            *
- *                                                                          *
- *   EDGESec is free software: you can redistribute it and/or modify it     *
- *   under the terms of the GNU Lesser General Public License as published  *
- *   by the Free Software Foundation, either version 3 of the License, or   *
- *   (at your option) any later version.                                    *
- *                                                                          *
- *   EDGESec is distributed in the hope that it will be useful,             *
- *   but WITHOUT ANY WARRANTY; without even the implied warranty of         *
- *   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the          *
- *   GNU Lesser General Public License for more details.                    *
- *                                                                          *
- *   You should have received a copy of the GNU Lesser General Public       *
- *   License along with EDGESec. If not, see <http://www.gnu.org/licenses/>.*
- ****************************************************************************/
+/**
+ * @file
+ * @author Alexandru Mereacre
+ * @date 2021
+ * @copyright
+ * SPDX-FileCopyrightText: © 2021 NQMCyber Ltd and edgesec contributors
+ * SPDX-License-Identifier: LGPL-3.0-or-later
+ */
 
 /**
  * @file dns_decoder.c

--- a/src/capture/middlewares/header_middleware/dns_decoder.c
+++ b/src/capture/middlewares/header_middleware/dns_decoder.c
@@ -6,7 +6,6 @@
  * SPDX-FileCopyrightText: © 2021 NQMCyber Ltd and edgesec contributors
  * SPDX-License-Identifier: LGPL-3.0-or-later
  *
- * @author Alexandru Mereacre
  * @brief File containing the implementation of the dns packet decoder
  * utilities.
  */

--- a/src/capture/middlewares/header_middleware/dns_decoder.h
+++ b/src/capture/middlewares/header_middleware/dns_decoder.h
@@ -6,7 +6,6 @@
  * SPDX-FileCopyrightText: © 2021 NQMCyber Ltd and edgesec contributors
  * SPDX-License-Identifier: LGPL-3.0-or-later
  *
- * @author Alexandru Mereacre
  * @brief File containing the definition of the dns packet decoder utilities.
  */
 

--- a/src/capture/middlewares/header_middleware/dns_decoder.h
+++ b/src/capture/middlewares/header_middleware/dns_decoder.h
@@ -5,10 +5,7 @@
  * @copyright
  * SPDX-FileCopyrightText: © 2021 NQMCyber Ltd and edgesec contributors
  * SPDX-License-Identifier: LGPL-3.0-or-later
- */
-
-/**
- * @file dns_decoder.h
+ *
  * @author Alexandru Mereacre
  * @brief File containing the definition of the dns packet decoder utilities.
  */

--- a/src/capture/middlewares/header_middleware/dns_decoder.h
+++ b/src/capture/middlewares/header_middleware/dns_decoder.h
@@ -1,21 +1,11 @@
-/****************************************************************************
- * Copyright (C) 2021 by NQMCyber Ltd                                       *
- *                                                                          *
- * This file is part of EDGESec.                                            *
- *                                                                          *
- *   EDGESec is free software: you can redistribute it and/or modify it     *
- *   under the terms of the GNU Lesser General Public License as published  *
- *   by the Free Software Foundation, either version 3 of the License, or   *
- *   (at your option) any later version.                                    *
- *                                                                          *
- *   EDGESec is distributed in the hope that it will be useful,             *
- *   but WITHOUT ANY WARRANTY; without even the implied warranty of         *
- *   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the          *
- *   GNU Lesser General Public License for more details.                    *
- *                                                                          *
- *   You should have received a copy of the GNU Lesser General Public       *
- *   License along with EDGESec. If not, see <http://www.gnu.org/licenses/>.*
- ****************************************************************************/
+/**
+ * @file
+ * @author Alexandru Mereacre
+ * @date 2021
+ * @copyright
+ * SPDX-FileCopyrightText: © 2021 NQMCyber Ltd and edgesec contributors
+ * SPDX-License-Identifier: LGPL-3.0-or-later
+ */
 
 /**
  * @file dns_decoder.h

--- a/src/capture/middlewares/header_middleware/dns_decoder.h
+++ b/src/capture/middlewares/header_middleware/dns_decoder.h
@@ -5,7 +5,6 @@
  * @copyright
  * SPDX-FileCopyrightText: © 2021 NQMCyber Ltd and edgesec contributors
  * SPDX-License-Identifier: LGPL-3.0-or-later
- *
  * @brief File containing the definition of the dns packet decoder utilities.
  */
 

--- a/src/capture/middlewares/header_middleware/header_middleware.c
+++ b/src/capture/middlewares/header_middleware/header_middleware.c
@@ -6,7 +6,6 @@
  * SPDX-FileCopyrightText: © 2021 NQMCyber Ltd and edgesec contributors
  * SPDX-License-Identifier: LGPL-3.0-or-later
  *
- * @author Alexandru Mereacre
  * @brief File containing the implementation of the header middleware
  * utilities.
  */

--- a/src/capture/middlewares/header_middleware/header_middleware.c
+++ b/src/capture/middlewares/header_middleware/header_middleware.c
@@ -1,21 +1,11 @@
-/****************************************************************************
- * Copyright (C) 2021 by NQMCyber Ltd                                       *
- *                                                                          *
- * This file is part of EDGESec.                                            *
- *                                                                          *
- *   EDGESec is free software: you can redistribute it and/or modify it     *
- *   under the terms of the GNU Lesser General Public License as published  *
- *   by the Free Software Foundation, either version 3 of the License, or   *
- *   (at your option) any later version.                                    *
- *                                                                          *
- *   EDGESec is distributed in the hope that it will be useful,             *
- *   but WITHOUT ANY WARRANTY; without even the implied warranty of         *
- *   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the          *
- *   GNU Lesser General Public License for more details.                    *
- *                                                                          *
- *   You should have received a copy of the GNU Lesser General Public       *
- *   License along with EDGESec. If not, see <http://www.gnu.org/licenses/>.*
- ****************************************************************************/
+/**
+ * @file
+ * @author Alexandru Mereacre
+ * @date 2021
+ * @copyright
+ * SPDX-FileCopyrightText: © 2021 NQMCyber Ltd and edgesec contributors
+ * SPDX-License-Identifier: LGPL-3.0-or-later
+ */
 
 /**
  * @file header_middleware.c

--- a/src/capture/middlewares/header_middleware/header_middleware.c
+++ b/src/capture/middlewares/header_middleware/header_middleware.c
@@ -5,7 +5,6 @@
  * @copyright
  * SPDX-FileCopyrightText: © 2021 NQMCyber Ltd and edgesec contributors
  * SPDX-License-Identifier: LGPL-3.0-or-later
- *
  * @brief File containing the implementation of the header middleware
  * utilities.
  */

--- a/src/capture/middlewares/header_middleware/header_middleware.c
+++ b/src/capture/middlewares/header_middleware/header_middleware.c
@@ -5,10 +5,7 @@
  * @copyright
  * SPDX-FileCopyrightText: © 2021 NQMCyber Ltd and edgesec contributors
  * SPDX-License-Identifier: LGPL-3.0-or-later
- */
-
-/**
- * @file header_middleware.c
+ *
  * @author Alexandru Mereacre
  * @brief File containing the implementation of the header middleware
  * utilities.

--- a/src/capture/middlewares/header_middleware/header_middleware.h
+++ b/src/capture/middlewares/header_middleware/header_middleware.h
@@ -1,21 +1,11 @@
-/****************************************************************************
- * Copyright (C) 2021 by NQMCyber Ltd                                       *
- *                                                                          *
- * This file is part of EDGESec.                                            *
- *                                                                          *
- *   EDGESec is free software: you can redistribute it and/or modify it     *
- *   under the terms of the GNU Lesser General Public License as published  *
- *   by the Free Software Foundation, either version 3 of the License, or   *
- *   (at your option) any later version.                                    *
- *                                                                          *
- *   EDGESec is distributed in the hope that it will be useful,             *
- *   but WITHOUT ANY WARRANTY; without even the implied warranty of         *
- *   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the          *
- *   GNU Lesser General Public License for more details.                    *
- *                                                                          *
- *   You should have received a copy of the GNU Lesser General Public       *
- *   License along with EDGESec. If not, see <http://www.gnu.org/licenses/>.*
- ****************************************************************************/
+/**
+ * @file
+ * @author Alexandru Mereacre
+ * @date 2021
+ * @copyright
+ * SPDX-FileCopyrightText: © 2021 NQMCyber Ltd and edgesec contributors
+ * SPDX-License-Identifier: LGPL-3.0-or-later
+ */
 
 /**
  * @file header_middleware.h

--- a/src/capture/middlewares/header_middleware/header_middleware.h
+++ b/src/capture/middlewares/header_middleware/header_middleware.h
@@ -5,7 +5,6 @@
  * @copyright
  * SPDX-FileCopyrightText: © 2021 NQMCyber Ltd and edgesec contributors
  * SPDX-License-Identifier: LGPL-3.0-or-later
- *
  * @brief File containing the definition of the header middleware utilities.
  *
  */

--- a/src/capture/middlewares/header_middleware/header_middleware.h
+++ b/src/capture/middlewares/header_middleware/header_middleware.h
@@ -6,7 +6,6 @@
  * SPDX-FileCopyrightText: © 2021 NQMCyber Ltd and edgesec contributors
  * SPDX-License-Identifier: LGPL-3.0-or-later
  *
- * @author Alexandru Mereacre
  * @brief File containing the definition of the header middleware utilities.
  *
  */

--- a/src/capture/middlewares/header_middleware/header_middleware.h
+++ b/src/capture/middlewares/header_middleware/header_middleware.h
@@ -18,7 +18,7 @@
  * @brief Packet Header Capture Middleware.
  * The header middleware stores packet headers and other packet metadata
  * into the capture SQLite database.
- * @author Alexandru Mereacre, Alois Klink
+ * @authors Alexandru Mereacre, Alois Klink
  */
 extern struct capture_middleware header_middleware;
 #endif

--- a/src/capture/middlewares/header_middleware/header_middleware.h
+++ b/src/capture/middlewares/header_middleware/header_middleware.h
@@ -5,10 +5,7 @@
  * @copyright
  * SPDX-FileCopyrightText: © 2021 NQMCyber Ltd and edgesec contributors
  * SPDX-License-Identifier: LGPL-3.0-or-later
- */
-
-/**
- * @file header_middleware.h
+ *
  * @author Alexandru Mereacre
  * @brief File containing the definition of the header middleware utilities.
  *

--- a/src/capture/middlewares/header_middleware/mdns_decoder.c
+++ b/src/capture/middlewares/header_middleware/mdns_decoder.c
@@ -5,10 +5,7 @@
  * @copyright
  * SPDX-FileCopyrightText: © 2021 NQMCyber Ltd and edgesec contributors
  * SPDX-License-Identifier: LGPL-3.0-or-later
- */
-
-/**
- * @file mdns_decoder.c
+ *
  * @author Alexandru Mereacre
  * @brief File containing the implementation of the mdns packet decoder
  * utilities.

--- a/src/capture/middlewares/header_middleware/mdns_decoder.c
+++ b/src/capture/middlewares/header_middleware/mdns_decoder.c
@@ -6,7 +6,6 @@
  * SPDX-FileCopyrightText: © 2021 NQMCyber Ltd and edgesec contributors
  * SPDX-License-Identifier: LGPL-3.0-or-later
  *
- * @author Alexandru Mereacre
  * @brief File containing the implementation of the mdns packet decoder
  * utilities.
  */

--- a/src/capture/middlewares/header_middleware/mdns_decoder.c
+++ b/src/capture/middlewares/header_middleware/mdns_decoder.c
@@ -5,7 +5,6 @@
  * @copyright
  * SPDX-FileCopyrightText: © 2021 NQMCyber Ltd and edgesec contributors
  * SPDX-License-Identifier: LGPL-3.0-or-later
- *
  * @brief File containing the implementation of the mdns packet decoder
  * utilities.
  */

--- a/src/capture/middlewares/header_middleware/mdns_decoder.c
+++ b/src/capture/middlewares/header_middleware/mdns_decoder.c
@@ -1,21 +1,11 @@
-/****************************************************************************
- * Copyright (C) 2021 by NQMCyber Ltd                                       *
- *                                                                          *
- * This file is part of EDGESec.                                            *
- *                                                                          *
- *   EDGESec is free software: you can redistribute it and/or modify it     *
- *   under the terms of the GNU Lesser General Public License as published  *
- *   by the Free Software Foundation, either version 3 of the License, or   *
- *   (at your option) any later version.                                    *
- *                                                                          *
- *   EDGESec is distributed in the hope that it will be useful,             *
- *   but WITHOUT ANY WARRANTY; without even the implied warranty of         *
- *   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the          *
- *   GNU Lesser General Public License for more details.                    *
- *                                                                          *
- *   You should have received a copy of the GNU Lesser General Public       *
- *   License along with EDGESec. If not, see <http://www.gnu.org/licenses/>.*
- ****************************************************************************/
+/**
+ * @file
+ * @author Alexandru Mereacre
+ * @date 2021
+ * @copyright
+ * SPDX-FileCopyrightText: © 2021 NQMCyber Ltd and edgesec contributors
+ * SPDX-License-Identifier: LGPL-3.0-or-later
+ */
 
 /**
  * @file mdns_decoder.c

--- a/src/capture/middlewares/header_middleware/mdns_decoder.h
+++ b/src/capture/middlewares/header_middleware/mdns_decoder.h
@@ -5,7 +5,6 @@
  * @copyright
  * SPDX-FileCopyrightText: © 2021 NQMCyber Ltd and edgesec contributors
  * SPDX-License-Identifier: LGPL-3.0-or-later
- *
  * @brief File containing the definition of the mdns packet decoder utilities.
  */
 

--- a/src/capture/middlewares/header_middleware/mdns_decoder.h
+++ b/src/capture/middlewares/header_middleware/mdns_decoder.h
@@ -5,10 +5,7 @@
  * @copyright
  * SPDX-FileCopyrightText: © 2021 NQMCyber Ltd and edgesec contributors
  * SPDX-License-Identifier: LGPL-3.0-or-later
- */
-
-/**
- * @file mdns_decoder.h
+ *
  * @author Alexandru Mereacre
  * @brief File containing the definition of the mdns packet decoder utilities.
  */

--- a/src/capture/middlewares/header_middleware/mdns_decoder.h
+++ b/src/capture/middlewares/header_middleware/mdns_decoder.h
@@ -6,7 +6,6 @@
  * SPDX-FileCopyrightText: © 2021 NQMCyber Ltd and edgesec contributors
  * SPDX-License-Identifier: LGPL-3.0-or-later
  *
- * @author Alexandru Mereacre
  * @brief File containing the definition of the mdns packet decoder utilities.
  */
 

--- a/src/capture/middlewares/header_middleware/mdns_decoder.h
+++ b/src/capture/middlewares/header_middleware/mdns_decoder.h
@@ -1,21 +1,11 @@
-/****************************************************************************
- * Copyright (C) 2021 by NQMCyber Ltd                                       *
- *                                                                          *
- * This file is part of EDGESec.                                            *
- *                                                                          *
- *   EDGESec is free software: you can redistribute it and/or modify it     *
- *   under the terms of the GNU Lesser General Public License as published  *
- *   by the Free Software Foundation, either version 3 of the License, or   *
- *   (at your option) any later version.                                    *
- *                                                                          *
- *   EDGESec is distributed in the hope that it will be useful,             *
- *   but WITHOUT ANY WARRANTY; without even the implied warranty of         *
- *   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the          *
- *   GNU Lesser General Public License for more details.                    *
- *                                                                          *
- *   You should have received a copy of the GNU Lesser General Public       *
- *   License along with EDGESec. If not, see <http://www.gnu.org/licenses/>.*
- ****************************************************************************/
+/**
+ * @file
+ * @author Alexandru Mereacre
+ * @date 2021
+ * @copyright
+ * SPDX-FileCopyrightText: © 2021 NQMCyber Ltd and edgesec contributors
+ * SPDX-License-Identifier: LGPL-3.0-or-later
+ */
 
 /**
  * @file mdns_decoder.h

--- a/src/capture/middlewares/header_middleware/packet_decoder.c
+++ b/src/capture/middlewares/header_middleware/packet_decoder.c
@@ -6,7 +6,6 @@
  * SPDX-FileCopyrightText: © 2021 NQMCyber Ltd and edgesec contributors
  * SPDX-License-Identifier: LGPL-3.0-or-later
  *
- * @author Alexandru Mereacre
  * @brief File containing the implementation of the packet decoder utilities.
  */
 

--- a/src/capture/middlewares/header_middleware/packet_decoder.c
+++ b/src/capture/middlewares/header_middleware/packet_decoder.c
@@ -1,21 +1,11 @@
-/****************************************************************************
- * Copyright (C) 2021 by NQMCyber Ltd                                       *
- *                                                                          *
- * This file is part of EDGESec.                                            *
- *                                                                          *
- *   EDGESec is free software: you can redistribute it and/or modify it     *
- *   under the terms of the GNU Lesser General Public License as published  *
- *   by the Free Software Foundation, either version 3 of the License, or   *
- *   (at your option) any later version.                                    *
- *                                                                          *
- *   EDGESec is distributed in the hope that it will be useful,             *
- *   but WITHOUT ANY WARRANTY; without even the implied warranty of         *
- *   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the          *
- *   GNU Lesser General Public License for more details.                    *
- *                                                                          *
- *   You should have received a copy of the GNU Lesser General Public       *
- *   License along with EDGESec. If not, see <http://www.gnu.org/licenses/>.*
- ****************************************************************************/
+/**
+ * @file
+ * @author Alexandru Mereacre
+ * @date 2021
+ * @copyright
+ * SPDX-FileCopyrightText: © 2021 NQMCyber Ltd and edgesec contributors
+ * SPDX-License-Identifier: LGPL-3.0-or-later
+ */
 
 /**
  * @file packet_decoder.c

--- a/src/capture/middlewares/header_middleware/packet_decoder.c
+++ b/src/capture/middlewares/header_middleware/packet_decoder.c
@@ -5,7 +5,6 @@
  * @copyright
  * SPDX-FileCopyrightText: © 2021 NQMCyber Ltd and edgesec contributors
  * SPDX-License-Identifier: LGPL-3.0-or-later
- *
  * @brief File containing the implementation of the packet decoder utilities.
  */
 

--- a/src/capture/middlewares/header_middleware/packet_decoder.c
+++ b/src/capture/middlewares/header_middleware/packet_decoder.c
@@ -5,10 +5,7 @@
  * @copyright
  * SPDX-FileCopyrightText: © 2021 NQMCyber Ltd and edgesec contributors
  * SPDX-License-Identifier: LGPL-3.0-or-later
- */
-
-/**
- * @file packet_decoder.c
+ *
  * @author Alexandru Mereacre
  * @brief File containing the implementation of the packet decoder utilities.
  */

--- a/src/capture/middlewares/header_middleware/packet_decoder.h
+++ b/src/capture/middlewares/header_middleware/packet_decoder.h
@@ -5,7 +5,6 @@
  * @copyright
  * SPDX-FileCopyrightText: © 2021 NQMCyber Ltd and edgesec contributors
  * SPDX-License-Identifier: LGPL-3.0-or-later
- *
  * @brief File containing the definition of the packet decoder utilities.
  */
 

--- a/src/capture/middlewares/header_middleware/packet_decoder.h
+++ b/src/capture/middlewares/header_middleware/packet_decoder.h
@@ -6,7 +6,6 @@
  * SPDX-FileCopyrightText: © 2021 NQMCyber Ltd and edgesec contributors
  * SPDX-License-Identifier: LGPL-3.0-or-later
  *
- * @author Alexandru Mereacre
  * @brief File containing the definition of the packet decoder utilities.
  */
 

--- a/src/capture/middlewares/header_middleware/packet_decoder.h
+++ b/src/capture/middlewares/header_middleware/packet_decoder.h
@@ -5,10 +5,7 @@
  * @copyright
  * SPDX-FileCopyrightText: © 2021 NQMCyber Ltd and edgesec contributors
  * SPDX-License-Identifier: LGPL-3.0-or-later
- */
-
-/**
- * @file packet_decoder.h
+ *
  * @author Alexandru Mereacre
  * @brief File containing the definition of the packet decoder utilities.
  */

--- a/src/capture/middlewares/header_middleware/packet_decoder.h
+++ b/src/capture/middlewares/header_middleware/packet_decoder.h
@@ -1,21 +1,11 @@
-/****************************************************************************
- * Copyright (C) 2021 by NQMCyber Ltd                                       *
- *                                                                          *
- * This file is part of EDGESec.                                            *
- *                                                                          *
- *   EDGESec is free software: you can redistribute it and/or modify it     *
- *   under the terms of the GNU Lesser General Public License as published  *
- *   by the Free Software Foundation, either version 3 of the License, or   *
- *   (at your option) any later version.                                    *
- *                                                                          *
- *   EDGESec is distributed in the hope that it will be useful,             *
- *   but WITHOUT ANY WARRANTY; without even the implied warranty of         *
- *   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the          *
- *   GNU Lesser General Public License for more details.                    *
- *                                                                          *
- *   You should have received a copy of the GNU Lesser General Public       *
- *   License along with EDGESec. If not, see <http://www.gnu.org/licenses/>.*
- ****************************************************************************/
+/**
+ * @file
+ * @author Alexandru Mereacre
+ * @date 2021
+ * @copyright
+ * SPDX-FileCopyrightText: © 2021 NQMCyber Ltd and edgesec contributors
+ * SPDX-License-Identifier: LGPL-3.0-or-later
+ */
 
 /**
  * @file packet_decoder.h

--- a/src/capture/middlewares/header_middleware/packet_queue.c
+++ b/src/capture/middlewares/header_middleware/packet_queue.c
@@ -1,21 +1,11 @@
-/****************************************************************************
- * Copyright (C) 2021 by NQMCyber Ltd                                       *
- *                                                                          *
- * This file is part of EDGESec.                                            *
- *                                                                          *
- *   EDGESec is free software: you can redistribute it and/or modify it     *
- *   under the terms of the GNU Lesser General Public License as published  *
- *   by the Free Software Foundation, either version 3 of the License, or   *
- *   (at your option) any later version.                                    *
- *                                                                          *
- *   EDGESec is distributed in the hope that it will be useful,             *
- *   but WITHOUT ANY WARRANTY; without even the implied warranty of         *
- *   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the          *
- *   GNU Lesser General Public License for more details.                    *
- *                                                                          *
- *   You should have received a copy of the GNU Lesser General Public       *
- *   License along with EDGESec. If not, see <http://www.gnu.org/licenses/>.*
- ****************************************************************************/
+/**
+ * @file
+ * @author Alexandru Mereacre
+ * @date 2021
+ * @copyright
+ * SPDX-FileCopyrightText: © 2021 NQMCyber Ltd and edgesec contributors
+ * SPDX-License-Identifier: LGPL-3.0-or-later
+ */
 
 /**
  * @file packet_queue.c

--- a/src/capture/middlewares/header_middleware/packet_queue.c
+++ b/src/capture/middlewares/header_middleware/packet_queue.c
@@ -6,7 +6,6 @@
  * SPDX-FileCopyrightText: © 2021 NQMCyber Ltd and edgesec contributors
  * SPDX-License-Identifier: LGPL-3.0-or-later
  *
- * @author Alexandru Mereacre
  * @brief File containing the implementation of the packet queue utilities.
  */
 

--- a/src/capture/middlewares/header_middleware/packet_queue.c
+++ b/src/capture/middlewares/header_middleware/packet_queue.c
@@ -5,10 +5,7 @@
  * @copyright
  * SPDX-FileCopyrightText: © 2021 NQMCyber Ltd and edgesec contributors
  * SPDX-License-Identifier: LGPL-3.0-or-later
- */
-
-/**
- * @file packet_queue.c
+ *
  * @author Alexandru Mereacre
  * @brief File containing the implementation of the packet queue utilities.
  */

--- a/src/capture/middlewares/header_middleware/packet_queue.c
+++ b/src/capture/middlewares/header_middleware/packet_queue.c
@@ -5,7 +5,6 @@
  * @copyright
  * SPDX-FileCopyrightText: © 2021 NQMCyber Ltd and edgesec contributors
  * SPDX-License-Identifier: LGPL-3.0-or-later
- *
  * @brief File containing the implementation of the packet queue utilities.
  */
 

--- a/src/capture/middlewares/header_middleware/packet_queue.h
+++ b/src/capture/middlewares/header_middleware/packet_queue.h
@@ -5,10 +5,7 @@
  * @copyright
  * SPDX-FileCopyrightText: © 2021 NQMCyber Ltd and edgesec contributors
  * SPDX-License-Identifier: LGPL-3.0-or-later
- */
-
-/**
- * @file packet_queue.h
+ *
  * @author Alexandru Mereacre
  * @brief File containing the definition of the packet queue utilities.
  */

--- a/src/capture/middlewares/header_middleware/packet_queue.h
+++ b/src/capture/middlewares/header_middleware/packet_queue.h
@@ -1,21 +1,11 @@
-/****************************************************************************
- * Copyright (C) 2021 by NQMCyber Ltd                                       *
- *                                                                          *
- * This file is part of EDGESec.                                            *
- *                                                                          *
- *   EDGESec is free software: you can redistribute it and/or modify it     *
- *   under the terms of the GNU Lesser General Public License as published  *
- *   by the Free Software Foundation, either version 3 of the License, or   *
- *   (at your option) any later version.                                    *
- *                                                                          *
- *   EDGESec is distributed in the hope that it will be useful,             *
- *   but WITHOUT ANY WARRANTY; without even the implied warranty of         *
- *   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the          *
- *   GNU Lesser General Public License for more details.                    *
- *                                                                          *
- *   You should have received a copy of the GNU Lesser General Public       *
- *   License along with EDGESec. If not, see <http://www.gnu.org/licenses/>.*
- ****************************************************************************/
+/**
+ * @file
+ * @author Alexandru Mereacre
+ * @date 2021
+ * @copyright
+ * SPDX-FileCopyrightText: © 2021 NQMCyber Ltd and edgesec contributors
+ * SPDX-License-Identifier: LGPL-3.0-or-later
+ */
 
 /**
  * @file packet_queue.h

--- a/src/capture/middlewares/header_middleware/packet_queue.h
+++ b/src/capture/middlewares/header_middleware/packet_queue.h
@@ -5,7 +5,6 @@
  * @copyright
  * SPDX-FileCopyrightText: © 2021 NQMCyber Ltd and edgesec contributors
  * SPDX-License-Identifier: LGPL-3.0-or-later
- *
  * @brief File containing the definition of the packet queue utilities.
  */
 

--- a/src/capture/middlewares/header_middleware/packet_queue.h
+++ b/src/capture/middlewares/header_middleware/packet_queue.h
@@ -6,7 +6,6 @@
  * SPDX-FileCopyrightText: © 2021 NQMCyber Ltd and edgesec contributors
  * SPDX-License-Identifier: LGPL-3.0-or-later
  *
- * @author Alexandru Mereacre
  * @brief File containing the definition of the packet queue utilities.
  */
 

--- a/src/capture/middlewares/header_middleware/sqlite_header.c
+++ b/src/capture/middlewares/header_middleware/sqlite_header.c
@@ -1,21 +1,11 @@
-/****************************************************************************
- * Copyright (C) 2021 by NQMCyber Ltd                                       *
- *                                                                          *
- * This file is part of EDGESec.                                            *
- *                                                                          *
- *   EDGESec is free software: you can redistribute it and/or modify it     *
- *   under the terms of the GNU Lesser General Public License as published  *
- *   by the Free Software Foundation, either version 3 of the License, or   *
- *   (at your option) any later version.                                    *
- *                                                                          *
- *   EDGESec is distributed in the hope that it will be useful,             *
- *   but WITHOUT ANY WARRANTY; without even the implied warranty of         *
- *   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the          *
- *   GNU Lesser General Public License for more details.                    *
- *                                                                          *
- *   You should have received a copy of the GNU Lesser General Public       *
- *   License along with EDGESec. If not, see <http://www.gnu.org/licenses/>.*
- ****************************************************************************/
+/**
+ * @file
+ * @author Alexandru Mereacre
+ * @date 2021
+ * @copyright
+ * SPDX-FileCopyrightText: © 2021 NQMCyber Ltd and edgesec contributors
+ * SPDX-License-Identifier: LGPL-3.0-or-later
+ */
 
 /**
  * @file sqlite_header.c

--- a/src/capture/middlewares/header_middleware/sqlite_header.c
+++ b/src/capture/middlewares/header_middleware/sqlite_header.c
@@ -5,7 +5,6 @@
  * @copyright
  * SPDX-FileCopyrightText: © 2021 NQMCyber Ltd and edgesec contributors
  * SPDX-License-Identifier: LGPL-3.0-or-later
- *
  * @brief File containing the implementation of the sqlite header
  * utilities.
  */

--- a/src/capture/middlewares/header_middleware/sqlite_header.c
+++ b/src/capture/middlewares/header_middleware/sqlite_header.c
@@ -6,7 +6,6 @@
  * SPDX-FileCopyrightText: © 2021 NQMCyber Ltd and edgesec contributors
  * SPDX-License-Identifier: LGPL-3.0-or-later
  *
- * @author Alexandru Mereacre
  * @brief File containing the implementation of the sqlite header
  * utilities.
  */

--- a/src/capture/middlewares/header_middleware/sqlite_header.c
+++ b/src/capture/middlewares/header_middleware/sqlite_header.c
@@ -5,10 +5,7 @@
  * @copyright
  * SPDX-FileCopyrightText: © 2021 NQMCyber Ltd and edgesec contributors
  * SPDX-License-Identifier: LGPL-3.0-or-later
- */
-
-/**
- * @file sqlite_header.c
+ *
  * @author Alexandru Mereacre
  * @brief File containing the implementation of the sqlite header
  * utilities.

--- a/src/capture/middlewares/header_middleware/sqlite_header.h
+++ b/src/capture/middlewares/header_middleware/sqlite_header.h
@@ -6,7 +6,6 @@
  * SPDX-FileCopyrightText: © 2021 NQMCyber Ltd and edgesec contributors
  * SPDX-License-Identifier: LGPL-3.0-or-later
  *
- * @author Alexandru Mereacre
  * @brief File containing the definition of the sqlite header utilities.
  */
 

--- a/src/capture/middlewares/header_middleware/sqlite_header.h
+++ b/src/capture/middlewares/header_middleware/sqlite_header.h
@@ -5,7 +5,6 @@
  * @copyright
  * SPDX-FileCopyrightText: © 2021 NQMCyber Ltd and edgesec contributors
  * SPDX-License-Identifier: LGPL-3.0-or-later
- *
  * @brief File containing the definition of the sqlite header utilities.
  */
 

--- a/src/capture/middlewares/header_middleware/sqlite_header.h
+++ b/src/capture/middlewares/header_middleware/sqlite_header.h
@@ -5,10 +5,7 @@
  * @copyright
  * SPDX-FileCopyrightText: © 2021 NQMCyber Ltd and edgesec contributors
  * SPDX-License-Identifier: LGPL-3.0-or-later
- */
-
-/**
- * @file slite_header.h
+ *
  * @author Alexandru Mereacre
  * @brief File containing the definition of the sqlite header utilities.
  */

--- a/src/capture/middlewares/header_middleware/sqlite_header.h
+++ b/src/capture/middlewares/header_middleware/sqlite_header.h
@@ -1,21 +1,11 @@
-/****************************************************************************
- * Copyright (C) 2021 by NQMCyber Ltd                                       *
- *                                                                          *
- * This file is part of EDGESec.                                            *
- *                                                                          *
- *   EDGESec is free software: you can redistribute it and/or modify it     *
- *   under the terms of the GNU Lesser General Public License as published  *
- *   by the Free Software Foundation, either version 3 of the License, or   *
- *   (at your option) any later version.                                    *
- *                                                                          *
- *   EDGESec is distributed in the hope that it will be useful,             *
- *   but WITHOUT ANY WARRANTY; without even the implied warranty of         *
- *   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the          *
- *   GNU Lesser General Public License for more details.                    *
- *                                                                          *
- *   You should have received a copy of the GNU Lesser General Public       *
- *   License along with EDGESec. If not, see <http://www.gnu.org/licenses/>.*
- ****************************************************************************/
+/**
+ * @file
+ * @author Alexandru Mereacre
+ * @date 2021
+ * @copyright
+ * SPDX-FileCopyrightText: © 2021 NQMCyber Ltd and edgesec contributors
+ * SPDX-License-Identifier: LGPL-3.0-or-later
+ */
 
 /**
  * @file slite_header.h

--- a/src/capture/middlewares/pcap_middleware/pcap_middleware.c
+++ b/src/capture/middlewares/pcap_middleware/pcap_middleware.c
@@ -5,10 +5,7 @@
  * @copyright
  * SPDX-FileCopyrightText: © 2021 NQMCyber Ltd and edgesec contributors
  * SPDX-License-Identifier: LGPL-3.0-or-later
- */
-
-/**
- * @file pcap_middleware.c
+ *
  * @author Alexandru Mereacre
  * @brief File containing the implementation of the pcap middleware
  * utilities.

--- a/src/capture/middlewares/pcap_middleware/pcap_middleware.c
+++ b/src/capture/middlewares/pcap_middleware/pcap_middleware.c
@@ -5,7 +5,6 @@
  * @copyright
  * SPDX-FileCopyrightText: © 2021 NQMCyber Ltd and edgesec contributors
  * SPDX-License-Identifier: LGPL-3.0-or-later
- *
  * @brief File containing the implementation of the pcap middleware
  * utilities.
  */

--- a/src/capture/middlewares/pcap_middleware/pcap_middleware.c
+++ b/src/capture/middlewares/pcap_middleware/pcap_middleware.c
@@ -6,7 +6,6 @@
  * SPDX-FileCopyrightText: © 2021 NQMCyber Ltd and edgesec contributors
  * SPDX-License-Identifier: LGPL-3.0-or-later
  *
- * @author Alexandru Mereacre
  * @brief File containing the implementation of the pcap middleware
  * utilities.
  */

--- a/src/capture/middlewares/pcap_middleware/pcap_middleware.c
+++ b/src/capture/middlewares/pcap_middleware/pcap_middleware.c
@@ -1,21 +1,11 @@
-/****************************************************************************
- * Copyright (C) 2021 by NQMCyber Ltd                                       *
- *                                                                          *
- * This file is part of EDGESec.                                            *
- *                                                                          *
- *   EDGESec is free software: you can redistribute it and/or modify it     *
- *   under the terms of the GNU Lesser General Public License as published  *
- *   by the Free Software Foundation, either version 3 of the License, or   *
- *   (at your option) any later version.                                    *
- *                                                                          *
- *   EDGESec is distributed in the hope that it will be useful,             *
- *   but WITHOUT ANY WARRANTY; without even the implied warranty of         *
- *   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the          *
- *   GNU Lesser General Public License for more details.                    *
- *                                                                          *
- *   You should have received a copy of the GNU Lesser General Public       *
- *   License along with EDGESec. If not, see <http://www.gnu.org/licenses/>.*
- ****************************************************************************/
+/**
+ * @file
+ * @author Alexandru Mereacre
+ * @date 2021
+ * @copyright
+ * SPDX-FileCopyrightText: © 2021 NQMCyber Ltd and edgesec contributors
+ * SPDX-License-Identifier: LGPL-3.0-or-later
+ */
 
 /**
  * @file pcap_middleware.c

--- a/src/capture/middlewares/pcap_middleware/pcap_middleware.h
+++ b/src/capture/middlewares/pcap_middleware/pcap_middleware.h
@@ -18,7 +18,7 @@
  * The PCAP capture middleware stores the full PCAP data from captured
  * middlewares. Because this is a lot of data, we recommended using the
  * ::cleaner_middleware too, to automatically cleanup/delete old PCAP files.
- * @author Alexandru Mereacre, Alois Klink
+ * @authors Alexandru Mereacre, Alois Klink
  */
 extern struct capture_middleware pcap_middleware;
 #endif

--- a/src/capture/middlewares/pcap_middleware/pcap_middleware.h
+++ b/src/capture/middlewares/pcap_middleware/pcap_middleware.h
@@ -5,7 +5,6 @@
  * @copyright
  * SPDX-FileCopyrightText: © 2021 NQMCyber Ltd and edgesec contributors
  * SPDX-License-Identifier: LGPL-3.0-or-later
- *
  * @brief File containing the definition of the pcap middleware utilities.
  */
 

--- a/src/capture/middlewares/pcap_middleware/pcap_middleware.h
+++ b/src/capture/middlewares/pcap_middleware/pcap_middleware.h
@@ -1,21 +1,11 @@
-/****************************************************************************
- * Copyright (C) 2021 by NQMCyber Ltd                                       *
- *                                                                          *
- * This file is part of EDGESec.                                            *
- *                                                                          *
- *   EDGESec is free software: you can redistribute it and/or modify it     *
- *   under the terms of the GNU Lesser General Public License as published  *
- *   by the Free Software Foundation, either version 3 of the License, or   *
- *   (at your option) any later version.                                    *
- *                                                                          *
- *   EDGESec is distributed in the hope that it will be useful,             *
- *   but WITHOUT ANY WARRANTY; without even the implied warranty of         *
- *   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the          *
- *   GNU Lesser General Public License for more details.                    *
- *                                                                          *
- *   You should have received a copy of the GNU Lesser General Public       *
- *   License along with EDGESec. If not, see <http://www.gnu.org/licenses/>.*
- ****************************************************************************/
+/**
+ * @file
+ * @author Alexandru Mereacre
+ * @date 2021
+ * @copyright
+ * SPDX-FileCopyrightText: © 2021 NQMCyber Ltd and edgesec contributors
+ * SPDX-License-Identifier: LGPL-3.0-or-later
+ */
 
 /**
  * @file pcap_middleware.h

--- a/src/capture/middlewares/pcap_middleware/pcap_middleware.h
+++ b/src/capture/middlewares/pcap_middleware/pcap_middleware.h
@@ -6,7 +6,6 @@
  * SPDX-FileCopyrightText: © 2021 NQMCyber Ltd and edgesec contributors
  * SPDX-License-Identifier: LGPL-3.0-or-later
  *
- * @author Alexandru Mereacre
  * @brief File containing the definition of the pcap middleware utilities.
  */
 

--- a/src/capture/middlewares/pcap_middleware/pcap_middleware.h
+++ b/src/capture/middlewares/pcap_middleware/pcap_middleware.h
@@ -5,10 +5,7 @@
  * @copyright
  * SPDX-FileCopyrightText: © 2021 NQMCyber Ltd and edgesec contributors
  * SPDX-License-Identifier: LGPL-3.0-or-later
- */
-
-/**
- * @file pcap_middleware.h
+ *
  * @author Alexandru Mereacre
  * @brief File containing the definition of the pcap middleware utilities.
  */

--- a/src/capture/middlewares/pcap_middleware/pcap_queue.c
+++ b/src/capture/middlewares/pcap_middleware/pcap_queue.c
@@ -1,21 +1,11 @@
-/****************************************************************************
- * Copyright (C) 2021 by NQMCyber Ltd                                       *
- *                                                                          *
- * This file is part of EDGESec.                                            *
- *                                                                          *
- *   EDGESec is free software: you can redistribute it and/or modify it     *
- *   under the terms of the GNU Lesser General Public License as published  *
- *   by the Free Software Foundation, either version 3 of the License, or   *
- *   (at your option) any later version.                                    *
- *                                                                          *
- *   EDGESec is distributed in the hope that it will be useful,             *
- *   but WITHOUT ANY WARRANTY; without even the implied warranty of         *
- *   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the          *
- *   GNU Lesser General Public License for more details.                    *
- *                                                                          *
- *   You should have received a copy of the GNU Lesser General Public       *
- *   License along with EDGESec. If not, see <http://www.gnu.org/licenses/>.*
- ****************************************************************************/
+/**
+ * @file
+ * @author Alexandru Mereacre
+ * @date 2021
+ * @copyright
+ * SPDX-FileCopyrightText: © 2021 NQMCyber Ltd and edgesec contributors
+ * SPDX-License-Identifier: LGPL-3.0-or-later
+ */
 
 /**
  * @file pcap_queue.c

--- a/src/capture/middlewares/pcap_middleware/pcap_queue.c
+++ b/src/capture/middlewares/pcap_middleware/pcap_queue.c
@@ -5,7 +5,6 @@
  * @copyright
  * SPDX-FileCopyrightText: © 2021 NQMCyber Ltd and edgesec contributors
  * SPDX-License-Identifier: LGPL-3.0-or-later
- *
  * @brief File containing the implementation of the pcap queue utilities.
  */
 

--- a/src/capture/middlewares/pcap_middleware/pcap_queue.c
+++ b/src/capture/middlewares/pcap_middleware/pcap_queue.c
@@ -6,7 +6,6 @@
  * SPDX-FileCopyrightText: © 2021 NQMCyber Ltd and edgesec contributors
  * SPDX-License-Identifier: LGPL-3.0-or-later
  *
- * @author Alexandru Mereacre
  * @brief File containing the implementation of the pcap queue utilities.
  */
 

--- a/src/capture/middlewares/pcap_middleware/pcap_queue.c
+++ b/src/capture/middlewares/pcap_middleware/pcap_queue.c
@@ -5,10 +5,7 @@
  * @copyright
  * SPDX-FileCopyrightText: © 2021 NQMCyber Ltd and edgesec contributors
  * SPDX-License-Identifier: LGPL-3.0-or-later
- */
-
-/**
- * @file pcap_queue.c
+ *
  * @author Alexandru Mereacre
  * @brief File containing the implementation of the pcap queue utilities.
  */

--- a/src/capture/middlewares/pcap_middleware/pcap_queue.h
+++ b/src/capture/middlewares/pcap_middleware/pcap_queue.h
@@ -5,10 +5,7 @@
  * @copyright
  * SPDX-FileCopyrightText: © 2021 NQMCyber Ltd and edgesec contributors
  * SPDX-License-Identifier: LGPL-3.0-or-later
- */
-
-/**
- * @file pcap_queue.h
+ *
  * @author Alexandru Mereacre
  * @brief File containing the definition of the pcap queue utilities.
  */

--- a/src/capture/middlewares/pcap_middleware/pcap_queue.h
+++ b/src/capture/middlewares/pcap_middleware/pcap_queue.h
@@ -5,7 +5,6 @@
  * @copyright
  * SPDX-FileCopyrightText: © 2021 NQMCyber Ltd and edgesec contributors
  * SPDX-License-Identifier: LGPL-3.0-or-later
- *
  * @brief File containing the definition of the pcap queue utilities.
  */
 

--- a/src/capture/middlewares/pcap_middleware/pcap_queue.h
+++ b/src/capture/middlewares/pcap_middleware/pcap_queue.h
@@ -1,21 +1,11 @@
-/****************************************************************************
- * Copyright (C) 2021 by NQMCyber Ltd                                       *
- *                                                                          *
- * This file is part of EDGESec.                                            *
- *                                                                          *
- *   EDGESec is free software: you can redistribute it and/or modify it     *
- *   under the terms of the GNU Lesser General Public License as published  *
- *   by the Free Software Foundation, either version 3 of the License, or   *
- *   (at your option) any later version.                                    *
- *                                                                          *
- *   EDGESec is distributed in the hope that it will be useful,             *
- *   but WITHOUT ANY WARRANTY; without even the implied warranty of         *
- *   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the          *
- *   GNU Lesser General Public License for more details.                    *
- *                                                                          *
- *   You should have received a copy of the GNU Lesser General Public       *
- *   License along with EDGESec. If not, see <http://www.gnu.org/licenses/>.*
- ****************************************************************************/
+/**
+ * @file
+ * @author Alexandru Mereacre
+ * @date 2021
+ * @copyright
+ * SPDX-FileCopyrightText: © 2021 NQMCyber Ltd and edgesec contributors
+ * SPDX-License-Identifier: LGPL-3.0-or-later
+ */
 
 /**
  * @file pcap_queue.h

--- a/src/capture/middlewares/pcap_middleware/pcap_queue.h
+++ b/src/capture/middlewares/pcap_middleware/pcap_queue.h
@@ -6,7 +6,6 @@
  * SPDX-FileCopyrightText: © 2021 NQMCyber Ltd and edgesec contributors
  * SPDX-License-Identifier: LGPL-3.0-or-later
  *
- * @author Alexandru Mereacre
  * @brief File containing the definition of the pcap queue utilities.
  */
 

--- a/src/capture/middlewares/pcap_middleware/sqlite_pcap.c
+++ b/src/capture/middlewares/pcap_middleware/sqlite_pcap.c
@@ -1,21 +1,11 @@
-/****************************************************************************
- * Copyright (C) 2021 by NQMCyber Ltd                                       *
- *                                                                          *
- * This file is part of EDGESec.                                            *
- *                                                                          *
- *   EDGESec is free software: you can redistribute it and/or modify it     *
- *   under the terms of the GNU Lesser General Public License as published  *
- *   by the Free Software Foundation, either version 3 of the License, or   *
- *   (at your option) any later version.                                    *
- *                                                                          *
- *   EDGESec is distributed in the hope that it will be useful,             *
- *   but WITHOUT ANY WARRANTY; without even the implied warranty of         *
- *   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the          *
- *   GNU Lesser General Public License for more details.                    *
- *                                                                          *
- *   You should have received a copy of the GNU Lesser General Public       *
- *   License along with EDGESec. If not, see <http://www.gnu.org/licenses/>.*
- ****************************************************************************/
+/**
+ * @file
+ * @author Alexandru Mereacre
+ * @date 2021
+ * @copyright
+ * SPDX-FileCopyrightText: © 2021 NQMCyber Ltd and edgesec contributors
+ * SPDX-License-Identifier: LGPL-3.0-or-later
+ */
 
 /**
  * @file sqlite_pcap.c

--- a/src/capture/middlewares/pcap_middleware/sqlite_pcap.c
+++ b/src/capture/middlewares/pcap_middleware/sqlite_pcap.c
@@ -6,7 +6,6 @@
  * SPDX-FileCopyrightText: © 2021 NQMCyber Ltd and edgesec contributors
  * SPDX-License-Identifier: LGPL-3.0-or-later
  *
- * @author Alexandru Mereacre
  * @brief File containing the implementation of the sqlite pcap utilities.
  */
 

--- a/src/capture/middlewares/pcap_middleware/sqlite_pcap.c
+++ b/src/capture/middlewares/pcap_middleware/sqlite_pcap.c
@@ -5,7 +5,6 @@
  * @copyright
  * SPDX-FileCopyrightText: © 2021 NQMCyber Ltd and edgesec contributors
  * SPDX-License-Identifier: LGPL-3.0-or-later
- *
  * @brief File containing the implementation of the sqlite pcap utilities.
  */
 

--- a/src/capture/middlewares/pcap_middleware/sqlite_pcap.c
+++ b/src/capture/middlewares/pcap_middleware/sqlite_pcap.c
@@ -5,10 +5,7 @@
  * @copyright
  * SPDX-FileCopyrightText: © 2021 NQMCyber Ltd and edgesec contributors
  * SPDX-License-Identifier: LGPL-3.0-or-later
- */
-
-/**
- * @file sqlite_pcap.c
+ *
  * @author Alexandru Mereacre
  * @brief File containing the implementation of the sqlite pcap utilities.
  */

--- a/src/capture/middlewares/pcap_middleware/sqlite_pcap.h
+++ b/src/capture/middlewares/pcap_middleware/sqlite_pcap.h
@@ -6,7 +6,6 @@
  * SPDX-FileCopyrightText: © 2021 NQMCyber Ltd and edgesec contributors
  * SPDX-License-Identifier: LGPL-3.0-or-later
  *
- * @author Alexandru Mereacre
  * @brief File containing the definition of the sqlite pcap utilities.
  */
 

--- a/src/capture/middlewares/pcap_middleware/sqlite_pcap.h
+++ b/src/capture/middlewares/pcap_middleware/sqlite_pcap.h
@@ -5,10 +5,7 @@
  * @copyright
  * SPDX-FileCopyrightText: © 2021 NQMCyber Ltd and edgesec contributors
  * SPDX-License-Identifier: LGPL-3.0-or-later
- */
-
-/**
- * @file sqlite_pcap.h
+ *
  * @author Alexandru Mereacre
  * @brief File containing the definition of the sqlite pcap utilities.
  */

--- a/src/capture/middlewares/pcap_middleware/sqlite_pcap.h
+++ b/src/capture/middlewares/pcap_middleware/sqlite_pcap.h
@@ -5,7 +5,6 @@
  * @copyright
  * SPDX-FileCopyrightText: © 2021 NQMCyber Ltd and edgesec contributors
  * SPDX-License-Identifier: LGPL-3.0-or-later
- *
  * @brief File containing the definition of the sqlite pcap utilities.
  */
 

--- a/src/capture/middlewares/pcap_middleware/sqlite_pcap.h
+++ b/src/capture/middlewares/pcap_middleware/sqlite_pcap.h
@@ -1,21 +1,11 @@
-/****************************************************************************
- * Copyright (C) 2021 by NQMCyber Ltd                                       *
- *                                                                          *
- * This file is part of EDGESec.                                            *
- *                                                                          *
- *   EDGESec is free software: you can redistribute it and/or modify it     *
- *   under the terms of the GNU Lesser General Public License as published  *
- *   by the Free Software Foundation, either version 3 of the License, or   *
- *   (at your option) any later version.                                    *
- *                                                                          *
- *   EDGESec is distributed in the hope that it will be useful,             *
- *   but WITHOUT ANY WARRANTY; without even the implied warranty of         *
- *   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the          *
- *   GNU Lesser General Public License for more details.                    *
- *                                                                          *
- *   You should have received a copy of the GNU Lesser General Public       *
- *   License along with EDGESec. If not, see <http://www.gnu.org/licenses/>.*
- ****************************************************************************/
+/**
+ * @file
+ * @author Alexandru Mereacre
+ * @date 2021
+ * @copyright
+ * SPDX-FileCopyrightText: © 2021 NQMCyber Ltd and edgesec contributors
+ * SPDX-License-Identifier: LGPL-3.0-or-later
+ */
 
 /**
  * @file sqlite_pcap.h

--- a/src/capture/middlewares_list.h
+++ b/src/capture/middlewares_list.h
@@ -1,6 +1,6 @@
 /**
  * @file middlewares_list.h
- * @author Alexandru Mereacre, Alois Klink
+ * @authors Alexandru Mereacre, Alois Klink
  * @brief File containing the definition of generic middleware creation
  * functions.
  * @details The CMake function `edgesecAddCaptureMiddleware` generated a custom

--- a/src/capture/pcap_service.c
+++ b/src/capture/pcap_service.c
@@ -5,7 +5,6 @@
  * @copyright
  * SPDX-FileCopyrightText: © 2021 NQMCyber Ltd and edgesec contributors
  * SPDX-License-Identifier: LGPL-3.0-or-later
- *
  * @brief File containing the implementation of the pcap service utilities.
  */
 #include <linux/if.h>

--- a/src/capture/pcap_service.c
+++ b/src/capture/pcap_service.c
@@ -5,10 +5,7 @@
  * @copyright
  * SPDX-FileCopyrightText: © 2021 NQMCyber Ltd and edgesec contributors
  * SPDX-License-Identifier: LGPL-3.0-or-later
- */
-
-/**
- * @file pcap_service.c
+ *
  * @author Alexandru Mereacre
  * @brief File containing the implementation of the pcap service utilities.
  */

--- a/src/capture/pcap_service.c
+++ b/src/capture/pcap_service.c
@@ -1,21 +1,11 @@
-/****************************************************************************
- * Copyright (C) 2021 by NQMCyber Ltd                                       *
- *                                                                          *
- * This file is part of EDGESec.                                            *
- *                                                                          *
- *   EDGESec is free software: you can redistribute it and/or modify it     *
- *   under the terms of the GNU Lesser General Public License as published  *
- *   by the Free Software Foundation, either version 3 of the License, or   *
- *   (at your option) any later version.                                    *
- *                                                                          *
- *   EDGESec is distributed in the hope that it will be useful,             *
- *   but WITHOUT ANY WARRANTY; without even the implied warranty of         *
- *   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the          *
- *   GNU Lesser General Public License for more details.                    *
- *                                                                          *
- *   You should have received a copy of the GNU Lesser General Public       *
- *   License along with EDGESec. If not, see <http://www.gnu.org/licenses/>.*
- ****************************************************************************/
+/**
+ * @file
+ * @author Alexandru Mereacre
+ * @date 2021
+ * @copyright
+ * SPDX-FileCopyrightText: © 2021 NQMCyber Ltd and edgesec contributors
+ * SPDX-License-Identifier: LGPL-3.0-or-later
+ */
 
 /**
  * @file pcap_service.c

--- a/src/capture/pcap_service.c
+++ b/src/capture/pcap_service.c
@@ -6,7 +6,6 @@
  * SPDX-FileCopyrightText: © 2021 NQMCyber Ltd and edgesec contributors
  * SPDX-License-Identifier: LGPL-3.0-or-later
  *
- * @author Alexandru Mereacre
  * @brief File containing the implementation of the pcap service utilities.
  */
 #include <linux/if.h>

--- a/src/capture/pcap_service.h
+++ b/src/capture/pcap_service.h
@@ -5,10 +5,7 @@
  * @copyright
  * SPDX-FileCopyrightText: © 2021 NQMCyber Ltd and edgesec contributors
  * SPDX-License-Identifier: LGPL-3.0-or-later
- */
-
-/**
- * @file pcap_service.h
+ *
  * @author Alexandru Mereacre
  * @brief File containing the definition of the pcap service utilities.
  */

--- a/src/capture/pcap_service.h
+++ b/src/capture/pcap_service.h
@@ -5,7 +5,6 @@
  * @copyright
  * SPDX-FileCopyrightText: © 2021 NQMCyber Ltd and edgesec contributors
  * SPDX-License-Identifier: LGPL-3.0-or-later
- *
  * @brief File containing the definition of the pcap service utilities.
  */
 

--- a/src/capture/pcap_service.h
+++ b/src/capture/pcap_service.h
@@ -1,21 +1,11 @@
-/****************************************************************************
- * Copyright (C) 2021 by NQMCyber Ltd                                       *
- *                                                                          *
- * This file is part of EDGESec.                                            *
- *                                                                          *
- *   EDGESec is free software: you can redistribute it and/or modify it     *
- *   under the terms of the GNU Lesser General Public License as published  *
- *   by the Free Software Foundation, either version 3 of the License, or   *
- *   (at your option) any later version.                                    *
- *                                                                          *
- *   EDGESec is distributed in the hope that it will be useful,             *
- *   but WITHOUT ANY WARRANTY; without even the implied warranty of         *
- *   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the          *
- *   GNU Lesser General Public License for more details.                    *
- *                                                                          *
- *   You should have received a copy of the GNU Lesser General Public       *
- *   License along with EDGESec. If not, see <http://www.gnu.org/licenses/>.*
- ****************************************************************************/
+/**
+ * @file
+ * @author Alexandru Mereacre
+ * @date 2021
+ * @copyright
+ * SPDX-FileCopyrightText: © 2021 NQMCyber Ltd and edgesec contributors
+ * SPDX-License-Identifier: LGPL-3.0-or-later
+ */
 
 /**
  * @file pcap_service.h

--- a/src/capture/pcap_service.h
+++ b/src/capture/pcap_service.h
@@ -6,7 +6,6 @@
  * SPDX-FileCopyrightText: © 2021 NQMCyber Ltd and edgesec contributors
  * SPDX-License-Identifier: LGPL-3.0-or-later
  *
- * @author Alexandru Mereacre
  * @brief File containing the definition of the pcap service utilities.
  */
 

--- a/src/config.c
+++ b/src/config.c
@@ -8,7 +8,7 @@
  */
 
 /**
- * @file config.c
+ *
  * @author Alexandru Mereacre
  * @brief File containing the implementation of the app configuration utilities.
  */

--- a/src/config.c
+++ b/src/config.c
@@ -1,21 +1,11 @@
-/****************************************************************************
- * Copyright (C) 2021 by NQMCyber Ltd                                       *
- *                                                                          *
- * This file is part of EDGESec.                                            *
- *                                                                          *
- *   EDGESec is free software: you can redistribute it and/or modify it     *
- *   under the terms of the GNU Lesser General Public License as published  *
- *   by the Free Software Foundation, either version 3 of the License, or   *
- *   (at your option) any later version.                                    *
- *                                                                          *
- *   EDGESec is distributed in the hope that it will be useful,             *
- *   but WITHOUT ANY WARRANTY; without even the implied warranty of         *
- *   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the          *
- *   GNU Lesser General Public License for more details.                    *
- *                                                                          *
- *   You should have received a copy of the GNU Lesser General Public       *
- *   License along with EDGESec. If not, see <http://www.gnu.org/licenses/>.*
- ****************************************************************************/
+/**
+ * @file
+ * @author Alexandru Mereacre
+ * @date 2021
+ * @copyright
+ * SPDX-FileCopyrightText: © 2021 NQMCyber Ltd and edgesec contributors
+ * SPDX-License-Identifier: LGPL-3.0-or-later
+ */
 
 /**
  * @file config.c

--- a/src/config.c
+++ b/src/config.c
@@ -9,7 +9,6 @@
 
 /**
  *
- * @author Alexandru Mereacre
  * @brief File containing the implementation of the app configuration utilities.
  */
 

--- a/src/config.c
+++ b/src/config.c
@@ -5,10 +5,6 @@
  * @copyright
  * SPDX-FileCopyrightText: © 2021 NQMCyber Ltd and edgesec contributors
  * SPDX-License-Identifier: LGPL-3.0-or-later
- */
-
-/**
- *
  * @brief File containing the implementation of the app configuration utilities.
  */
 

--- a/src/config.h
+++ b/src/config.h
@@ -5,10 +5,7 @@
  * @copyright
  * SPDX-FileCopyrightText: © 2021 NQMCyber Ltd and edgesec contributors
  * SPDX-License-Identifier: LGPL-3.0-or-later
- */
-
-/**
- * @file config.h
+ *
  * @author Alexandru Mereacre
  * @brief File containing the definition of the app configuration utilities.
  */

--- a/src/config.h
+++ b/src/config.h
@@ -6,7 +6,6 @@
  * SPDX-FileCopyrightText: © 2021 NQMCyber Ltd and edgesec contributors
  * SPDX-License-Identifier: LGPL-3.0-or-later
  *
- * @author Alexandru Mereacre
  * @brief File containing the definition of the app configuration utilities.
  */
 #ifndef CONFIG_H

--- a/src/config.h
+++ b/src/config.h
@@ -5,7 +5,6 @@
  * @copyright
  * SPDX-FileCopyrightText: © 2021 NQMCyber Ltd and edgesec contributors
  * SPDX-License-Identifier: LGPL-3.0-or-later
- *
  * @brief File containing the definition of the app configuration utilities.
  */
 #ifndef CONFIG_H

--- a/src/config.h
+++ b/src/config.h
@@ -1,21 +1,11 @@
-/****************************************************************************
- * Copyright (C) 2021 by NQMCyber Ltd                                       *
- *                                                                          *
- * This file is part of EDGESec.                                            *
- *                                                                          *
- *   EDGESec is free software: you can redistribute it and/or modify it     *
- *   under the terms of the GNU Lesser General Public License as published  *
- *   by the Free Software Foundation, either version 3 of the License, or   *
- *   (at your option) any later version.                                    *
- *                                                                          *
- *   EDGESec is distributed in the hope that it will be useful,             *
- *   but WITHOUT ANY WARRANTY; without even the implied warranty of         *
- *   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the          *
- *   GNU Lesser General Public License for more details.                    *
- *                                                                          *
- *   You should have received a copy of the GNU Lesser General Public       *
- *   License along with EDGESec. If not, see <http://www.gnu.org/licenses/>.*
- ****************************************************************************/
+/**
+ * @file
+ * @author Alexandru Mereacre
+ * @date 2021
+ * @copyright
+ * SPDX-FileCopyrightText: © 2021 NQMCyber Ltd and edgesec contributors
+ * SPDX-License-Identifier: LGPL-3.0-or-later
+ */
 
 /**
  * @file config.h

--- a/src/crypt/crypt_config.h
+++ b/src/crypt/crypt_config.h
@@ -1,21 +1,11 @@
-/****************************************************************************
- * Copyright (C) 2021 by NQMCyber Ltd                                       *
- *                                                                          *
- * This file is part of EDGESec.                                            *
- *                                                                          *
- *   EDGESec is free software: you can redistribute it and/or modify it     *
- *   under the terms of the GNU Lesser General Public License as published  *
- *   by the Free Software Foundation, either version 3 of the License, or   *
- *   (at your option) any later version.                                    *
- *                                                                          *
- *   EDGESec is distributed in the hope that it will be useful,             *
- *   but WITHOUT ANY WARRANTY; without even the implied warranty of         *
- *   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the          *
- *   GNU Lesser General Public License for more details.                    *
- *                                                                          *
- *   You should have received a copy of the GNU Lesser General Public       *
- *   License along with EDGESec. If not, see <http://www.gnu.org/licenses/>.*
- ****************************************************************************/
+/**
+ * @file
+ * @author Alexandru Mereacre
+ * @date 2021
+ * @copyright
+ * SPDX-FileCopyrightText: © 2021 NQMCyber Ltd and edgesec contributors
+ * SPDX-License-Identifier: LGPL-3.0-or-later
+ */
 
 /**
  * @file crypt_config.h

--- a/src/crypt/crypt_config.h
+++ b/src/crypt/crypt_config.h
@@ -6,7 +6,6 @@
  * SPDX-FileCopyrightText: © 2021 NQMCyber Ltd and edgesec contributors
  * SPDX-License-Identifier: LGPL-3.0-or-later
  *
- * @author Alexandru Mereacre
  * @brief File containing the definition of crypt configuration structure.
  */
 #ifndef CRYPT_CONFIG_H

--- a/src/crypt/crypt_config.h
+++ b/src/crypt/crypt_config.h
@@ -5,7 +5,6 @@
  * @copyright
  * SPDX-FileCopyrightText: © 2021 NQMCyber Ltd and edgesec contributors
  * SPDX-License-Identifier: LGPL-3.0-or-later
- *
  * @brief File containing the definition of crypt configuration structure.
  */
 #ifndef CRYPT_CONFIG_H

--- a/src/crypt/crypt_config.h
+++ b/src/crypt/crypt_config.h
@@ -5,10 +5,7 @@
  * @copyright
  * SPDX-FileCopyrightText: © 2021 NQMCyber Ltd and edgesec contributors
  * SPDX-License-Identifier: LGPL-3.0-or-later
- */
-
-/**
- * @file crypt_config.h
+ *
  * @author Alexandru Mereacre
  * @brief File containing the definition of crypt configuration structure.
  */

--- a/src/crypt/crypt_service.c
+++ b/src/crypt/crypt_service.c
@@ -5,7 +5,6 @@
  * @copyright
  * SPDX-FileCopyrightText: © 2021 NQMCyber Ltd and edgesec contributors
  * SPDX-License-Identifier: LGPL-3.0-or-later
- *
  * @brief File containing the implementation of crypt service configuration
  * utilities.
  */

--- a/src/crypt/crypt_service.c
+++ b/src/crypt/crypt_service.c
@@ -6,7 +6,6 @@
  * SPDX-FileCopyrightText: © 2021 NQMCyber Ltd and edgesec contributors
  * SPDX-License-Identifier: LGPL-3.0-or-later
  *
- * @author Alexandru Mereacre
  * @brief File containing the implementation of crypt service configuration
  * utilities.
  */

--- a/src/crypt/crypt_service.c
+++ b/src/crypt/crypt_service.c
@@ -1,21 +1,11 @@
-/****************************************************************************
- * Copyright (C) 2021 by NQMCyber Ltd                                       *
- *                                                                          *
- * This file is part of EDGESec.                                            *
- *                                                                          *
- *   EDGESec is free software: you can redistribute it and/or modify it     *
- *   under the terms of the GNU Lesser General Public License as published  *
- *   by the Free Software Foundation, either version 3 of the License, or   *
- *   (at your option) any later version.                                    *
- *                                                                          *
- *   EDGESec is distributed in the hope that it will be useful,             *
- *   but WITHOUT ANY WARRANTY; without even the implied warranty of         *
- *   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the          *
- *   GNU Lesser General Public License for more details.                    *
- *                                                                          *
- *   You should have received a copy of the GNU Lesser General Public       *
- *   License along with EDGESec. If not, see <http://www.gnu.org/licenses/>.*
- ****************************************************************************/
+/**
+ * @file
+ * @author Alexandru Mereacre
+ * @date 2021
+ * @copyright
+ * SPDX-FileCopyrightText: © 2021 NQMCyber Ltd and edgesec contributors
+ * SPDX-License-Identifier: LGPL-3.0-or-later
+ */
 
 /**
  * @file crypt_service.c

--- a/src/crypt/crypt_service.c
+++ b/src/crypt/crypt_service.c
@@ -5,10 +5,7 @@
  * @copyright
  * SPDX-FileCopyrightText: © 2021 NQMCyber Ltd and edgesec contributors
  * SPDX-License-Identifier: LGPL-3.0-or-later
- */
-
-/**
- * @file crypt_service.c
+ *
  * @author Alexandru Mereacre
  * @brief File containing the implementation of crypt service configuration
  * utilities.

--- a/src/crypt/crypt_service.h
+++ b/src/crypt/crypt_service.h
@@ -1,21 +1,11 @@
-/****************************************************************************
- * Copyright (C) 2021 by NQMCyber Ltd                                       *
- *                                                                          *
- * This file is part of EDGESec.                                            *
- *                                                                          *
- *   EDGESec is free software: you can redistribute it and/or modify it     *
- *   under the terms of the GNU Lesser General Public License as published  *
- *   by the Free Software Foundation, either version 3 of the License, or   *
- *   (at your option) any later version.                                    *
- *                                                                          *
- *   EDGESec is distributed in the hope that it will be useful,             *
- *   but WITHOUT ANY WARRANTY; without even the implied warranty of         *
- *   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the          *
- *   GNU Lesser General Public License for more details.                    *
- *                                                                          *
- *   You should have received a copy of the GNU Lesser General Public       *
- *   License along with EDGESec. If not, see <http://www.gnu.org/licenses/>.*
- ****************************************************************************/
+/**
+ * @file
+ * @author Alexandru Mereacre
+ * @date 2021
+ * @copyright
+ * SPDX-FileCopyrightText: © 2021 NQMCyber Ltd and edgesec contributors
+ * SPDX-License-Identifier: LGPL-3.0-or-later
+ */
 
 /**
  * @file crypt_service.h

--- a/src/crypt/crypt_service.h
+++ b/src/crypt/crypt_service.h
@@ -5,7 +5,6 @@
  * @copyright
  * SPDX-FileCopyrightText: © 2021 NQMCyber Ltd and edgesec contributors
  * SPDX-License-Identifier: LGPL-3.0-or-later
- *
  * @brief File containing the definition of crypt service configuration
  * utilities.
  */

--- a/src/crypt/crypt_service.h
+++ b/src/crypt/crypt_service.h
@@ -5,10 +5,7 @@
  * @copyright
  * SPDX-FileCopyrightText: © 2021 NQMCyber Ltd and edgesec contributors
  * SPDX-License-Identifier: LGPL-3.0-or-later
- */
-
-/**
- * @file crypt_service.h
+ *
  * @author Alexandru Mereacre
  * @brief File containing the definition of crypt service configuration
  * utilities.

--- a/src/crypt/crypt_service.h
+++ b/src/crypt/crypt_service.h
@@ -6,7 +6,6 @@
  * SPDX-FileCopyrightText: © 2021 NQMCyber Ltd and edgesec contributors
  * SPDX-License-Identifier: LGPL-3.0-or-later
  *
- * @author Alexandru Mereacre
  * @brief File containing the definition of crypt service configuration
  * utilities.
  */

--- a/src/crypt/generic_hsm_driver.c
+++ b/src/crypt/generic_hsm_driver.c
@@ -6,7 +6,6 @@
  * SPDX-FileCopyrightText: © 2021 NQMCyber Ltd and edgesec contributors
  * SPDX-License-Identifier: LGPL-3.0-or-later
  *
- * @author Alexandru Mereacre
  * @brief File containing the implementation of generic HSM driver configuration
  * utilities.
  */

--- a/src/crypt/generic_hsm_driver.c
+++ b/src/crypt/generic_hsm_driver.c
@@ -1,21 +1,11 @@
-/****************************************************************************
- * Copyright (C) 2021 by NQMCyber Ltd                                       *
- *                                                                          *
- * This file is part of EDGESec.                                            *
- *                                                                          *
- *   EDGESec is free software: you can redistribute it and/or modify it     *
- *   under the terms of the GNU Lesser General Public License as published  *
- *   by the Free Software Foundation, either version 3 of the License, or   *
- *   (at your option) any later version.                                    *
- *                                                                          *
- *   EDGESec is distributed in the hope that it will be useful,             *
- *   but WITHOUT ANY WARRANTY; without even the implied warranty of         *
- *   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the          *
- *   GNU Lesser General Public License for more details.                    *
- *                                                                          *
- *   You should have received a copy of the GNU Lesser General Public       *
- *   License along with EDGESec. If not, see <http://www.gnu.org/licenses/>.*
- ****************************************************************************/
+/**
+ * @file
+ * @author Alexandru Mereacre
+ * @date 2021
+ * @copyright
+ * SPDX-FileCopyrightText: © 2021 NQMCyber Ltd and edgesec contributors
+ * SPDX-License-Identifier: LGPL-3.0-or-later
+ */
 
 /**
  * @file generic_hsm_driver.c

--- a/src/crypt/generic_hsm_driver.c
+++ b/src/crypt/generic_hsm_driver.c
@@ -5,10 +5,7 @@
  * @copyright
  * SPDX-FileCopyrightText: © 2021 NQMCyber Ltd and edgesec contributors
  * SPDX-License-Identifier: LGPL-3.0-or-later
- */
-
-/**
- * @file generic_hsm_driver.c
+ *
  * @author Alexandru Mereacre
  * @brief File containing the implementation of generic HSM driver configuration
  * utilities.

--- a/src/crypt/generic_hsm_driver.c
+++ b/src/crypt/generic_hsm_driver.c
@@ -5,7 +5,6 @@
  * @copyright
  * SPDX-FileCopyrightText: © 2021 NQMCyber Ltd and edgesec contributors
  * SPDX-License-Identifier: LGPL-3.0-or-later
- *
  * @brief File containing the implementation of generic HSM driver configuration
  * utilities.
  */

--- a/src/crypt/generic_hsm_driver.h
+++ b/src/crypt/generic_hsm_driver.h
@@ -6,7 +6,6 @@
  * SPDX-FileCopyrightText: © 2021 NQMCyber Ltd and edgesec contributors
  * SPDX-License-Identifier: LGPL-3.0-or-later
  *
- * @author Alexandru Mereacre
  * @brief File containing the definition of generic HSM driver configuration
  * utilities.
  */

--- a/src/crypt/generic_hsm_driver.h
+++ b/src/crypt/generic_hsm_driver.h
@@ -5,10 +5,7 @@
  * @copyright
  * SPDX-FileCopyrightText: © 2021 NQMCyber Ltd and edgesec contributors
  * SPDX-License-Identifier: LGPL-3.0-or-later
- */
-
-/**
- * @file generic_hsm_driver.h
+ *
  * @author Alexandru Mereacre
  * @brief File containing the definition of generic HSM driver configuration
  * utilities.

--- a/src/crypt/generic_hsm_driver.h
+++ b/src/crypt/generic_hsm_driver.h
@@ -1,21 +1,11 @@
-/****************************************************************************
- * Copyright (C) 2021 by NQMCyber Ltd                                       *
- *                                                                          *
- * This file is part of EDGESec.                                            *
- *                                                                          *
- *   EDGESec is free software: you can redistribute it and/or modify it     *
- *   under the terms of the GNU Lesser General Public License as published  *
- *   by the Free Software Foundation, either version 3 of the License, or   *
- *   (at your option) any later version.                                    *
- *                                                                          *
- *   EDGESec is distributed in the hope that it will be useful,             *
- *   but WITHOUT ANY WARRANTY; without even the implied warranty of         *
- *   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the          *
- *   GNU Lesser General Public License for more details.                    *
- *                                                                          *
- *   You should have received a copy of the GNU Lesser General Public       *
- *   License along with EDGESec. If not, see <http://www.gnu.org/licenses/>.*
- ****************************************************************************/
+/**
+ * @file
+ * @author Alexandru Mereacre
+ * @date 2021
+ * @copyright
+ * SPDX-FileCopyrightText: © 2021 NQMCyber Ltd and edgesec contributors
+ * SPDX-License-Identifier: LGPL-3.0-or-later
+ */
 
 /**
  * @file generic_hsm_driver.h

--- a/src/crypt/generic_hsm_driver.h
+++ b/src/crypt/generic_hsm_driver.h
@@ -5,7 +5,6 @@
  * @copyright
  * SPDX-FileCopyrightText: © 2021 NQMCyber Ltd and edgesec contributors
  * SPDX-License-Identifier: LGPL-3.0-or-later
- *
  * @brief File containing the definition of generic HSM driver configuration
  * utilities.
  */

--- a/src/crypt/sqlite_crypt_writer.c
+++ b/src/crypt/sqlite_crypt_writer.c
@@ -5,10 +5,7 @@
  * @copyright
  * SPDX-FileCopyrightText: © 2021 NQMCyber Ltd and edgesec contributors
  * SPDX-License-Identifier: LGPL-3.0-or-later
- */
-
-/**
- * @file sqlite_crypt_writer.c
+ *
  * @author Alexandru Mereacre
  * @brief File containing the implementation of the sqlite crypt writer
  * utilities.

--- a/src/crypt/sqlite_crypt_writer.c
+++ b/src/crypt/sqlite_crypt_writer.c
@@ -6,7 +6,6 @@
  * SPDX-FileCopyrightText: © 2021 NQMCyber Ltd and edgesec contributors
  * SPDX-License-Identifier: LGPL-3.0-or-later
  *
- * @author Alexandru Mereacre
  * @brief File containing the implementation of the sqlite crypt writer
  * utilities.
  */

--- a/src/crypt/sqlite_crypt_writer.c
+++ b/src/crypt/sqlite_crypt_writer.c
@@ -1,21 +1,11 @@
-/****************************************************************************
- * Copyright (C) 2021 by NQMCyber Ltd                                       *
- *                                                                          *
- * This file is part of EDGESec.                                            *
- *                                                                          *
- *   EDGESec is free software: you can redistribute it and/or modify it     *
- *   under the terms of the GNU Lesser General Public License as published  *
- *   by the Free Software Foundation, either version 3 of the License, or   *
- *   (at your option) any later version.                                    *
- *                                                                          *
- *   EDGESec is distributed in the hope that it will be useful,             *
- *   but WITHOUT ANY WARRANTY; without even the implied warranty of         *
- *   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the          *
- *   GNU Lesser General Public License for more details.                    *
- *                                                                          *
- *   You should have received a copy of the GNU Lesser General Public       *
- *   License along with EDGESec. If not, see <http://www.gnu.org/licenses/>.*
- ****************************************************************************/
+/**
+ * @file
+ * @author Alexandru Mereacre
+ * @date 2021
+ * @copyright
+ * SPDX-FileCopyrightText: © 2021 NQMCyber Ltd and edgesec contributors
+ * SPDX-License-Identifier: LGPL-3.0-or-later
+ */
 
 /**
  * @file sqlite_crypt_writer.c

--- a/src/crypt/sqlite_crypt_writer.c
+++ b/src/crypt/sqlite_crypt_writer.c
@@ -5,7 +5,6 @@
  * @copyright
  * SPDX-FileCopyrightText: © 2021 NQMCyber Ltd and edgesec contributors
  * SPDX-License-Identifier: LGPL-3.0-or-later
- *
  * @brief File containing the implementation of the sqlite crypt writer
  * utilities.
  */

--- a/src/crypt/sqlite_crypt_writer.h
+++ b/src/crypt/sqlite_crypt_writer.h
@@ -1,21 +1,11 @@
-/****************************************************************************
- * Copyright (C) 2021 by NQMCyber Ltd                                       *
- *                                                                          *
- * This file is part of EDGESec.                                            *
- *                                                                          *
- *   EDGESec is free software: you can redistribute it and/or modify it     *
- *   under the terms of the GNU Lesser General Public License as published  *
- *   by the Free Software Foundation, either version 3 of the License, or   *
- *   (at your option) any later version.                                    *
- *                                                                          *
- *   EDGESec is distributed in the hope that it will be useful,             *
- *   but WITHOUT ANY WARRANTY; without even the implied warranty of         *
- *   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the          *
- *   GNU Lesser General Public License for more details.                    *
- *                                                                          *
- *   You should have received a copy of the GNU Lesser General Public       *
- *   License along with EDGESec. If not, see <http://www.gnu.org/licenses/>.*
- ****************************************************************************/
+/**
+ * @file
+ * @author Alexandru Mereacre
+ * @date 2021
+ * @copyright
+ * SPDX-FileCopyrightText: © 2021 NQMCyber Ltd and edgesec contributors
+ * SPDX-License-Identifier: LGPL-3.0-or-later
+ */
 
 /**
  * @file sqlite_crypt_writer.h

--- a/src/crypt/sqlite_crypt_writer.h
+++ b/src/crypt/sqlite_crypt_writer.h
@@ -5,10 +5,7 @@
  * @copyright
  * SPDX-FileCopyrightText: © 2021 NQMCyber Ltd and edgesec contributors
  * SPDX-License-Identifier: LGPL-3.0-or-later
- */
-
-/**
- * @file sqlite_crypt_writer.h
+ *
  * @author Alexandru Mereacre
  * @brief File containing the definition of the sqlite crypt writer utilities.
  */

--- a/src/crypt/sqlite_crypt_writer.h
+++ b/src/crypt/sqlite_crypt_writer.h
@@ -6,7 +6,6 @@
  * SPDX-FileCopyrightText: © 2021 NQMCyber Ltd and edgesec contributors
  * SPDX-License-Identifier: LGPL-3.0-or-later
  *
- * @author Alexandru Mereacre
  * @brief File containing the definition of the sqlite crypt writer utilities.
  */
 

--- a/src/crypt/sqlite_crypt_writer.h
+++ b/src/crypt/sqlite_crypt_writer.h
@@ -5,7 +5,6 @@
  * @copyright
  * SPDX-FileCopyrightText: © 2021 NQMCyber Ltd and edgesec contributors
  * SPDX-License-Identifier: LGPL-3.0-or-later
- *
  * @brief File containing the definition of the sqlite crypt writer utilities.
  */
 

--- a/src/crypt/zymkey4_driver.c
+++ b/src/crypt/zymkey4_driver.c
@@ -1,21 +1,11 @@
-/****************************************************************************
- * Copyright (C) 2021 by NQMCyber Ltd                                       *
- *                                                                          *
- * This file is part of EDGESec.                                            *
- *                                                                          *
- *   EDGESec is free software: you can redistribute it and/or modify it     *
- *   under the terms of the GNU Lesser General Public License as published  *
- *   by the Free Software Foundation, either version 3 of the License, or   *
- *   (at your option) any later version.                                    *
- *                                                                          *
- *   EDGESec is distributed in the hope that it will be useful,             *
- *   but WITHOUT ANY WARRANTY; without even the implied warranty of         *
- *   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the          *
- *   GNU Lesser General Public License for more details.                    *
- *                                                                          *
- *   You should have received a copy of the GNU Lesser General Public       *
- *   License along with EDGESec. If not, see <http://www.gnu.org/licenses/>.*
- ****************************************************************************/
+/**
+ * @file
+ * @author Alexandru Mereacre
+ * @date 2021
+ * @copyright
+ * SPDX-FileCopyrightText: © 2021 NQMCyber Ltd and edgesec contributors
+ * SPDX-License-Identifier: LGPL-3.0-or-later
+ */
 
 /**
  * @file zymkey4_driver.c

--- a/src/crypt/zymkey4_driver.c
+++ b/src/crypt/zymkey4_driver.c
@@ -6,7 +6,6 @@
  * SPDX-FileCopyrightText: © 2021 NQMCyber Ltd and edgesec contributors
  * SPDX-License-Identifier: LGPL-3.0-or-later
  *
- * @author Alexandru Mereacre
  * @brief File containing the implementation of zymkey4 driver configuration
  * utilities.
  */

--- a/src/crypt/zymkey4_driver.c
+++ b/src/crypt/zymkey4_driver.c
@@ -5,10 +5,7 @@
  * @copyright
  * SPDX-FileCopyrightText: © 2021 NQMCyber Ltd and edgesec contributors
  * SPDX-License-Identifier: LGPL-3.0-or-later
- */
-
-/**
- * @file zymkey4_driver.c
+ *
  * @author Alexandru Mereacre
  * @brief File containing the implementation of zymkey4 driver configuration
  * utilities.

--- a/src/crypt/zymkey4_driver.c
+++ b/src/crypt/zymkey4_driver.c
@@ -5,7 +5,6 @@
  * @copyright
  * SPDX-FileCopyrightText: © 2021 NQMCyber Ltd and edgesec contributors
  * SPDX-License-Identifier: LGPL-3.0-or-later
- *
  * @brief File containing the implementation of zymkey4 driver configuration
  * utilities.
  */

--- a/src/crypt/zymkey4_driver.h
+++ b/src/crypt/zymkey4_driver.h
@@ -1,21 +1,11 @@
-/****************************************************************************
- * Copyright (C) 2021 by NQMCyber Ltd                                       *
- *                                                                          *
- * This file is part of EDGESec.                                            *
- *                                                                          *
- *   EDGESec is free software: you can redistribute it and/or modify it     *
- *   under the terms of the GNU Lesser General Public License as published  *
- *   by the Free Software Foundation, either version 3 of the License, or   *
- *   (at your option) any later version.                                    *
- *                                                                          *
- *   EDGESec is distributed in the hope that it will be useful,             *
- *   but WITHOUT ANY WARRANTY; without even the implied warranty of         *
- *   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the          *
- *   GNU Lesser General Public License for more details.                    *
- *                                                                          *
- *   You should have received a copy of the GNU Lesser General Public       *
- *   License along with EDGESec. If not, see <http://www.gnu.org/licenses/>.*
- ****************************************************************************/
+/**
+ * @file
+ * @author Alexandru Mereacre
+ * @date 2021
+ * @copyright
+ * SPDX-FileCopyrightText: © 2021 NQMCyber Ltd and edgesec contributors
+ * SPDX-License-Identifier: LGPL-3.0-or-later
+ */
 
 /**
  * @file zymkey4_driver.h

--- a/src/crypt/zymkey4_driver.h
+++ b/src/crypt/zymkey4_driver.h
@@ -5,7 +5,6 @@
  * @copyright
  * SPDX-FileCopyrightText: © 2021 NQMCyber Ltd and edgesec contributors
  * SPDX-License-Identifier: LGPL-3.0-or-later
- *
  * @brief File containing the definition of zymkey4 driver configuration
  * utilities.
  */

--- a/src/crypt/zymkey4_driver.h
+++ b/src/crypt/zymkey4_driver.h
@@ -6,7 +6,6 @@
  * SPDX-FileCopyrightText: © 2021 NQMCyber Ltd and edgesec contributors
  * SPDX-License-Identifier: LGPL-3.0-or-later
  *
- * @author Alexandru Mereacre
  * @brief File containing the definition of zymkey4 driver configuration
  * utilities.
  */

--- a/src/crypt/zymkey4_driver.h
+++ b/src/crypt/zymkey4_driver.h
@@ -5,10 +5,7 @@
  * @copyright
  * SPDX-FileCopyrightText: © 2021 NQMCyber Ltd and edgesec contributors
  * SPDX-License-Identifier: LGPL-3.0-or-later
- */
-
-/**
- * @file zymkey4_driver.h
+ *
  * @author Alexandru Mereacre
  * @brief File containing the definition of zymkey4 driver configuration
  * utilities.

--- a/src/dhcp/dhcp_config.h
+++ b/src/dhcp/dhcp_config.h
@@ -5,7 +5,6 @@
  * @copyright
  * SPDX-FileCopyrightText: © 2021 NQMCyber Ltd and edgesec contributors
  * SPDX-License-Identifier: LGPL-3.0-or-later
- *
  * @brief File containing the definition of dhcp configuration structures.
  */
 #ifndef DHCP_CONFIG_H

--- a/src/dhcp/dhcp_config.h
+++ b/src/dhcp/dhcp_config.h
@@ -1,21 +1,11 @@
-/****************************************************************************
- * Copyright (C) 2021 by NQMCyber Ltd                                       *
- *                                                                          *
- * This file is part of EDGESec.                                            *
- *                                                                          *
- *   EDGESec is free software: you can redistribute it and/or modify it     *
- *   under the terms of the GNU Lesser General Public License as published  *
- *   by the Free Software Foundation, either version 3 of the License, or   *
- *   (at your option) any later version.                                    *
- *                                                                          *
- *   EDGESec is distributed in the hope that it will be useful,             *
- *   but WITHOUT ANY WARRANTY; without even the implied warranty of         *
- *   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the          *
- *   GNU Lesser General Public License for more details.                    *
- *                                                                          *
- *   You should have received a copy of the GNU Lesser General Public       *
- *   License along with EDGESec. If not, see <http://www.gnu.org/licenses/>.*
- ****************************************************************************/
+/**
+ * @file
+ * @author Alexandru Mereacre
+ * @date 2021
+ * @copyright
+ * SPDX-FileCopyrightText: © 2021 NQMCyber Ltd and edgesec contributors
+ * SPDX-License-Identifier: LGPL-3.0-or-later
+ */
 
 /**
  * @file dhcp_config.h

--- a/src/dhcp/dhcp_config.h
+++ b/src/dhcp/dhcp_config.h
@@ -5,10 +5,7 @@
  * @copyright
  * SPDX-FileCopyrightText: © 2021 NQMCyber Ltd and edgesec contributors
  * SPDX-License-Identifier: LGPL-3.0-or-later
- */
-
-/**
- * @file dhcp_config.h
+ *
  * @author Alexandru Mereacre
  * @brief File containing the definition of dhcp configuration structures.
  */

--- a/src/dhcp/dhcp_config.h
+++ b/src/dhcp/dhcp_config.h
@@ -6,7 +6,6 @@
  * SPDX-FileCopyrightText: © 2021 NQMCyber Ltd and edgesec contributors
  * SPDX-License-Identifier: LGPL-3.0-or-later
  *
- * @author Alexandru Mereacre
  * @brief File containing the definition of dhcp configuration structures.
  */
 #ifndef DHCP_CONFIG_H

--- a/src/dhcp/dhcp_service.c
+++ b/src/dhcp/dhcp_service.c
@@ -6,7 +6,6 @@
  * SPDX-FileCopyrightText: © 2021 NQMCyber Ltd and edgesec contributors
  * SPDX-License-Identifier: LGPL-3.0-or-later
  *
- * @author Alexandru Mereacre
  * @brief File containing the implementation of dhcp service configuration
  * utilities.
  */

--- a/src/dhcp/dhcp_service.c
+++ b/src/dhcp/dhcp_service.c
@@ -5,7 +5,6 @@
  * @copyright
  * SPDX-FileCopyrightText: © 2021 NQMCyber Ltd and edgesec contributors
  * SPDX-License-Identifier: LGPL-3.0-or-later
- *
  * @brief File containing the implementation of dhcp service configuration
  * utilities.
  */

--- a/src/dhcp/dhcp_service.c
+++ b/src/dhcp/dhcp_service.c
@@ -5,10 +5,7 @@
  * @copyright
  * SPDX-FileCopyrightText: © 2021 NQMCyber Ltd and edgesec contributors
  * SPDX-License-Identifier: LGPL-3.0-or-later
- */
-
-/**
- * @file dhcp_service.c
+ *
  * @author Alexandru Mereacre
  * @brief File containing the implementation of dhcp service configuration
  * utilities.

--- a/src/dhcp/dhcp_service.c
+++ b/src/dhcp/dhcp_service.c
@@ -1,21 +1,11 @@
-/****************************************************************************
- * Copyright (C) 2021 by NQMCyber Ltd                                       *
- *                                                                          *
- * This file is part of EDGESec.                                            *
- *                                                                          *
- *   EDGESec is free software: you can redistribute it and/or modify it     *
- *   under the terms of the GNU Lesser General Public License as published  *
- *   by the Free Software Foundation, either version 3 of the License, or   *
- *   (at your option) any later version.                                    *
- *                                                                          *
- *   EDGESec is distributed in the hope that it will be useful,             *
- *   but WITHOUT ANY WARRANTY; without even the implied warranty of         *
- *   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the          *
- *   GNU Lesser General Public License for more details.                    *
- *                                                                          *
- *   You should have received a copy of the GNU Lesser General Public       *
- *   License along with EDGESec. If not, see <http://www.gnu.org/licenses/>.*
- ****************************************************************************/
+/**
+ * @file
+ * @author Alexandru Mereacre
+ * @date 2021
+ * @copyright
+ * SPDX-FileCopyrightText: © 2021 NQMCyber Ltd and edgesec contributors
+ * SPDX-License-Identifier: LGPL-3.0-or-later
+ */
 
 /**
  * @file dhcp_service.c

--- a/src/dhcp/dhcp_service.h
+++ b/src/dhcp/dhcp_service.h
@@ -5,7 +5,6 @@
  * @copyright
  * SPDX-FileCopyrightText: © 2021 NQMCyber Ltd and edgesec contributors
  * SPDX-License-Identifier: LGPL-3.0-or-later
- *
  * @brief File containing the definition of dhcp service configuration
  * utilities.
  */

--- a/src/dhcp/dhcp_service.h
+++ b/src/dhcp/dhcp_service.h
@@ -1,21 +1,11 @@
-/****************************************************************************
- * Copyright (C) 2021 by NQMCyber Ltd                                       *
- *                                                                          *
- * This file is part of EDGESec.                                            *
- *                                                                          *
- *   EDGESec is free software: you can redistribute it and/or modify it     *
- *   under the terms of the GNU Lesser General Public License as published  *
- *   by the Free Software Foundation, either version 3 of the License, or   *
- *   (at your option) any later version.                                    *
- *                                                                          *
- *   EDGESec is distributed in the hope that it will be useful,             *
- *   but WITHOUT ANY WARRANTY; without even the implied warranty of         *
- *   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the          *
- *   GNU Lesser General Public License for more details.                    *
- *                                                                          *
- *   You should have received a copy of the GNU Lesser General Public       *
- *   License along with EDGESec. If not, see <http://www.gnu.org/licenses/>.*
- ****************************************************************************/
+/**
+ * @file
+ * @author Alexandru Mereacre
+ * @date 2021
+ * @copyright
+ * SPDX-FileCopyrightText: © 2021 NQMCyber Ltd and edgesec contributors
+ * SPDX-License-Identifier: LGPL-3.0-or-later
+ */
 
 /**
  * @file dhcp_service.h

--- a/src/dhcp/dhcp_service.h
+++ b/src/dhcp/dhcp_service.h
@@ -5,10 +5,7 @@
  * @copyright
  * SPDX-FileCopyrightText: © 2021 NQMCyber Ltd and edgesec contributors
  * SPDX-License-Identifier: LGPL-3.0-or-later
- */
-
-/**
- * @file dhcp_service.h
+ *
  * @author Alexandru Mereacre
  * @brief File containing the definition of dhcp service configuration
  * utilities.

--- a/src/dhcp/dhcp_service.h
+++ b/src/dhcp/dhcp_service.h
@@ -6,7 +6,6 @@
  * SPDX-FileCopyrightText: © 2021 NQMCyber Ltd and edgesec contributors
  * SPDX-License-Identifier: LGPL-3.0-or-later
  *
- * @author Alexandru Mereacre
  * @brief File containing the definition of dhcp service configuration
  * utilities.
  */

--- a/src/dhcp/dnsmasq.c
+++ b/src/dhcp/dnsmasq.c
@@ -1,21 +1,11 @@
-/****************************************************************************
- * Copyright (C) 2021 by NQMCyber Ltd                                       *
- *                                                                          *
- * This file is part of EDGESec.                                            *
- *                                                                          *
- *   EDGESec is free software: you can redistribute it and/or modify it     *
- *   under the terms of the GNU Lesser General Public License as published  *
- *   by the Free Software Foundation, either version 3 of the License, or   *
- *   (at your option) any later version.                                    *
- *                                                                          *
- *   EDGESec is distributed in the hope that it will be useful,             *
- *   but WITHOUT ANY WARRANTY; without even the implied warranty of         *
- *   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the          *
- *   GNU Lesser General Public License for more details.                    *
- *                                                                          *
- *   You should have received a copy of the GNU Lesser General Public       *
- *   License along with EDGESec. If not, see <http://www.gnu.org/licenses/>.*
- ****************************************************************************/
+/**
+ * @file
+ * @author Alexandru Mereacre
+ * @date 2021
+ * @copyright
+ * SPDX-FileCopyrightText: © 2021 NQMCyber Ltd and edgesec contributors
+ * SPDX-License-Identifier: LGPL-3.0-or-later
+ */
 
 /**
  * @file dnsmasq.c

--- a/src/dhcp/dnsmasq.c
+++ b/src/dhcp/dnsmasq.c
@@ -6,7 +6,6 @@
  * SPDX-FileCopyrightText: © 2021 NQMCyber Ltd and edgesec contributors
  * SPDX-License-Identifier: LGPL-3.0-or-later
  *
- * @author Alexandru Mereacre
  * @brief File containing the implementation of dnsmasq service configuration
  * utilities.
  */

--- a/src/dhcp/dnsmasq.c
+++ b/src/dhcp/dnsmasq.c
@@ -5,7 +5,6 @@
  * @copyright
  * SPDX-FileCopyrightText: © 2021 NQMCyber Ltd and edgesec contributors
  * SPDX-License-Identifier: LGPL-3.0-or-later
- *
  * @brief File containing the implementation of dnsmasq service configuration
  * utilities.
  */

--- a/src/dhcp/dnsmasq.c
+++ b/src/dhcp/dnsmasq.c
@@ -5,10 +5,7 @@
  * @copyright
  * SPDX-FileCopyrightText: © 2021 NQMCyber Ltd and edgesec contributors
  * SPDX-License-Identifier: LGPL-3.0-or-later
- */
-
-/**
- * @file dnsmasq.c
+ *
  * @author Alexandru Mereacre
  * @brief File containing the implementation of dnsmasq service configuration
  * utilities.

--- a/src/dhcp/dnsmasq.h
+++ b/src/dhcp/dnsmasq.h
@@ -5,10 +5,7 @@
  * @copyright
  * SPDX-FileCopyrightText: © 2021 NQMCyber Ltd and edgesec contributors
  * SPDX-License-Identifier: LGPL-3.0-or-later
- */
-
-/**
- * @file dnsmasq.h
+ *
  * @author Alexandru Mereacre
  * @brief File containing the definition of dnsmasq service configuration
  * utilities.

--- a/src/dhcp/dnsmasq.h
+++ b/src/dhcp/dnsmasq.h
@@ -6,7 +6,6 @@
  * SPDX-FileCopyrightText: © 2021 NQMCyber Ltd and edgesec contributors
  * SPDX-License-Identifier: LGPL-3.0-or-later
  *
- * @author Alexandru Mereacre
  * @brief File containing the definition of dnsmasq service configuration
  * utilities.
  */

--- a/src/dhcp/dnsmasq.h
+++ b/src/dhcp/dnsmasq.h
@@ -5,7 +5,6 @@
  * @copyright
  * SPDX-FileCopyrightText: © 2021 NQMCyber Ltd and edgesec contributors
  * SPDX-License-Identifier: LGPL-3.0-or-later
- *
  * @brief File containing the definition of dnsmasq service configuration
  * utilities.
  */

--- a/src/dhcp/dnsmasq.h
+++ b/src/dhcp/dnsmasq.h
@@ -1,21 +1,11 @@
-/****************************************************************************
- * Copyright (C) 2021 by NQMCyber Ltd                                       *
- *                                                                          *
- * This file is part of EDGESec.                                            *
- *                                                                          *
- *   EDGESec is free software: you can redistribute it and/or modify it     *
- *   under the terms of the GNU Lesser General Public License as published  *
- *   by the Free Software Foundation, either version 3 of the License, or   *
- *   (at your option) any later version.                                    *
- *                                                                          *
- *   EDGESec is distributed in the hope that it will be useful,             *
- *   but WITHOUT ANY WARRANTY; without even the implied warranty of         *
- *   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the          *
- *   GNU Lesser General Public License for more details.                    *
- *                                                                          *
- *   You should have received a copy of the GNU Lesser General Public       *
- *   License along with EDGESec. If not, see <http://www.gnu.org/licenses/>.*
- ****************************************************************************/
+/**
+ * @file
+ * @author Alexandru Mereacre
+ * @date 2021
+ * @copyright
+ * SPDX-FileCopyrightText: © 2021 NQMCyber Ltd and edgesec contributors
+ * SPDX-License-Identifier: LGPL-3.0-or-later
+ */
 
 /**
  * @file dnsmasq.h

--- a/src/dns/command_mapper.c
+++ b/src/dns/command_mapper.c
@@ -5,7 +5,6 @@
  * @copyright
  * SPDX-FileCopyrightText: © 2021 NQMCyber Ltd and edgesec contributors
  * SPDX-License-Identifier: LGPL-3.0-or-later
- *
  * @brief File containing the implementation of the command mapper.
  */
 

--- a/src/dns/command_mapper.c
+++ b/src/dns/command_mapper.c
@@ -6,7 +6,6 @@
  * SPDX-FileCopyrightText: © 2021 NQMCyber Ltd and edgesec contributors
  * SPDX-License-Identifier: LGPL-3.0-or-later
  *
- * @author Alexandru Mereacre
  * @brief File containing the implementation of the command mapper.
  */
 

--- a/src/dns/command_mapper.c
+++ b/src/dns/command_mapper.c
@@ -1,21 +1,11 @@
-/****************************************************************************
- * Copyright (C) 2021 by NQMCyber Ltd                                       *
- *                                                                          *
- * This file is part of EDGESec.                                            *
- *                                                                          *
- *   EDGESec is free software: you can redistribute it and/or modify it     *
- *   under the terms of the GNU Lesser General Public License as published  *
- *   by the Free Software Foundation, either version 3 of the License, or   *
- *   (at your option) any later version.                                    *
- *                                                                          *
- *   EDGESec is distributed in the hope that it will be useful,             *
- *   but WITHOUT ANY WARRANTY; without even the implied warranty of         *
- *   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the          *
- *   GNU Lesser General Public License for more details.                    *
- *                                                                          *
- *   You should have received a copy of the GNU Lesser General Public       *
- *   License along with EDGESec. If not, see <http://www.gnu.org/licenses/>.*
- ****************************************************************************/
+/**
+ * @file
+ * @author Alexandru Mereacre
+ * @date 2021
+ * @copyright
+ * SPDX-FileCopyrightText: © 2021 NQMCyber Ltd and edgesec contributors
+ * SPDX-License-Identifier: LGPL-3.0-or-later
+ */
 
 /**
  * @file command_mapper.c

--- a/src/dns/command_mapper.c
+++ b/src/dns/command_mapper.c
@@ -5,10 +5,7 @@
  * @copyright
  * SPDX-FileCopyrightText: © 2021 NQMCyber Ltd and edgesec contributors
  * SPDX-License-Identifier: LGPL-3.0-or-later
- */
-
-/**
- * @file command_mapper.c
+ *
  * @author Alexandru Mereacre
  * @brief File containing the implementation of the command mapper.
  */

--- a/src/dns/command_mapper.h
+++ b/src/dns/command_mapper.h
@@ -1,21 +1,11 @@
-/****************************************************************************
- * Copyright (C) 2021 by NQMCyber Ltd                                       *
- *                                                                          *
- * This file is part of EDGESec.                                            *
- *                                                                          *
- *   EDGESec is free software: you can redistribute it and/or modify it     *
- *   under the terms of the GNU Lesser General Public License as published  *
- *   by the Free Software Foundation, either version 3 of the License, or   *
- *   (at your option) any later version.                                    *
- *                                                                          *
- *   EDGESec is distributed in the hope that it will be useful,             *
- *   but WITHOUT ANY WARRANTY; without even the implied warranty of         *
- *   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the          *
- *   GNU Lesser General Public License for more details.                    *
- *                                                                          *
- *   You should have received a copy of the GNU Lesser General Public       *
- *   License along with EDGESec. If not, see <http://www.gnu.org/licenses/>.*
- ****************************************************************************/
+/**
+ * @file
+ * @author Alexandru Mereacre
+ * @date 2021
+ * @copyright
+ * SPDX-FileCopyrightText: © 2021 NQMCyber Ltd and edgesec contributors
+ * SPDX-License-Identifier: LGPL-3.0-or-later
+ */
 
 /**
  * @file command_mapper.h

--- a/src/dns/command_mapper.h
+++ b/src/dns/command_mapper.h
@@ -5,10 +5,7 @@
  * @copyright
  * SPDX-FileCopyrightText: © 2021 NQMCyber Ltd and edgesec contributors
  * SPDX-License-Identifier: LGPL-3.0-or-later
- */
-
-/**
- * @file command_mapper.h
+ *
  * @author Alexandru Mereacre
  * @brief File containing the definition of the command mapper.
  */

--- a/src/dns/command_mapper.h
+++ b/src/dns/command_mapper.h
@@ -5,7 +5,6 @@
  * @copyright
  * SPDX-FileCopyrightText: © 2021 NQMCyber Ltd and edgesec contributors
  * SPDX-License-Identifier: LGPL-3.0-or-later
- *
  * @brief File containing the definition of the command mapper.
  */
 

--- a/src/dns/command_mapper.h
+++ b/src/dns/command_mapper.h
@@ -6,7 +6,6 @@
  * SPDX-FileCopyrightText: © 2021 NQMCyber Ltd and edgesec contributors
  * SPDX-License-Identifier: LGPL-3.0-or-later
  *
- * @author Alexandru Mereacre
  * @brief File containing the definition of the command mapper.
  */
 

--- a/src/dns/dns_config.h
+++ b/src/dns/dns_config.h
@@ -5,10 +5,7 @@
  * @copyright
  * SPDX-FileCopyrightText: © 2021 NQMCyber Ltd and edgesec contributors
  * SPDX-License-Identifier: LGPL-3.0-or-later
- */
-
-/**
- * @file dns_config.h
+ *
  * @author Alexandru Mereacre
  * @brief File containing the definition of dns service configuration utilities.
  */

--- a/src/dns/dns_config.h
+++ b/src/dns/dns_config.h
@@ -5,7 +5,6 @@
  * @copyright
  * SPDX-FileCopyrightText: © 2021 NQMCyber Ltd and edgesec contributors
  * SPDX-License-Identifier: LGPL-3.0-or-later
- *
  * @brief File containing the definition of dns service configuration utilities.
  */
 #ifndef DNS_CONFIG_H

--- a/src/dns/dns_config.h
+++ b/src/dns/dns_config.h
@@ -6,7 +6,6 @@
  * SPDX-FileCopyrightText: © 2021 NQMCyber Ltd and edgesec contributors
  * SPDX-License-Identifier: LGPL-3.0-or-later
  *
- * @author Alexandru Mereacre
  * @brief File containing the definition of dns service configuration utilities.
  */
 #ifndef DNS_CONFIG_H

--- a/src/dns/dns_config.h
+++ b/src/dns/dns_config.h
@@ -1,21 +1,11 @@
-/****************************************************************************
- * Copyright (C) 2021 by NQMCyber Ltd                                       *
- *                                                                          *
- * This file is part of EDGESec.                                            *
- *                                                                          *
- *   EDGESec is free software: you can redistribute it and/or modify it     *
- *   under the terms of the GNU Lesser General Public License as published  *
- *   by the Free Software Foundation, either version 3 of the License, or   *
- *   (at your option) any later version.                                    *
- *                                                                          *
- *   EDGESec is distributed in the hope that it will be useful,             *
- *   but WITHOUT ANY WARRANTY; without even the implied warranty of         *
- *   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the          *
- *   GNU Lesser General Public License for more details.                    *
- *                                                                          *
- *   You should have received a copy of the GNU Lesser General Public       *
- *   License along with EDGESec. If not, see <http://www.gnu.org/licenses/>.*
- ****************************************************************************/
+/**
+ * @file
+ * @author Alexandru Mereacre
+ * @date 2021
+ * @copyright
+ * SPDX-FileCopyrightText: © 2021 NQMCyber Ltd and edgesec contributors
+ * SPDX-License-Identifier: LGPL-3.0-or-later
+ */
 
 /**
  * @file dns_config.h

--- a/src/dns/mcast.c
+++ b/src/dns/mcast.c
@@ -6,7 +6,6 @@
  * SPDX-FileCopyrightText: © 2021 NQMCyber Ltd and edgesec contributors
  * SPDX-License-Identifier: LGPL-3.0-or-later
  *
- * @author Alexandru Mereacre
  * @brief File containing the implementation of mDNS utils.
  */
 

--- a/src/dns/mcast.c
+++ b/src/dns/mcast.c
@@ -1,21 +1,11 @@
-/****************************************************************************
- * Copyright (C) 2021 by NQMCyber Ltd                                       *
- *                                                                          *
- * This file is part of EDGESec.                                            *
- *                                                                          *
- *   EDGESec is free software: you can redistribute it and/or modify it     *
- *   under the terms of the GNU Lesser General Public License as published  *
- *   by the Free Software Foundation, either version 3 of the License, or   *
- *   (at your option) any later version.                                    *
- *                                                                          *
- *   EDGESec is distributed in the hope that it will be useful,             *
- *   but WITHOUT ANY WARRANTY; without even the implied warranty of         *
- *   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the          *
- *   GNU Lesser General Public License for more details.                    *
- *                                                                          *
- *   You should have received a copy of the GNU Lesser General Public       *
- *   License along with EDGESec. If not, see <http://www.gnu.org/licenses/>.*
- ****************************************************************************/
+/**
+ * @file
+ * @author Alexandru Mereacre
+ * @date 2021
+ * @copyright
+ * SPDX-FileCopyrightText: © 2021 NQMCyber Ltd and edgesec contributors
+ * SPDX-License-Identifier: LGPL-3.0-or-later
+ */
 
 /**
  * @file mcast.c

--- a/src/dns/mcast.c
+++ b/src/dns/mcast.c
@@ -5,10 +5,7 @@
  * @copyright
  * SPDX-FileCopyrightText: © 2021 NQMCyber Ltd and edgesec contributors
  * SPDX-License-Identifier: LGPL-3.0-or-later
- */
-
-/**
- * @file mcast.c
+ *
  * @author Alexandru Mereacre
  * @brief File containing the implementation of mDNS utils.
  */

--- a/src/dns/mcast.c
+++ b/src/dns/mcast.c
@@ -5,7 +5,6 @@
  * @copyright
  * SPDX-FileCopyrightText: © 2021 NQMCyber Ltd and edgesec contributors
  * SPDX-License-Identifier: LGPL-3.0-or-later
- *
  * @brief File containing the implementation of mDNS utils.
  */
 

--- a/src/dns/mcast.h
+++ b/src/dns/mcast.h
@@ -5,10 +5,7 @@
  * @copyright
  * SPDX-FileCopyrightText: © 2021 NQMCyber Ltd and edgesec contributors
  * SPDX-License-Identifier: LGPL-3.0-or-later
- */
-
-/**
- * @file mcast.h
+ *
  * @author Alexandru Mereacre
  * @brief File containing the definition of mDNS utils.
  */

--- a/src/dns/mcast.h
+++ b/src/dns/mcast.h
@@ -6,7 +6,6 @@
  * SPDX-FileCopyrightText: © 2021 NQMCyber Ltd and edgesec contributors
  * SPDX-License-Identifier: LGPL-3.0-or-later
  *
- * @author Alexandru Mereacre
  * @brief File containing the definition of mDNS utils.
  */
 

--- a/src/dns/mcast.h
+++ b/src/dns/mcast.h
@@ -1,21 +1,11 @@
-/****************************************************************************
- * Copyright (C) 2021 by NQMCyber Ltd                                       *
- *                                                                          *
- * This file is part of EDGESec.                                            *
- *                                                                          *
- *   EDGESec is free software: you can redistribute it and/or modify it     *
- *   under the terms of the GNU Lesser General Public License as published  *
- *   by the Free Software Foundation, either version 3 of the License, or   *
- *   (at your option) any later version.                                    *
- *                                                                          *
- *   EDGESec is distributed in the hope that it will be useful,             *
- *   but WITHOUT ANY WARRANTY; without even the implied warranty of         *
- *   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the          *
- *   GNU Lesser General Public License for more details.                    *
- *                                                                          *
- *   You should have received a copy of the GNU Lesser General Public       *
- *   License along with EDGESec. If not, see <http://www.gnu.org/licenses/>.*
- ****************************************************************************/
+/**
+ * @file
+ * @author Alexandru Mereacre
+ * @date 2021
+ * @copyright
+ * SPDX-FileCopyrightText: © 2021 NQMCyber Ltd and edgesec contributors
+ * SPDX-License-Identifier: LGPL-3.0-or-later
+ */
 
 /**
  * @file mcast.h

--- a/src/dns/mcast.h
+++ b/src/dns/mcast.h
@@ -5,7 +5,6 @@
  * @copyright
  * SPDX-FileCopyrightText: © 2021 NQMCyber Ltd and edgesec contributors
  * SPDX-License-Identifier: LGPL-3.0-or-later
- *
  * @brief File containing the definition of mDNS utils.
  */
 

--- a/src/dns/mdns_list.c
+++ b/src/dns/mdns_list.c
@@ -5,10 +5,7 @@
  * @copyright
  * SPDX-FileCopyrightText: © 2021 NQMCyber Ltd and edgesec contributors
  * SPDX-License-Identifier: LGPL-3.0-or-later
- */
-
-/**
- * @file mdns_list.c
+ *
  * @author Alexandru Mereacre
  * @brief File containing the implementation of mdns list utils.
  */

--- a/src/dns/mdns_list.c
+++ b/src/dns/mdns_list.c
@@ -5,7 +5,6 @@
  * @copyright
  * SPDX-FileCopyrightText: © 2021 NQMCyber Ltd and edgesec contributors
  * SPDX-License-Identifier: LGPL-3.0-or-later
- *
  * @brief File containing the implementation of mdns list utils.
  */
 

--- a/src/dns/mdns_list.c
+++ b/src/dns/mdns_list.c
@@ -6,7 +6,6 @@
  * SPDX-FileCopyrightText: © 2021 NQMCyber Ltd and edgesec contributors
  * SPDX-License-Identifier: LGPL-3.0-or-later
  *
- * @author Alexandru Mereacre
  * @brief File containing the implementation of mdns list utils.
  */
 

--- a/src/dns/mdns_list.c
+++ b/src/dns/mdns_list.c
@@ -1,21 +1,11 @@
-/****************************************************************************
- * Copyright (C) 2021 by NQMCyber Ltd                                       *
- *                                                                          *
- * This file is part of EDGESec.                                            *
- *                                                                          *
- *   EDGESec is free software: you can redistribute it and/or modify it     *
- *   under the terms of the GNU Lesser General Public License as published  *
- *   by the Free Software Foundation, either version 3 of the License, or   *
- *   (at your option) any later version.                                    *
- *                                                                          *
- *   EDGESec is distributed in the hope that it will be useful,             *
- *   but WITHOUT ANY WARRANTY; without even the implied warranty of         *
- *   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the          *
- *   GNU Lesser General Public License for more details.                    *
- *                                                                          *
- *   You should have received a copy of the GNU Lesser General Public       *
- *   License along with EDGESec. If not, see <http://www.gnu.org/licenses/>.*
- ****************************************************************************/
+/**
+ * @file
+ * @author Alexandru Mereacre
+ * @date 2021
+ * @copyright
+ * SPDX-FileCopyrightText: © 2021 NQMCyber Ltd and edgesec contributors
+ * SPDX-License-Identifier: LGPL-3.0-or-later
+ */
 
 /**
  * @file mdns_list.c

--- a/src/dns/mdns_list.h
+++ b/src/dns/mdns_list.h
@@ -5,7 +5,6 @@
  * @copyright
  * SPDX-FileCopyrightText: © 2021 NQMCyber Ltd and edgesec contributors
  * SPDX-License-Identifier: LGPL-3.0-or-later
- *
  * @brief File containing the definition of mdns list utils.
  */
 

--- a/src/dns/mdns_list.h
+++ b/src/dns/mdns_list.h
@@ -1,21 +1,11 @@
-/****************************************************************************
- * Copyright (C) 2021 by NQMCyber Ltd                                       *
- *                                                                          *
- * This file is part of EDGESec.                                            *
- *                                                                          *
- *   EDGESec is free software: you can redistribute it and/or modify it     *
- *   under the terms of the GNU Lesser General Public License as published  *
- *   by the Free Software Foundation, either version 3 of the License, or   *
- *   (at your option) any later version.                                    *
- *                                                                          *
- *   EDGESec is distributed in the hope that it will be useful,             *
- *   but WITHOUT ANY WARRANTY; without even the implied warranty of         *
- *   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the          *
- *   GNU Lesser General Public License for more details.                    *
- *                                                                          *
- *   You should have received a copy of the GNU Lesser General Public       *
- *   License along with EDGESec. If not, see <http://www.gnu.org/licenses/>.*
- ****************************************************************************/
+/**
+ * @file
+ * @author Alexandru Mereacre
+ * @date 2021
+ * @copyright
+ * SPDX-FileCopyrightText: © 2021 NQMCyber Ltd and edgesec contributors
+ * SPDX-License-Identifier: LGPL-3.0-or-later
+ */
 
 /**
  * @file mdns_list.h

--- a/src/dns/mdns_list.h
+++ b/src/dns/mdns_list.h
@@ -6,7 +6,6 @@
  * SPDX-FileCopyrightText: © 2021 NQMCyber Ltd and edgesec contributors
  * SPDX-License-Identifier: LGPL-3.0-or-later
  *
- * @author Alexandru Mereacre
  * @brief File containing the definition of mdns list utils.
  */
 

--- a/src/dns/mdns_list.h
+++ b/src/dns/mdns_list.h
@@ -5,10 +5,7 @@
  * @copyright
  * SPDX-FileCopyrightText: © 2021 NQMCyber Ltd and edgesec contributors
  * SPDX-License-Identifier: LGPL-3.0-or-later
- */
-
-/**
- * @file mdns_list.h
+ *
  * @author Alexandru Mereacre
  * @brief File containing the definition of mdns list utils.
  */

--- a/src/dns/mdns_mapper.c
+++ b/src/dns/mdns_mapper.c
@@ -1,21 +1,11 @@
-/****************************************************************************
- * Copyright (C) 2021 by NQMCyber Ltd                                       *
- *                                                                          *
- * This file is part of EDGESec.                                            *
- *                                                                          *
- *   EDGESec is free software: you can redistribute it and/or modify it     *
- *   under the terms of the GNU Lesser General Public License as published  *
- *   by the Free Software Foundation, either version 3 of the License, or   *
- *   (at your option) any later version.                                    *
- *                                                                          *
- *   EDGESec is distributed in the hope that it will be useful,             *
- *   but WITHOUT ANY WARRANTY; without even the implied warranty of         *
- *   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the          *
- *   GNU Lesser General Public License for more details.                    *
- *                                                                          *
- *   You should have received a copy of the GNU Lesser General Public       *
- *   License along with EDGESec. If not, see <http://www.gnu.org/licenses/>.*
- ****************************************************************************/
+/**
+ * @file
+ * @author Alexandru Mereacre
+ * @date 2021
+ * @copyright
+ * SPDX-FileCopyrightText: © 2021 NQMCyber Ltd and edgesec contributors
+ * SPDX-License-Identifier: LGPL-3.0-or-later
+ */
 
 /**
  * @file mdns_mapper.c

--- a/src/dns/mdns_mapper.c
+++ b/src/dns/mdns_mapper.c
@@ -6,7 +6,6 @@
  * SPDX-FileCopyrightText: © 2021 NQMCyber Ltd and edgesec contributors
  * SPDX-License-Identifier: LGPL-3.0-or-later
  *
- * @author Alexandru Mereacre
  * @brief File containing the implementation of the mdns mapper utils.
  */
 

--- a/src/dns/mdns_mapper.c
+++ b/src/dns/mdns_mapper.c
@@ -5,10 +5,7 @@
  * @copyright
  * SPDX-FileCopyrightText: © 2021 NQMCyber Ltd and edgesec contributors
  * SPDX-License-Identifier: LGPL-3.0-or-later
- */
-
-/**
- * @file mdns_mapper.c
+ *
  * @author Alexandru Mereacre
  * @brief File containing the implementation of the mdns mapper utils.
  */

--- a/src/dns/mdns_mapper.c
+++ b/src/dns/mdns_mapper.c
@@ -5,7 +5,6 @@
  * @copyright
  * SPDX-FileCopyrightText: © 2021 NQMCyber Ltd and edgesec contributors
  * SPDX-License-Identifier: LGPL-3.0-or-later
- *
  * @brief File containing the implementation of the mdns mapper utils.
  */
 

--- a/src/dns/mdns_mapper.h
+++ b/src/dns/mdns_mapper.h
@@ -5,10 +5,7 @@
  * @copyright
  * SPDX-FileCopyrightText: © 2021 NQMCyber Ltd and edgesec contributors
  * SPDX-License-Identifier: LGPL-3.0-or-later
- */
-
-/**
- * @file mdns_mapper.h
+ *
  * @author Alexandru Mereacre
  * @brief File containing the definition of mdns mapper utils.
  */

--- a/src/dns/mdns_mapper.h
+++ b/src/dns/mdns_mapper.h
@@ -5,7 +5,6 @@
  * @copyright
  * SPDX-FileCopyrightText: © 2021 NQMCyber Ltd and edgesec contributors
  * SPDX-License-Identifier: LGPL-3.0-or-later
- *
  * @brief File containing the definition of mdns mapper utils.
  */
 

--- a/src/dns/mdns_mapper.h
+++ b/src/dns/mdns_mapper.h
@@ -6,7 +6,6 @@
  * SPDX-FileCopyrightText: © 2021 NQMCyber Ltd and edgesec contributors
  * SPDX-License-Identifier: LGPL-3.0-or-later
  *
- * @author Alexandru Mereacre
  * @brief File containing the definition of mdns mapper utils.
  */
 

--- a/src/dns/mdns_mapper.h
+++ b/src/dns/mdns_mapper.h
@@ -1,21 +1,11 @@
-/****************************************************************************
- * Copyright (C) 2021 by NQMCyber Ltd                                       *
- *                                                                          *
- * This file is part of EDGESec.                                            *
- *                                                                          *
- *   EDGESec is free software: you can redistribute it and/or modify it     *
- *   under the terms of the GNU Lesser General Public License as published  *
- *   by the Free Software Foundation, either version 3 of the License, or   *
- *   (at your option) any later version.                                    *
- *                                                                          *
- *   EDGESec is distributed in the hope that it will be useful,             *
- *   but WITHOUT ANY WARRANTY; without even the implied warranty of         *
- *   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the          *
- *   GNU Lesser General Public License for more details.                    *
- *                                                                          *
- *   You should have received a copy of the GNU Lesser General Public       *
- *   License along with EDGESec. If not, see <http://www.gnu.org/licenses/>.*
- ****************************************************************************/
+/**
+ * @file
+ * @author Alexandru Mereacre
+ * @date 2021
+ * @copyright
+ * SPDX-FileCopyrightText: © 2021 NQMCyber Ltd and edgesec contributors
+ * SPDX-License-Identifier: LGPL-3.0-or-later
+ */
 
 /**
  * @file mdns_mapper.h

--- a/src/dns/mdns_service.c
+++ b/src/dns/mdns_service.c
@@ -6,7 +6,6 @@
  * SPDX-FileCopyrightText: © 2021 NQMCyber Ltd and edgesec contributors
  * SPDX-License-Identifier: LGPL-3.0-or-later
  *
- * @author Alexandru Mereacre
  * @brief File containing the implementation of mDNS service structures.
  */
 

--- a/src/dns/mdns_service.c
+++ b/src/dns/mdns_service.c
@@ -1,21 +1,11 @@
-/****************************************************************************
- * Copyright (C) 2021 by NQMCyber Ltd                                       *
- *                                                                          *
- * This file is part of EDGESec.                                            *
- *                                                                          *
- *   EDGESec is free software: you can redistribute it and/or modify it     *
- *   under the terms of the GNU Lesser General Public License as published  *
- *   by the Free Software Foundation, either version 3 of the License, or   *
- *   (at your option) any later version.                                    *
- *                                                                          *
- *   EDGESec is distributed in the hope that it will be useful,             *
- *   but WITHOUT ANY WARRANTY; without even the implied warranty of         *
- *   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the          *
- *   GNU Lesser General Public License for more details.                    *
- *                                                                          *
- *   You should have received a copy of the GNU Lesser General Public       *
- *   License along with EDGESec. If not, see <http://www.gnu.org/licenses/>.*
- ****************************************************************************/
+/**
+ * @file
+ * @author Alexandru Mereacre
+ * @date 2021
+ * @copyright
+ * SPDX-FileCopyrightText: © 2021 NQMCyber Ltd and edgesec contributors
+ * SPDX-License-Identifier: LGPL-3.0-or-later
+ */
 
 /**
  * @file mdns_service.c

--- a/src/dns/mdns_service.c
+++ b/src/dns/mdns_service.c
@@ -5,10 +5,7 @@
  * @copyright
  * SPDX-FileCopyrightText: © 2021 NQMCyber Ltd and edgesec contributors
  * SPDX-License-Identifier: LGPL-3.0-or-later
- */
-
-/**
- * @file mdns_service.c
+ *
  * @author Alexandru Mereacre
  * @brief File containing the implementation of mDNS service structures.
  */

--- a/src/dns/mdns_service.c
+++ b/src/dns/mdns_service.c
@@ -5,7 +5,6 @@
  * @copyright
  * SPDX-FileCopyrightText: © 2021 NQMCyber Ltd and edgesec contributors
  * SPDX-License-Identifier: LGPL-3.0-or-later
- *
  * @brief File containing the implementation of mDNS service structures.
  */
 

--- a/src/dns/mdns_service.h
+++ b/src/dns/mdns_service.h
@@ -5,7 +5,6 @@
  * @copyright
  * SPDX-FileCopyrightText: © 2021 NQMCyber Ltd and edgesec contributors
  * SPDX-License-Identifier: LGPL-3.0-or-later
- *
  * @brief File containing the definition of mDNS service structures.
  */
 

--- a/src/dns/mdns_service.h
+++ b/src/dns/mdns_service.h
@@ -5,10 +5,7 @@
  * @copyright
  * SPDX-FileCopyrightText: © 2021 NQMCyber Ltd and edgesec contributors
  * SPDX-License-Identifier: LGPL-3.0-or-later
- */
-
-/**
- * @file mdns_service.h
+ *
  * @author Alexandru Mereacre
  * @brief File containing the definition of mDNS service structures.
  */

--- a/src/dns/mdns_service.h
+++ b/src/dns/mdns_service.h
@@ -6,7 +6,6 @@
  * SPDX-FileCopyrightText: © 2021 NQMCyber Ltd and edgesec contributors
  * SPDX-License-Identifier: LGPL-3.0-or-later
  *
- * @author Alexandru Mereacre
  * @brief File containing the definition of mDNS service structures.
  */
 

--- a/src/dns/mdns_service.h
+++ b/src/dns/mdns_service.h
@@ -1,21 +1,11 @@
-/****************************************************************************
- * Copyright (C) 2021 by NQMCyber Ltd                                       *
- *                                                                          *
- * This file is part of EDGESec.                                            *
- *                                                                          *
- *   EDGESec is free software: you can redistribute it and/or modify it     *
- *   under the terms of the GNU Lesser General Public License as published  *
- *   by the Free Software Foundation, either version 3 of the License, or   *
- *   (at your option) any later version.                                    *
- *                                                                          *
- *   EDGESec is distributed in the hope that it will be useful,             *
- *   but WITHOUT ANY WARRANTY; without even the implied warranty of         *
- *   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the          *
- *   GNU Lesser General Public License for more details.                    *
- *                                                                          *
- *   You should have received a copy of the GNU Lesser General Public       *
- *   License along with EDGESec. If not, see <http://www.gnu.org/licenses/>.*
- ****************************************************************************/
+/**
+ * @file
+ * @author Alexandru Mereacre
+ * @date 2021
+ * @copyright
+ * SPDX-FileCopyrightText: © 2021 NQMCyber Ltd and edgesec contributors
+ * SPDX-License-Identifier: LGPL-3.0-or-later
+ */
 
 /**
  * @file mdns_service.h

--- a/src/dns/reflection_list.c
+++ b/src/dns/reflection_list.c
@@ -5,7 +5,6 @@
  * @copyright
  * SPDX-FileCopyrightText: © 2021 NQMCyber Ltd and edgesec contributors
  * SPDX-License-Identifier: LGPL-3.0-or-later
- *
  * @brief File containing the implementation of reflection list structures.
  */
 

--- a/src/dns/reflection_list.c
+++ b/src/dns/reflection_list.c
@@ -1,21 +1,11 @@
-/****************************************************************************
- * Copyright (C) 2021 by NQMCyber Ltd                                       *
- *                                                                          *
- * This file is part of EDGESec.                                            *
- *                                                                          *
- *   EDGESec is free software: you can redistribute it and/or modify it     *
- *   under the terms of the GNU Lesser General Public License as published  *
- *   by the Free Software Foundation, either version 3 of the License, or   *
- *   (at your option) any later version.                                    *
- *                                                                          *
- *   EDGESec is distributed in the hope that it will be useful,             *
- *   but WITHOUT ANY WARRANTY; without even the implied warranty of         *
- *   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the          *
- *   GNU Lesser General Public License for more details.                    *
- *                                                                          *
- *   You should have received a copy of the GNU Lesser General Public       *
- *   License along with EDGESec. If not, see <http://www.gnu.org/licenses/>.*
- ****************************************************************************/
+/**
+ * @file
+ * @author Alexandru Mereacre
+ * @date 2021
+ * @copyright
+ * SPDX-FileCopyrightText: © 2021 NQMCyber Ltd and edgesec contributors
+ * SPDX-License-Identifier: LGPL-3.0-or-later
+ */
 
 /**
  * @file reflection_list.c

--- a/src/dns/reflection_list.c
+++ b/src/dns/reflection_list.c
@@ -5,10 +5,7 @@
  * @copyright
  * SPDX-FileCopyrightText: © 2021 NQMCyber Ltd and edgesec contributors
  * SPDX-License-Identifier: LGPL-3.0-or-later
- */
-
-/**
- * @file reflection_list.c
+ *
  * @author Alexandru Mereacre
  * @brief File containing the implementation of reflection list structures.
  */

--- a/src/dns/reflection_list.c
+++ b/src/dns/reflection_list.c
@@ -6,7 +6,6 @@
  * SPDX-FileCopyrightText: © 2021 NQMCyber Ltd and edgesec contributors
  * SPDX-License-Identifier: LGPL-3.0-or-later
  *
- * @author Alexandru Mereacre
  * @brief File containing the implementation of reflection list structures.
  */
 

--- a/src/dns/reflection_list.h
+++ b/src/dns/reflection_list.h
@@ -6,7 +6,6 @@
  * SPDX-FileCopyrightText: © 2021 NQMCyber Ltd and edgesec contributors
  * SPDX-License-Identifier: LGPL-3.0-or-later
  *
- * @author Alexandru Mereacre
  * @brief File containing the definition of reflection list structures.
  */
 

--- a/src/dns/reflection_list.h
+++ b/src/dns/reflection_list.h
@@ -5,10 +5,7 @@
  * @copyright
  * SPDX-FileCopyrightText: © 2021 NQMCyber Ltd and edgesec contributors
  * SPDX-License-Identifier: LGPL-3.0-or-later
- */
-
-/**
- * @file reflection_list.h
+ *
  * @author Alexandru Mereacre
  * @brief File containing the definition of reflection list structures.
  */

--- a/src/dns/reflection_list.h
+++ b/src/dns/reflection_list.h
@@ -5,7 +5,6 @@
  * @copyright
  * SPDX-FileCopyrightText: © 2021 NQMCyber Ltd and edgesec contributors
  * SPDX-License-Identifier: LGPL-3.0-or-later
- *
  * @brief File containing the definition of reflection list structures.
  */
 

--- a/src/dns/reflection_list.h
+++ b/src/dns/reflection_list.h
@@ -1,21 +1,11 @@
-/****************************************************************************
- * Copyright (C) 2021 by NQMCyber Ltd                                       *
- *                                                                          *
- * This file is part of EDGESec.                                            *
- *                                                                          *
- *   EDGESec is free software: you can redistribute it and/or modify it     *
- *   under the terms of the GNU Lesser General Public License as published  *
- *   by the Free Software Foundation, either version 3 of the License, or   *
- *   (at your option) any later version.                                    *
- *                                                                          *
- *   EDGESec is distributed in the hope that it will be useful,             *
- *   but WITHOUT ANY WARRANTY; without even the implied warranty of         *
- *   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the          *
- *   GNU Lesser General Public License for more details.                    *
- *                                                                          *
- *   You should have received a copy of the GNU Lesser General Public       *
- *   License along with EDGESec. If not, see <http://www.gnu.org/licenses/>.*
- ****************************************************************************/
+/**
+ * @file
+ * @author Alexandru Mereacre
+ * @date 2021
+ * @copyright
+ * SPDX-FileCopyrightText: © 2021 NQMCyber Ltd and edgesec contributors
+ * SPDX-License-Identifier: LGPL-3.0-or-later
+ */
 
 /**
  * @file reflection_list.h

--- a/src/edgesec.c
+++ b/src/edgesec.c
@@ -5,10 +5,7 @@
  * @copyright
  * SPDX-FileCopyrightText: © 2020 NQMCyber Ltd and edgesec contributors
  * SPDX-License-Identifier: LGPL-3.0-or-later
- */
-
-/**
- * @file edgesec.c
+ *
  * @author Alexandru Mereacre
  * @brief File containing the edgesec tool implementations.
  */

--- a/src/edgesec.c
+++ b/src/edgesec.c
@@ -5,7 +5,6 @@
  * @copyright
  * SPDX-FileCopyrightText: © 2020 NQMCyber Ltd and edgesec contributors
  * SPDX-License-Identifier: LGPL-3.0-or-later
- *
  * @brief File containing the edgesec tool implementations.
  */
 

--- a/src/edgesec.c
+++ b/src/edgesec.c
@@ -1,21 +1,11 @@
-/****************************************************************************
- * Copyright (C) 2020 by NQMCyber Ltd                                       *
- *                                                                          *
- * This file is part of EDGESec.                                            *
- *                                                                          *
- *   EDGESec is free software: you can redistribute it and/or modify it     *
- *   under the terms of the GNU Lesser General Public License as published  *
- *   by the Free Software Foundation, either version 3 of the License, or   *
- *   (at your option) any later version.                                    *
- *                                                                          *
- *   EDGESec is distributed in the hope that it will be useful,             *
- *   but WITHOUT ANY WARRANTY; without even the implied warranty of         *
- *   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the          *
- *   GNU Lesser General Public License for more details.                    *
- *                                                                          *
- *   You should have received a copy of the GNU Lesser General Public       *
- *   License along with EDGESec. If not, see <http://www.gnu.org/licenses/>.*
- ****************************************************************************/
+/**
+ * @file
+ * @author Alexandru Mereacre
+ * @date 2020
+ * @copyright
+ * SPDX-FileCopyrightText: © 2020 NQMCyber Ltd and edgesec contributors
+ * SPDX-License-Identifier: LGPL-3.0-or-later
+ */
 
 /**
  * @file edgesec.c

--- a/src/edgesec.c
+++ b/src/edgesec.c
@@ -6,7 +6,6 @@
  * SPDX-FileCopyrightText: © 2020 NQMCyber Ltd and edgesec contributors
  * SPDX-License-Identifier: LGPL-3.0-or-later
  *
- * @author Alexandru Mereacre
  * @brief File containing the edgesec tool implementations.
  */
 

--- a/src/firewall/firewall_config.h
+++ b/src/firewall/firewall_config.h
@@ -1,21 +1,11 @@
-/****************************************************************************
- * Copyright (C) 2022 by NQMCyber Ltd                                       *
- *                                                                          *
- * This file is part of EDGESec.                                            *
- *                                                                          *
- *   EDGESec is free software: you can redistribute it and/or modify it     *
- *   under the terms of the GNU Lesser General Public License as published  *
- *   by the Free Software Foundation, either version 3 of the License, or   *
- *   (at your option) any later version.                                    *
- *                                                                          *
- *   EDGESec is distributed in the hope that it will be useful,             *
- *   but WITHOUT ANY WARRANTY; without even the implied warranty of         *
- *   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the          *
- *   GNU Lesser General Public License for more details.                    *
- *                                                                          *
- *   You should have received a copy of the GNU Lesser General Public       *
- *   License along with EDGESec. If not, see <http://www.gnu.org/licenses/>.*
- ****************************************************************************/
+/**
+ * @file
+ * @author Alexandru Mereacre
+ * @date 2022
+ * @copyright
+ * SPDX-FileCopyrightText: © 2022 NQMCyber Ltd and edgesec contributors
+ * SPDX-License-Identifier: LGPL-3.0-or-later
+ */
 
 /**
  * @file firewall_service.h

--- a/src/firewall/firewall_config.h
+++ b/src/firewall/firewall_config.h
@@ -5,7 +5,6 @@
  * @copyright
  * SPDX-FileCopyrightText: © 2022 NQMCyber Ltd and edgesec contributors
  * SPDX-License-Identifier: LGPL-3.0-or-later
- *
  * @brief File containing the definition of the firewall structures.
  */
 

--- a/src/firewall/firewall_config.h
+++ b/src/firewall/firewall_config.h
@@ -5,10 +5,7 @@
  * @copyright
  * SPDX-FileCopyrightText: © 2022 NQMCyber Ltd and edgesec contributors
  * SPDX-License-Identifier: LGPL-3.0-or-later
- */
-
-/**
- * @file firewall_service.h
+ *
  * @author Alexandru Mereacre
  * @brief File containing the definition of the firewall structures.
  */

--- a/src/firewall/firewall_config.h
+++ b/src/firewall/firewall_config.h
@@ -6,7 +6,6 @@
  * SPDX-FileCopyrightText: © 2022 NQMCyber Ltd and edgesec contributors
  * SPDX-License-Identifier: LGPL-3.0-or-later
  *
- * @author Alexandru Mereacre
  * @brief File containing the definition of the firewall structures.
  */
 

--- a/src/firewall/firewall_service.c
+++ b/src/firewall/firewall_service.c
@@ -1,21 +1,11 @@
-/****************************************************************************
- * Copyright (C) 2020 by NQMCyber Ltd                                       *
- *                                                                          *
- * This file is part of EDGESec.                                            *
- *                                                                          *
- *   EDGESec is free software: you can redistribute it and/or modify it     *
- *   under the terms of the GNU Lesser General Public License as published  *
- *   by the Free Software Foundation, either version 3 of the License, or   *
- *   (at your option) any later version.                                    *
- *                                                                          *
- *   EDGESec is distributed in the hope that it will be useful,             *
- *   but WITHOUT ANY WARRANTY; without even the implied warranty of         *
- *   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the          *
- *   GNU Lesser General Public License for more details.                    *
- *                                                                          *
- *   You should have received a copy of the GNU Lesser General Public       *
- *   License along with EDGESec. If not, see <http://www.gnu.org/licenses/>.*
- ****************************************************************************/
+/**
+ * @file
+ * @author Alexandru Mereacre
+ * @date 2020
+ * @copyright
+ * SPDX-FileCopyrightText: © 2020 NQMCyber Ltd and edgesec contributors
+ * SPDX-License-Identifier: LGPL-3.0-or-later
+ */
 
 /**
  * @file firewall_service.c

--- a/src/firewall/firewall_service.c
+++ b/src/firewall/firewall_service.c
@@ -5,7 +5,6 @@
  * @copyright
  * SPDX-FileCopyrightText: © 2020 NQMCyber Ltd and edgesec contributors
  * SPDX-License-Identifier: LGPL-3.0-or-later
- *
  * @brief File containing the implementation of the firewall service commands.
  */
 

--- a/src/firewall/firewall_service.c
+++ b/src/firewall/firewall_service.c
@@ -6,7 +6,6 @@
  * SPDX-FileCopyrightText: © 2020 NQMCyber Ltd and edgesec contributors
  * SPDX-License-Identifier: LGPL-3.0-or-later
  *
- * @author Alexandru Mereacre
  * @brief File containing the implementation of the firewall service commands.
  */
 

--- a/src/firewall/firewall_service.c
+++ b/src/firewall/firewall_service.c
@@ -5,10 +5,7 @@
  * @copyright
  * SPDX-FileCopyrightText: © 2020 NQMCyber Ltd and edgesec contributors
  * SPDX-License-Identifier: LGPL-3.0-or-later
- */
-
-/**
- * @file firewall_service.c
+ *
  * @author Alexandru Mereacre
  * @brief File containing the implementation of the firewall service commands.
  */

--- a/src/firewall/firewall_service.h
+++ b/src/firewall/firewall_service.h
@@ -5,7 +5,6 @@
  * @copyright
  * SPDX-FileCopyrightText: © 2022 NQMCyber Ltd and edgesec contributors
  * SPDX-License-Identifier: LGPL-3.0-or-later
- *
  * @brief File containing the definition of the firewall service commands.
  */
 

--- a/src/firewall/firewall_service.h
+++ b/src/firewall/firewall_service.h
@@ -1,21 +1,11 @@
-/****************************************************************************
- * Copyright (C) 2022 by NQMCyber Ltd                                       *
- *                                                                          *
- * This file is part of EDGESec.                                            *
- *                                                                          *
- *   EDGESec is free software: you can redistribute it and/or modify it     *
- *   under the terms of the GNU Lesser General Public License as published  *
- *   by the Free Software Foundation, either version 3 of the License, or   *
- *   (at your option) any later version.                                    *
- *                                                                          *
- *   EDGESec is distributed in the hope that it will be useful,             *
- *   but WITHOUT ANY WARRANTY; without even the implied warranty of         *
- *   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the          *
- *   GNU Lesser General Public License for more details.                    *
- *                                                                          *
- *   You should have received a copy of the GNU Lesser General Public       *
- *   License along with EDGESec. If not, see <http://www.gnu.org/licenses/>.*
- ****************************************************************************/
+/**
+ * @file
+ * @author Alexandru Mereacre
+ * @date 2022
+ * @copyright
+ * SPDX-FileCopyrightText: © 2022 NQMCyber Ltd and edgesec contributors
+ * SPDX-License-Identifier: LGPL-3.0-or-later
+ */
 
 /**
  * @file firewall_service.h

--- a/src/firewall/firewall_service.h
+++ b/src/firewall/firewall_service.h
@@ -6,7 +6,6 @@
  * SPDX-FileCopyrightText: © 2022 NQMCyber Ltd and edgesec contributors
  * SPDX-License-Identifier: LGPL-3.0-or-later
  *
- * @author Alexandru Mereacre
  * @brief File containing the definition of the firewall service commands.
  */
 

--- a/src/firewall/firewall_service.h
+++ b/src/firewall/firewall_service.h
@@ -5,10 +5,7 @@
  * @copyright
  * SPDX-FileCopyrightText: © 2022 NQMCyber Ltd and edgesec contributors
  * SPDX-License-Identifier: LGPL-3.0-or-later
- */
-
-/**
- * @file firewall_service.h
+ *
  * @author Alexandru Mereacre
  * @brief File containing the definition of the firewall service commands.
  */

--- a/src/radius/radius_config.h
+++ b/src/radius/radius_config.h
@@ -5,7 +5,6 @@
  * @copyright
  * SPDX-FileCopyrightText: © 2022 NQMCyber Ltd and edgesec contributors
  * SPDX-License-Identifier: LGPL-3.0-or-later
- *
  * @brief File containing the definition of the radius config.
  */
 

--- a/src/radius/radius_config.h
+++ b/src/radius/radius_config.h
@@ -5,10 +5,7 @@
  * @copyright
  * SPDX-FileCopyrightText: © 2022 NQMCyber Ltd and edgesec contributors
  * SPDX-License-Identifier: LGPL-3.0-or-later
- */
-
-/**
- * @file radius_config.h
+ *
  * @author Alexandru Mereacre
  * @brief File containing the definition of the radius config.
  */

--- a/src/radius/radius_config.h
+++ b/src/radius/radius_config.h
@@ -6,7 +6,6 @@
  * SPDX-FileCopyrightText: © 2022 NQMCyber Ltd and edgesec contributors
  * SPDX-License-Identifier: LGPL-3.0-or-later
  *
- * @author Alexandru Mereacre
  * @brief File containing the definition of the radius config.
  */
 

--- a/src/radius/radius_config.h
+++ b/src/radius/radius_config.h
@@ -1,21 +1,11 @@
-/****************************************************************************
- * Copyright (C) 2022 by NQMCyber Ltd                                       *
- *                                                                          *
- * This file is part of EDGESec.                                            *
- *                                                                          *
- *   EDGESec is free software: you can redistribute it and/or modify it     *
- *   under the terms of the GNU Lesser General Public License as published  *
- *   by the Free Software Foundation, either version 3 of the License, or   *
- *   (at your option) any later version.                                    *
- *                                                                          *
- *   EDGESec is distributed in the hope that it will be useful,             *
- *   but WITHOUT ANY WARRANTY; without even the implied warranty of         *
- *   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the          *
- *   GNU Lesser General Public License for more details.                    *
- *                                                                          *
- *   You should have received a copy of the GNU Lesser General Public       *
- *   License along with EDGESec. If not, see <http://www.gnu.org/licenses/>.*
- ****************************************************************************/
+/**
+ * @file
+ * @author Alexandru Mereacre
+ * @date 2022
+ * @copyright
+ * SPDX-FileCopyrightText: © 2022 NQMCyber Ltd and edgesec contributors
+ * SPDX-License-Identifier: LGPL-3.0-or-later
+ */
 
 /**
  * @file radius_config.h

--- a/src/radius/radius_service.c
+++ b/src/radius/radius_service.c
@@ -5,10 +5,7 @@
  * @copyright
  * SPDX-FileCopyrightText: © 2021 NQMCyber Ltd and edgesec contributors
  * SPDX-License-Identifier: LGPL-3.0-or-later
- */
-
-/**
- * @file radius_service.h
+ *
  * @author Alexandru Mereacre
  * @brief File containing the implementation of the radius service.
  */

--- a/src/radius/radius_service.c
+++ b/src/radius/radius_service.c
@@ -6,7 +6,6 @@
  * SPDX-FileCopyrightText: © 2021 NQMCyber Ltd and edgesec contributors
  * SPDX-License-Identifier: LGPL-3.0-or-later
  *
- * @author Alexandru Mereacre
  * @brief File containing the implementation of the radius service.
  */
 

--- a/src/radius/radius_service.c
+++ b/src/radius/radius_service.c
@@ -1,21 +1,11 @@
-/****************************************************************************
- * Copyright (C) 2021 by NQMCyber Ltd                                       *
- *                                                                          *
- * This file is part of EDGESec.                                            *
- *                                                                          *
- *   EDGESec is free software: you can redistribute it and/or modify it     *
- *   under the terms of the GNU Lesser General Public License as published  *
- *   by the Free Software Foundation, either version 3 of the License, or   *
- *   (at your option) any later version.                                    *
- *                                                                          *
- *   EDGESec is distributed in the hope that it will be useful,             *
- *   but WITHOUT ANY WARRANTY; without even the implied warranty of         *
- *   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the          *
- *   GNU Lesser General Public License for more details.                    *
- *                                                                          *
- *   You should have received a copy of the GNU Lesser General Public       *
- *   License along with EDGESec. If not, see <http://www.gnu.org/licenses/>.*
- ****************************************************************************/
+/**
+ * @file
+ * @author Alexandru Mereacre
+ * @date 2021
+ * @copyright
+ * SPDX-FileCopyrightText: © 2021 NQMCyber Ltd and edgesec contributors
+ * SPDX-License-Identifier: LGPL-3.0-or-later
+ */
 
 /**
  * @file radius_service.h

--- a/src/radius/radius_service.c
+++ b/src/radius/radius_service.c
@@ -5,7 +5,6 @@
  * @copyright
  * SPDX-FileCopyrightText: © 2021 NQMCyber Ltd and edgesec contributors
  * SPDX-License-Identifier: LGPL-3.0-or-later
- *
  * @brief File containing the implementation of the radius service.
  */
 

--- a/src/radius/radius_service.h
+++ b/src/radius/radius_service.h
@@ -1,21 +1,11 @@
-/****************************************************************************
- * Copyright (C) 2021 by NQMCyber Ltd                                       *
- *                                                                          *
- * This file is part of EDGESec.                                            *
- *                                                                          *
- *   EDGESec is free software: you can redistribute it and/or modify it     *
- *   under the terms of the GNU Lesser General Public License as published  *
- *   by the Free Software Foundation, either version 3 of the License, or   *
- *   (at your option) any later version.                                    *
- *                                                                          *
- *   EDGESec is distributed in the hope that it will be useful,             *
- *   but WITHOUT ANY WARRANTY; without even the implied warranty of         *
- *   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the          *
- *   GNU Lesser General Public License for more details.                    *
- *                                                                          *
- *   You should have received a copy of the GNU Lesser General Public       *
- *   License along with EDGESec. If not, see <http://www.gnu.org/licenses/>.*
- ****************************************************************************/
+/**
+ * @file
+ * @author Alexandru Mereacre
+ * @date 2021
+ * @copyright
+ * SPDX-FileCopyrightText: © 2021 NQMCyber Ltd and edgesec contributors
+ * SPDX-License-Identifier: LGPL-3.0-or-later
+ */
 
 /**
  * @file radius_service.h

--- a/src/radius/radius_service.h
+++ b/src/radius/radius_service.h
@@ -6,7 +6,6 @@
  * SPDX-FileCopyrightText: © 2021 NQMCyber Ltd and edgesec contributors
  * SPDX-License-Identifier: LGPL-3.0-or-later
  *
- * @author Alexandru Mereacre
  * @brief File containing the definition of the radius service.
  */
 

--- a/src/radius/radius_service.h
+++ b/src/radius/radius_service.h
@@ -5,7 +5,6 @@
  * @copyright
  * SPDX-FileCopyrightText: © 2021 NQMCyber Ltd and edgesec contributors
  * SPDX-License-Identifier: LGPL-3.0-or-later
- *
  * @brief File containing the definition of the radius service.
  */
 

--- a/src/radius/radius_service.h
+++ b/src/radius/radius_service.h
@@ -5,10 +5,7 @@
  * @copyright
  * SPDX-FileCopyrightText: © 2021 NQMCyber Ltd and edgesec contributors
  * SPDX-License-Identifier: LGPL-3.0-or-later
- */
-
-/**
- * @file radius_service.h
+ *
  * @author Alexandru Mereacre
  * @brief File containing the definition of the radius service.
  */

--- a/src/runctl.c
+++ b/src/runctl.c
@@ -5,10 +5,7 @@
  * @copyright
  * SPDX-FileCopyrightText: © 2020 NQMCyber Ltd and edgesec contributors
  * SPDX-License-Identifier: LGPL-3.0-or-later
- */
-
-/**
- * @file runctl.c
+ *
  * @author Alexandru Mereacre
  * @brief File containing the definition of the service runners.
  */

--- a/src/runctl.c
+++ b/src/runctl.c
@@ -1,21 +1,11 @@
-/****************************************************************************
- * Copyright (C) 2020 by NQMCyber Ltd                                       *
- *                                                                          *
- * This file is part of EDGESec.                                            *
- *                                                                          *
- *   EDGESec is free software: you can redistribute it and/or modify it     *
- *   under the terms of the GNU Lesser General Public License as published  *
- *   by the Free Software Foundation, either version 3 of the License, or   *
- *   (at your option) any later version.                                    *
- *                                                                          *
- *   EDGESec is distributed in the hope that it will be useful,             *
- *   but WITHOUT ANY WARRANTY; without even the implied warranty of         *
- *   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the          *
- *   GNU Lesser General Public License for more details.                    *
- *                                                                          *
- *   You should have received a copy of the GNU Lesser General Public       *
- *   License along with EDGESec. If not, see <http://www.gnu.org/licenses/>.*
- ****************************************************************************/
+/**
+ * @file
+ * @author Alexandru Mereacre
+ * @date 2020
+ * @copyright
+ * SPDX-FileCopyrightText: © 2020 NQMCyber Ltd and edgesec contributors
+ * SPDX-License-Identifier: LGPL-3.0-or-later
+ */
 
 /**
  * @file runctl.c

--- a/src/runctl.c
+++ b/src/runctl.c
@@ -6,7 +6,6 @@
  * SPDX-FileCopyrightText: © 2020 NQMCyber Ltd and edgesec contributors
  * SPDX-License-Identifier: LGPL-3.0-or-later
  *
- * @author Alexandru Mereacre
  * @brief File containing the definition of the service runners.
  */
 

--- a/src/runctl.c
+++ b/src/runctl.c
@@ -5,7 +5,6 @@
  * @copyright
  * SPDX-FileCopyrightText: © 2020 NQMCyber Ltd and edgesec contributors
  * SPDX-License-Identifier: LGPL-3.0-or-later
- *
  * @brief File containing the definition of the service runners.
  */
 

--- a/src/runctl.h
+++ b/src/runctl.h
@@ -5,10 +5,7 @@
  * @copyright
  * SPDX-FileCopyrightText: © 2020 NQMCyber Ltd and edgesec contributors
  * SPDX-License-Identifier: LGPL-3.0-or-later
- */
-
-/**
- * @file runctl.h
+ *
  * @author Alexandru Mereacre
  * @brief File containing the definition of the service runners.
  */

--- a/src/runctl.h
+++ b/src/runctl.h
@@ -6,7 +6,6 @@
  * SPDX-FileCopyrightText: © 2020 NQMCyber Ltd and edgesec contributors
  * SPDX-License-Identifier: LGPL-3.0-or-later
  *
- * @author Alexandru Mereacre
  * @brief File containing the definition of the service runners.
  */
 #ifndef ENGINE_H

--- a/src/runctl.h
+++ b/src/runctl.h
@@ -1,21 +1,11 @@
-/****************************************************************************
- * Copyright (C) 2020 by NQMCyber Ltd                                       *
- *                                                                          *
- * This file is part of EDGESec.                                            *
- *                                                                          *
- *   EDGESec is free software: you can redistribute it and/or modify it     *
- *   under the terms of the GNU Lesser General Public License as published  *
- *   by the Free Software Foundation, either version 3 of the License, or   *
- *   (at your option) any later version.                                    *
- *                                                                          *
- *   EDGESec is distributed in the hope that it will be useful,             *
- *   but WITHOUT ANY WARRANTY; without even the implied warranty of         *
- *   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the          *
- *   GNU Lesser General Public License for more details.                    *
- *                                                                          *
- *   You should have received a copy of the GNU Lesser General Public       *
- *   License along with EDGESec. If not, see <http://www.gnu.org/licenses/>.*
- ****************************************************************************/
+/**
+ * @file
+ * @author Alexandru Mereacre
+ * @date 2020
+ * @copyright
+ * SPDX-FileCopyrightText: © 2020 NQMCyber Ltd and edgesec contributors
+ * SPDX-License-Identifier: LGPL-3.0-or-later
+ */
 
 /**
  * @file runctl.h

--- a/src/runctl.h
+++ b/src/runctl.h
@@ -5,7 +5,6 @@
  * @copyright
  * SPDX-FileCopyrightText: © 2020 NQMCyber Ltd and edgesec contributors
  * SPDX-License-Identifier: LGPL-3.0-or-later
- *
  * @brief File containing the definition of the service runners.
  */
 #ifndef ENGINE_H

--- a/src/supervisor/bridge_list.c
+++ b/src/supervisor/bridge_list.c
@@ -5,7 +5,6 @@
  * @copyright
  * SPDX-FileCopyrightText: © 2020 NQMCyber Ltd and edgesec contributors
  * SPDX-License-Identifier: LGPL-3.0-or-later
- *
  * @brief File containing the implementation of the bridge creation functions.
  */
 

--- a/src/supervisor/bridge_list.c
+++ b/src/supervisor/bridge_list.c
@@ -1,21 +1,11 @@
-/****************************************************************************
- * Copyright (C) 2020 by NQMCyber Ltd                                       *
- *                                                                          *
- * This file is part of EDGESec.                                            *
- *                                                                          *
- *   EDGESec is free software: you can redistribute it and/or modify it     *
- *   under the terms of the GNU Lesser General Public License as published  *
- *   by the Free Software Foundation, either version 3 of the License, or   *
- *   (at your option) any later version.                                    *
- *                                                                          *
- *   EDGESec is distributed in the hope that it will be useful,             *
- *   but WITHOUT ANY WARRANTY; without even the implied warranty of         *
- *   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the          *
- *   GNU Lesser General Public License for more details.                    *
- *                                                                          *
- *   You should have received a copy of the GNU Lesser General Public       *
- *   License along with EDGESec. If not, see <http://www.gnu.org/licenses/>.*
- ****************************************************************************/
+/**
+ * @file
+ * @author Alexandru Mereacre
+ * @date 2020
+ * @copyright
+ * SPDX-FileCopyrightText: © 2020 NQMCyber Ltd and edgesec contributors
+ * SPDX-License-Identifier: LGPL-3.0-or-later
+ */
 
 /**
  * @file bridge_list.c

--- a/src/supervisor/bridge_list.c
+++ b/src/supervisor/bridge_list.c
@@ -6,7 +6,6 @@
  * SPDX-FileCopyrightText: © 2020 NQMCyber Ltd and edgesec contributors
  * SPDX-License-Identifier: LGPL-3.0-or-later
  *
- * @author Alexandru Mereacre
  * @brief File containing the implementation of the bridge creation functions.
  */
 

--- a/src/supervisor/bridge_list.c
+++ b/src/supervisor/bridge_list.c
@@ -5,10 +5,7 @@
  * @copyright
  * SPDX-FileCopyrightText: © 2020 NQMCyber Ltd and edgesec contributors
  * SPDX-License-Identifier: LGPL-3.0-or-later
- */
-
-/**
- * @file bridge_list.c
+ *
  * @author Alexandru Mereacre
  * @brief File containing the implementation of the bridge creation functions.
  */

--- a/src/supervisor/bridge_list.h
+++ b/src/supervisor/bridge_list.h
@@ -1,21 +1,11 @@
-/****************************************************************************
- * Copyright (C) 2020 by NQMCyber Ltd                                       *
- *                                                                          *
- * This file is part of EDGESec.                                            *
- *                                                                          *
- *   EDGESec is free software: you can redistribute it and/or modify it     *
- *   under the terms of the GNU Lesser General Public License as published  *
- *   by the Free Software Foundation, either version 3 of the License, or   *
- *   (at your option) any later version.                                    *
- *                                                                          *
- *   EDGESec is distributed in the hope that it will be useful,             *
- *   but WITHOUT ANY WARRANTY; without even the implied warranty of         *
- *   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the          *
- *   GNU Lesser General Public License for more details.                    *
- *                                                                          *
- *   You should have received a copy of the GNU Lesser General Public       *
- *   License along with EDGESec. If not, see <http://www.gnu.org/licenses/>.*
- ****************************************************************************/
+/**
+ * @file
+ * @author Alexandru Mereacre
+ * @date 2020
+ * @copyright
+ * SPDX-FileCopyrightText: © 2020 NQMCyber Ltd and edgesec contributors
+ * SPDX-License-Identifier: LGPL-3.0-or-later
+ */
 
 /**
  * @file bridge_list.h

--- a/src/supervisor/bridge_list.h
+++ b/src/supervisor/bridge_list.h
@@ -6,7 +6,6 @@
  * SPDX-FileCopyrightText: © 2020 NQMCyber Ltd and edgesec contributors
  * SPDX-License-Identifier: LGPL-3.0-or-later
  *
- * @author Alexandru Mereacre
  * @brief File containing the definition of the bridge creation functions.
  */
 

--- a/src/supervisor/bridge_list.h
+++ b/src/supervisor/bridge_list.h
@@ -5,7 +5,6 @@
  * @copyright
  * SPDX-FileCopyrightText: © 2020 NQMCyber Ltd and edgesec contributors
  * SPDX-License-Identifier: LGPL-3.0-or-later
- *
  * @brief File containing the definition of the bridge creation functions.
  */
 

--- a/src/supervisor/bridge_list.h
+++ b/src/supervisor/bridge_list.h
@@ -5,10 +5,7 @@
  * @copyright
  * SPDX-FileCopyrightText: © 2020 NQMCyber Ltd and edgesec contributors
  * SPDX-License-Identifier: LGPL-3.0-or-later
- */
-
-/**
- * @file bridge_list.h
+ *
  * @author Alexandru Mereacre
  * @brief File containing the definition of the bridge creation functions.
  */

--- a/src/supervisor/cmd_processor.c
+++ b/src/supervisor/cmd_processor.c
@@ -5,7 +5,6 @@
  * @copyright
  * SPDX-FileCopyrightText: © 2020 NQMCyber Ltd and edgesec contributors
  * SPDX-License-Identifier: LGPL-3.0-or-later
- *
  * @brief File containing the implementation of the command processor functions.
  */
 

--- a/src/supervisor/cmd_processor.c
+++ b/src/supervisor/cmd_processor.c
@@ -5,10 +5,7 @@
  * @copyright
  * SPDX-FileCopyrightText: © 2020 NQMCyber Ltd and edgesec contributors
  * SPDX-License-Identifier: LGPL-3.0-or-later
- */
-
-/**
- * @file cmd_processor.c
+ *
  * @author Alexandru Mereacre
  * @brief File containing the implementation of the command processor functions.
  */

--- a/src/supervisor/cmd_processor.c
+++ b/src/supervisor/cmd_processor.c
@@ -6,7 +6,6 @@
  * SPDX-FileCopyrightText: © 2020 NQMCyber Ltd and edgesec contributors
  * SPDX-License-Identifier: LGPL-3.0-or-later
  *
- * @author Alexandru Mereacre
  * @brief File containing the implementation of the command processor functions.
  */
 

--- a/src/supervisor/cmd_processor.c
+++ b/src/supervisor/cmd_processor.c
@@ -1,21 +1,11 @@
-/****************************************************************************
- * Copyright (C) 2020 by NQMCyber Ltd                                       *
- *                                                                          *
- * This file is part of EDGESec.                                            *
- *                                                                          *
- *   EDGESec is free software: you can redistribute it and/or modify it     *
- *   under the terms of the GNU Lesser General Public License as published  *
- *   by the Free Software Foundation, either version 3 of the License, or   *
- *   (at your option) any later version.                                    *
- *                                                                          *
- *   EDGESec is distributed in the hope that it will be useful,             *
- *   but WITHOUT ANY WARRANTY; without even the implied warranty of         *
- *   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the          *
- *   GNU Lesser General Public License for more details.                    *
- *                                                                          *
- *   You should have received a copy of the GNU Lesser General Public       *
- *   License along with EDGESec. If not, see <http://www.gnu.org/licenses/>.*
- ****************************************************************************/
+/**
+ * @file
+ * @author Alexandru Mereacre
+ * @date 2020
+ * @copyright
+ * SPDX-FileCopyrightText: © 2020 NQMCyber Ltd and edgesec contributors
+ * SPDX-License-Identifier: LGPL-3.0-or-later
+ */
 
 /**
  * @file cmd_processor.c

--- a/src/supervisor/cmd_processor.h
+++ b/src/supervisor/cmd_processor.h
@@ -5,10 +5,7 @@
  * @copyright
  * SPDX-FileCopyrightText: © 2020 NQMCyber Ltd and edgesec contributors
  * SPDX-License-Identifier: LGPL-3.0-or-later
- */
-
-/**
- * @file cmd_processor.h
+ *
  * @author Alexandru Mereacre
  * @brief File containing the definition of the command processor functions.
  */

--- a/src/supervisor/cmd_processor.h
+++ b/src/supervisor/cmd_processor.h
@@ -5,7 +5,6 @@
  * @copyright
  * SPDX-FileCopyrightText: © 2020 NQMCyber Ltd and edgesec contributors
  * SPDX-License-Identifier: LGPL-3.0-or-later
- *
  * @brief File containing the definition of the command processor functions.
  */
 

--- a/src/supervisor/cmd_processor.h
+++ b/src/supervisor/cmd_processor.h
@@ -6,7 +6,6 @@
  * SPDX-FileCopyrightText: © 2020 NQMCyber Ltd and edgesec contributors
  * SPDX-License-Identifier: LGPL-3.0-or-later
  *
- * @author Alexandru Mereacre
  * @brief File containing the definition of the command processor functions.
  */
 

--- a/src/supervisor/cmd_processor.h
+++ b/src/supervisor/cmd_processor.h
@@ -1,21 +1,11 @@
-/****************************************************************************
- * Copyright (C) 2020 by NQMCyber Ltd                                       *
- *                                                                          *
- * This file is part of EDGESec.                                            *
- *                                                                          *
- *   EDGESec is free software: you can redistribute it and/or modify it     *
- *   under the terms of the GNU Lesser General Public License as published  *
- *   by the Free Software Foundation, either version 3 of the License, or   *
- *   (at your option) any later version.                                    *
- *                                                                          *
- *   EDGESec is distributed in the hope that it will be useful,             *
- *   but WITHOUT ANY WARRANTY; without even the implied warranty of         *
- *   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the          *
- *   GNU Lesser General Public License for more details.                    *
- *                                                                          *
- *   You should have received a copy of the GNU Lesser General Public       *
- *   License along with EDGESec. If not, see <http://www.gnu.org/licenses/>.*
- ****************************************************************************/
+/**
+ * @file
+ * @author Alexandru Mereacre
+ * @date 2020
+ * @copyright
+ * SPDX-FileCopyrightText: © 2020 NQMCyber Ltd and edgesec contributors
+ * SPDX-License-Identifier: LGPL-3.0-or-later
+ */
 
 /**
  * @file cmd_processor.h

--- a/src/supervisor/crypt_commands.c
+++ b/src/supervisor/crypt_commands.c
@@ -5,10 +5,7 @@
  * @copyright
  * SPDX-FileCopyrightText: © 2021 NQMCyber Ltd and edgesec contributors
  * SPDX-License-Identifier: LGPL-3.0-or-later
- */
-
-/**
- * @file crypt_commands.c
+ *
  * @author Alexandru Mereacre
  * @brief File containing the implementation of the crypt commands.
  */

--- a/src/supervisor/crypt_commands.c
+++ b/src/supervisor/crypt_commands.c
@@ -6,7 +6,6 @@
  * SPDX-FileCopyrightText: © 2021 NQMCyber Ltd and edgesec contributors
  * SPDX-License-Identifier: LGPL-3.0-or-later
  *
- * @author Alexandru Mereacre
  * @brief File containing the implementation of the crypt commands.
  */
 

--- a/src/supervisor/crypt_commands.c
+++ b/src/supervisor/crypt_commands.c
@@ -1,21 +1,11 @@
-/****************************************************************************
- * Copyright (C) 2021 by NQMCyber Ltd                                       *
- *                                                                          *
- * This file is part of EDGESec.                                            *
- *                                                                          *
- *   EDGESec is free software: you can redistribute it and/or modify it     *
- *   under the terms of the GNU Lesser General Public License as published  *
- *   by the Free Software Foundation, either version 3 of the License, or   *
- *   (at your option) any later version.                                    *
- *                                                                          *
- *   EDGESec is distributed in the hope that it will be useful,             *
- *   but WITHOUT ANY WARRANTY; without even the implied warranty of         *
- *   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the          *
- *   GNU Lesser General Public License for more details.                    *
- *                                                                          *
- *   You should have received a copy of the GNU Lesser General Public       *
- *   License along with EDGESec. If not, see <http://www.gnu.org/licenses/>.*
- ****************************************************************************/
+/**
+ * @file
+ * @author Alexandru Mereacre
+ * @date 2021
+ * @copyright
+ * SPDX-FileCopyrightText: © 2021 NQMCyber Ltd and edgesec contributors
+ * SPDX-License-Identifier: LGPL-3.0-or-later
+ */
 
 /**
  * @file crypt_commands.c

--- a/src/supervisor/crypt_commands.c
+++ b/src/supervisor/crypt_commands.c
@@ -5,7 +5,6 @@
  * @copyright
  * SPDX-FileCopyrightText: © 2021 NQMCyber Ltd and edgesec contributors
  * SPDX-License-Identifier: LGPL-3.0-or-later
- *
  * @brief File containing the implementation of the crypt commands.
  */
 

--- a/src/supervisor/crypt_commands.h
+++ b/src/supervisor/crypt_commands.h
@@ -5,10 +5,7 @@
  * @copyright
  * SPDX-FileCopyrightText: © 2021 NQMCyber Ltd and edgesec contributors
  * SPDX-License-Identifier: LGPL-3.0-or-later
- */
-
-/**
- * @file crypt_commands.h
+ *
  * @author Alexandru Mereacre
  * @brief File containing the definition of the crypt commands.
  */

--- a/src/supervisor/crypt_commands.h
+++ b/src/supervisor/crypt_commands.h
@@ -1,21 +1,11 @@
-/****************************************************************************
- * Copyright (C) 2021 by NQMCyber Ltd                                       *
- *                                                                          *
- * This file is part of EDGESec.                                            *
- *                                                                          *
- *   EDGESec is free software: you can redistribute it and/or modify it     *
- *   under the terms of the GNU Lesser General Public License as published  *
- *   by the Free Software Foundation, either version 3 of the License, or   *
- *   (at your option) any later version.                                    *
- *                                                                          *
- *   EDGESec is distributed in the hope that it will be useful,             *
- *   but WITHOUT ANY WARRANTY; without even the implied warranty of         *
- *   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the          *
- *   GNU Lesser General Public License for more details.                    *
- *                                                                          *
- *   You should have received a copy of the GNU Lesser General Public       *
- *   License along with EDGESec. If not, see <http://www.gnu.org/licenses/>.*
- ****************************************************************************/
+/**
+ * @file
+ * @author Alexandru Mereacre
+ * @date 2021
+ * @copyright
+ * SPDX-FileCopyrightText: © 2021 NQMCyber Ltd and edgesec contributors
+ * SPDX-License-Identifier: LGPL-3.0-or-later
+ */
 
 /**
  * @file crypt_commands.h

--- a/src/supervisor/crypt_commands.h
+++ b/src/supervisor/crypt_commands.h
@@ -6,7 +6,6 @@
  * SPDX-FileCopyrightText: © 2021 NQMCyber Ltd and edgesec contributors
  * SPDX-License-Identifier: LGPL-3.0-or-later
  *
- * @author Alexandru Mereacre
  * @brief File containing the definition of the crypt commands.
  */
 

--- a/src/supervisor/crypt_commands.h
+++ b/src/supervisor/crypt_commands.h
@@ -5,7 +5,6 @@
  * @copyright
  * SPDX-FileCopyrightText: © 2021 NQMCyber Ltd and edgesec contributors
  * SPDX-License-Identifier: LGPL-3.0-or-later
- *
  * @brief File containing the definition of the crypt commands.
  */
 

--- a/src/supervisor/mac_mapper.c
+++ b/src/supervisor/mac_mapper.c
@@ -6,7 +6,6 @@
  * SPDX-FileCopyrightText: © 2020 NQMCyber Ltd and edgesec contributors
  * SPDX-License-Identifier: LGPL-3.0-or-later
  *
- * @author Alexandru Mereacre
  * @brief File containing the implementation of the mac mapper.
  */
 #include <stdbool.h>

--- a/src/supervisor/mac_mapper.c
+++ b/src/supervisor/mac_mapper.c
@@ -5,10 +5,7 @@
  * @copyright
  * SPDX-FileCopyrightText: © 2020 NQMCyber Ltd and edgesec contributors
  * SPDX-License-Identifier: LGPL-3.0-or-later
- */
-
-/**
- * @file mac_mapper.c
+ *
  * @author Alexandru Mereacre
  * @brief File containing the implementation of the mac mapper.
  */

--- a/src/supervisor/mac_mapper.c
+++ b/src/supervisor/mac_mapper.c
@@ -1,21 +1,11 @@
-/****************************************************************************
- * Copyright (C) 2020 by NQMCyber Ltd                                       *
- *                                                                          *
- * This file is part of EDGESec.                                            *
- *                                                                          *
- *   EDGESec is free software: you can redistribute it and/or modify it     *
- *   under the terms of the GNU Lesser General Public License as published  *
- *   by the Free Software Foundation, either version 3 of the License, or   *
- *   (at your option) any later version.                                    *
- *                                                                          *
- *   EDGESec is distributed in the hope that it will be useful,             *
- *   but WITHOUT ANY WARRANTY; without even the implied warranty of         *
- *   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the          *
- *   GNU Lesser General Public License for more details.                    *
- *                                                                          *
- *   You should have received a copy of the GNU Lesser General Public       *
- *   License along with EDGESec. If not, see <http://www.gnu.org/licenses/>.*
- ****************************************************************************/
+/**
+ * @file
+ * @author Alexandru Mereacre
+ * @date 2020
+ * @copyright
+ * SPDX-FileCopyrightText: © 2020 NQMCyber Ltd and edgesec contributors
+ * SPDX-License-Identifier: LGPL-3.0-or-later
+ */
 
 /**
  * @file mac_mapper.c

--- a/src/supervisor/mac_mapper.c
+++ b/src/supervisor/mac_mapper.c
@@ -5,7 +5,6 @@
  * @copyright
  * SPDX-FileCopyrightText: © 2020 NQMCyber Ltd and edgesec contributors
  * SPDX-License-Identifier: LGPL-3.0-or-later
- *
  * @brief File containing the implementation of the mac mapper.
  */
 #include <stdbool.h>

--- a/src/supervisor/mac_mapper.h
+++ b/src/supervisor/mac_mapper.h
@@ -5,7 +5,6 @@
  * @copyright
  * SPDX-FileCopyrightText: © 2020 NQMCyber Ltd and edgesec contributors
  * SPDX-License-Identifier: LGPL-3.0-or-later
- *
  * @brief File containing the definition of the mac mapper.
  */
 

--- a/src/supervisor/mac_mapper.h
+++ b/src/supervisor/mac_mapper.h
@@ -6,7 +6,6 @@
  * SPDX-FileCopyrightText: © 2020 NQMCyber Ltd and edgesec contributors
  * SPDX-License-Identifier: LGPL-3.0-or-later
  *
- * @author Alexandru Mereacre
  * @brief File containing the definition of the mac mapper.
  */
 

--- a/src/supervisor/mac_mapper.h
+++ b/src/supervisor/mac_mapper.h
@@ -1,21 +1,11 @@
-/****************************************************************************
- * Copyright (C) 2020 by NQMCyber Ltd                                       *
- *                                                                          *
- * This file is part of EDGESec.                                            *
- *                                                                          *
- *   EDGESec is free software: you can redistribute it and/or modify it     *
- *   under the terms of the GNU Lesser General Public License as published  *
- *   by the Free Software Foundation, either version 3 of the License, or   *
- *   (at your option) any later version.                                    *
- *                                                                          *
- *   EDGESec is distributed in the hope that it will be useful,             *
- *   but WITHOUT ANY WARRANTY; without even the implied warranty of         *
- *   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the          *
- *   GNU Lesser General Public License for more details.                    *
- *                                                                          *
- *   You should have received a copy of the GNU Lesser General Public       *
- *   License along with EDGESec. If not, see <http://www.gnu.org/licenses/>.*
- ****************************************************************************/
+/**
+ * @file
+ * @author Alexandru Mereacre
+ * @date 2020
+ * @copyright
+ * SPDX-FileCopyrightText: © 2020 NQMCyber Ltd and edgesec contributors
+ * SPDX-License-Identifier: LGPL-3.0-or-later
+ */
 
 /**
  * @file mac_mapper.h

--- a/src/supervisor/mac_mapper.h
+++ b/src/supervisor/mac_mapper.h
@@ -5,10 +5,7 @@
  * @copyright
  * SPDX-FileCopyrightText: © 2020 NQMCyber Ltd and edgesec contributors
  * SPDX-License-Identifier: LGPL-3.0-or-later
- */
-
-/**
- * @file mac_mapper.h
+ *
  * @author Alexandru Mereacre
  * @brief File containing the definition of the mac mapper.
  */

--- a/src/supervisor/network_commands.c
+++ b/src/supervisor/network_commands.c
@@ -5,10 +5,7 @@
  * @copyright
  * SPDX-FileCopyrightText: © 2021 NQMCyber Ltd and edgesec contributors
  * SPDX-License-Identifier: LGPL-3.0-or-later
- */
-
-/**
- * @file network_commands.c
+ *
  * @author Alexandru Mereacre
  * @brief File containing the implementation of the network commands.
  */

--- a/src/supervisor/network_commands.c
+++ b/src/supervisor/network_commands.c
@@ -6,7 +6,6 @@
  * SPDX-FileCopyrightText: © 2021 NQMCyber Ltd and edgesec contributors
  * SPDX-License-Identifier: LGPL-3.0-or-later
  *
- * @author Alexandru Mereacre
  * @brief File containing the implementation of the network commands.
  */
 #include <libgen.h>

--- a/src/supervisor/network_commands.c
+++ b/src/supervisor/network_commands.c
@@ -1,21 +1,11 @@
-/****************************************************************************
- * Copyright (C) 2021 by NQMCyber Ltd                                       *
- *                                                                          *
- * This file is part of EDGESec.                                            *
- *                                                                          *
- *   EDGESec is free software: you can redistribute it and/or modify it     *
- *   under the terms of the GNU Lesser General Public License as published  *
- *   by the Free Software Foundation, either version 3 of the License, or   *
- *   (at your option) any later version.                                    *
- *                                                                          *
- *   EDGESec is distributed in the hope that it will be useful,             *
- *   but WITHOUT ANY WARRANTY; without even the implied warranty of         *
- *   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the          *
- *   GNU Lesser General Public License for more details.                    *
- *                                                                          *
- *   You should have received a copy of the GNU Lesser General Public       *
- *   License along with EDGESec. If not, see <http://www.gnu.org/licenses/>.*
- ****************************************************************************/
+/**
+ * @file
+ * @author Alexandru Mereacre
+ * @date 2021
+ * @copyright
+ * SPDX-FileCopyrightText: © 2021 NQMCyber Ltd and edgesec contributors
+ * SPDX-License-Identifier: LGPL-3.0-or-later
+ */
 
 /**
  * @file network_commands.c

--- a/src/supervisor/network_commands.c
+++ b/src/supervisor/network_commands.c
@@ -5,7 +5,6 @@
  * @copyright
  * SPDX-FileCopyrightText: © 2021 NQMCyber Ltd and edgesec contributors
  * SPDX-License-Identifier: LGPL-3.0-or-later
- *
  * @brief File containing the implementation of the network commands.
  */
 #include <libgen.h>

--- a/src/supervisor/network_commands.h
+++ b/src/supervisor/network_commands.h
@@ -1,21 +1,11 @@
-/****************************************************************************
- * Copyright (C) 2021 by NQMCyber Ltd                                       *
- *                                                                          *
- * This file is part of EDGESec.                                            *
- *                                                                          *
- *   EDGESec is free software: you can redistribute it and/or modify it     *
- *   under the terms of the GNU Lesser General Public License as published  *
- *   by the Free Software Foundation, either version 3 of the License, or   *
- *   (at your option) any later version.                                    *
- *                                                                          *
- *   EDGESec is distributed in the hope that it will be useful,             *
- *   but WITHOUT ANY WARRANTY; without even the implied warranty of         *
- *   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the          *
- *   GNU Lesser General Public License for more details.                    *
- *                                                                          *
- *   You should have received a copy of the GNU Lesser General Public       *
- *   License along with EDGESec. If not, see <http://www.gnu.org/licenses/>.*
- ****************************************************************************/
+/**
+ * @file
+ * @author Alexandru Mereacre
+ * @date 2021
+ * @copyright
+ * SPDX-FileCopyrightText: © 2021 NQMCyber Ltd and edgesec contributors
+ * SPDX-License-Identifier: LGPL-3.0-or-later
+ */
 
 /**
  * @file network_commands.h

--- a/src/supervisor/network_commands.h
+++ b/src/supervisor/network_commands.h
@@ -5,7 +5,6 @@
  * @copyright
  * SPDX-FileCopyrightText: © 2021 NQMCyber Ltd and edgesec contributors
  * SPDX-License-Identifier: LGPL-3.0-or-later
- *
  * @brief File containing the definition of the network commands.
  */
 

--- a/src/supervisor/network_commands.h
+++ b/src/supervisor/network_commands.h
@@ -5,10 +5,7 @@
  * @copyright
  * SPDX-FileCopyrightText: © 2021 NQMCyber Ltd and edgesec contributors
  * SPDX-License-Identifier: LGPL-3.0-or-later
- */
-
-/**
- * @file network_commands.h
+ *
  * @author Alexandru Mereacre
  * @brief File containing the definition of the network commands.
  */

--- a/src/supervisor/network_commands.h
+++ b/src/supervisor/network_commands.h
@@ -6,7 +6,6 @@
  * SPDX-FileCopyrightText: © 2021 NQMCyber Ltd and edgesec contributors
  * SPDX-License-Identifier: LGPL-3.0-or-later
  *
- * @author Alexandru Mereacre
  * @brief File containing the definition of the network commands.
  */
 

--- a/src/supervisor/sqlite_macconn_writer.c
+++ b/src/supervisor/sqlite_macconn_writer.c
@@ -5,7 +5,6 @@
  * @copyright
  * SPDX-FileCopyrightText: © 2021 NQMCyber Ltd and edgesec contributors
  * SPDX-License-Identifier: LGPL-3.0-or-later
- *
  * @brief File containing the implementation of the sqlite macconn writer
  * utilities.
  */

--- a/src/supervisor/sqlite_macconn_writer.c
+++ b/src/supervisor/sqlite_macconn_writer.c
@@ -6,7 +6,6 @@
  * SPDX-FileCopyrightText: © 2021 NQMCyber Ltd and edgesec contributors
  * SPDX-License-Identifier: LGPL-3.0-or-later
  *
- * @author Alexandru Mereacre
  * @brief File containing the implementation of the sqlite macconn writer
  * utilities.
  */

--- a/src/supervisor/sqlite_macconn_writer.c
+++ b/src/supervisor/sqlite_macconn_writer.c
@@ -5,10 +5,7 @@
  * @copyright
  * SPDX-FileCopyrightText: © 2021 NQMCyber Ltd and edgesec contributors
  * SPDX-License-Identifier: LGPL-3.0-or-later
- */
-
-/**
- * @file sqlite_macconn_writer.c
+ *
  * @author Alexandru Mereacre
  * @brief File containing the implementation of the sqlite macconn writer
  * utilities.

--- a/src/supervisor/sqlite_macconn_writer.c
+++ b/src/supervisor/sqlite_macconn_writer.c
@@ -1,21 +1,11 @@
-/****************************************************************************
- * Copyright (C) 2021 by NQMCyber Ltd                                       *
- *                                                                          *
- * This file is part of EDGESec.                                            *
- *                                                                          *
- *   EDGESec is free software: you can redistribute it and/or modify it     *
- *   under the terms of the GNU Lesser General Public License as published  *
- *   by the Free Software Foundation, either version 3 of the License, or   *
- *   (at your option) any later version.                                    *
- *                                                                          *
- *   EDGESec is distributed in the hope that it will be useful,             *
- *   but WITHOUT ANY WARRANTY; without even the implied warranty of         *
- *   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the          *
- *   GNU Lesser General Public License for more details.                    *
- *                                                                          *
- *   You should have received a copy of the GNU Lesser General Public       *
- *   License along with EDGESec. If not, see <http://www.gnu.org/licenses/>.*
- ****************************************************************************/
+/**
+ * @file
+ * @author Alexandru Mereacre
+ * @date 2021
+ * @copyright
+ * SPDX-FileCopyrightText: © 2021 NQMCyber Ltd and edgesec contributors
+ * SPDX-License-Identifier: LGPL-3.0-or-later
+ */
 
 /**
  * @file sqlite_macconn_writer.c

--- a/src/supervisor/sqlite_macconn_writer.h
+++ b/src/supervisor/sqlite_macconn_writer.h
@@ -5,10 +5,7 @@
  * @copyright
  * SPDX-FileCopyrightText: © 2021 NQMCyber Ltd and edgesec contributors
  * SPDX-License-Identifier: LGPL-3.0-or-later
- */
-
-/**
- * @file sqlite_macconn_writer.h
+ *
  * @author Alexandru Mereacre
  * @brief File containing the definition of the sqlite macconn writer utilities.
  */

--- a/src/supervisor/sqlite_macconn_writer.h
+++ b/src/supervisor/sqlite_macconn_writer.h
@@ -5,7 +5,6 @@
  * @copyright
  * SPDX-FileCopyrightText: © 2021 NQMCyber Ltd and edgesec contributors
  * SPDX-License-Identifier: LGPL-3.0-or-later
- *
  * @brief File containing the definition of the sqlite macconn writer utilities.
  */
 

--- a/src/supervisor/sqlite_macconn_writer.h
+++ b/src/supervisor/sqlite_macconn_writer.h
@@ -6,7 +6,6 @@
  * SPDX-FileCopyrightText: © 2021 NQMCyber Ltd and edgesec contributors
  * SPDX-License-Identifier: LGPL-3.0-or-later
  *
- * @author Alexandru Mereacre
  * @brief File containing the definition of the sqlite macconn writer utilities.
  */
 

--- a/src/supervisor/sqlite_macconn_writer.h
+++ b/src/supervisor/sqlite_macconn_writer.h
@@ -1,21 +1,11 @@
-/****************************************************************************
- * Copyright (C) 2021 by NQMCyber Ltd                                       *
- *                                                                          *
- * This file is part of EDGESec.                                            *
- *                                                                          *
- *   EDGESec is free software: you can redistribute it and/or modify it     *
- *   under the terms of the GNU Lesser General Public License as published  *
- *   by the Free Software Foundation, either version 3 of the License, or   *
- *   (at your option) any later version.                                    *
- *                                                                          *
- *   EDGESec is distributed in the hope that it will be useful,             *
- *   but WITHOUT ANY WARRANTY; without even the implied warranty of         *
- *   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the          *
- *   GNU Lesser General Public License for more details.                    *
- *                                                                          *
- *   You should have received a copy of the GNU Lesser General Public       *
- *   License along with EDGESec. If not, see <http://www.gnu.org/licenses/>.*
- ****************************************************************************/
+/**
+ * @file
+ * @author Alexandru Mereacre
+ * @date 2021
+ * @copyright
+ * SPDX-FileCopyrightText: © 2021 NQMCyber Ltd and edgesec contributors
+ * SPDX-License-Identifier: LGPL-3.0-or-later
+ */
 
 /**
  * @file sqlite_macconn_writer.h

--- a/src/supervisor/subscriber_events.c
+++ b/src/supervisor/subscriber_events.c
@@ -6,7 +6,6 @@
  * SPDX-FileCopyrightText: © 2021 NQMCyber Ltd and edgesec contributors
  * SPDX-License-Identifier: LGPL-3.0-or-later
  *
- * @author Alexandru Mereacre
  * @brief File containing the implementation of the subscriber events structure.
  */
 

--- a/src/supervisor/subscriber_events.c
+++ b/src/supervisor/subscriber_events.c
@@ -5,10 +5,7 @@
  * @copyright
  * SPDX-FileCopyrightText: © 2021 NQMCyber Ltd and edgesec contributors
  * SPDX-License-Identifier: LGPL-3.0-or-later
- */
-
-/**
- * @file subscriber_events.c
+ *
  * @author Alexandru Mereacre
  * @brief File containing the implementation of the subscriber events structure.
  */

--- a/src/supervisor/subscriber_events.c
+++ b/src/supervisor/subscriber_events.c
@@ -5,7 +5,6 @@
  * @copyright
  * SPDX-FileCopyrightText: © 2021 NQMCyber Ltd and edgesec contributors
  * SPDX-License-Identifier: LGPL-3.0-or-later
- *
  * @brief File containing the implementation of the subscriber events structure.
  */
 

--- a/src/supervisor/subscriber_events.c
+++ b/src/supervisor/subscriber_events.c
@@ -1,21 +1,11 @@
-/****************************************************************************
- * Copyright (C) 2021 by NQMCyber Ltd                                       *
- *                                                                          *
- * This file is part of EDGESec.                                            *
- *                                                                          *
- *   EDGESec is free software: you can redistribute it and/or modify it     *
- *   under the terms of the GNU Lesser General Public License as published  *
- *   by the Free Software Foundation, either version 3 of the License, or   *
- *   (at your option) any later version.                                    *
- *                                                                          *
- *   EDGESec is distributed in the hope that it will be useful,             *
- *   but WITHOUT ANY WARRANTY; without even the implied warranty of         *
- *   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the          *
- *   GNU Lesser General Public License for more details.                    *
- *                                                                          *
- *   You should have received a copy of the GNU Lesser General Public       *
- *   License along with EDGESec. If not, see <http://www.gnu.org/licenses/>.*
- ****************************************************************************/
+/**
+ * @file
+ * @author Alexandru Mereacre
+ * @date 2021
+ * @copyright
+ * SPDX-FileCopyrightText: © 2021 NQMCyber Ltd and edgesec contributors
+ * SPDX-License-Identifier: LGPL-3.0-or-later
+ */
 
 /**
  * @file subscriber_events.c

--- a/src/supervisor/subscriber_events.h
+++ b/src/supervisor/subscriber_events.h
@@ -5,10 +5,7 @@
  * @copyright
  * SPDX-FileCopyrightText: © 2021 NQMCyber Ltd and edgesec contributors
  * SPDX-License-Identifier: LGPL-3.0-or-later
- */
-
-/**
- * @file subscriber_events.c
+ *
  * @author Alexandru Mereacre
  * @brief File containing the definition of the subscriber events structure.
  */

--- a/src/supervisor/subscriber_events.h
+++ b/src/supervisor/subscriber_events.h
@@ -6,7 +6,6 @@
  * SPDX-FileCopyrightText: © 2021 NQMCyber Ltd and edgesec contributors
  * SPDX-License-Identifier: LGPL-3.0-or-later
  *
- * @author Alexandru Mereacre
  * @brief File containing the definition of the subscriber events structure.
  */
 

--- a/src/supervisor/subscriber_events.h
+++ b/src/supervisor/subscriber_events.h
@@ -1,21 +1,11 @@
-/****************************************************************************
- * Copyright (C) 2021 by NQMCyber Ltd                                       *
- *                                                                          *
- * This file is part of EDGESec.                                            *
- *                                                                          *
- *   EDGESec is free software: you can redistribute it and/or modify it     *
- *   under the terms of the GNU Lesser General Public License as published  *
- *   by the Free Software Foundation, either version 3 of the License, or   *
- *   (at your option) any later version.                                    *
- *                                                                          *
- *   EDGESec is distributed in the hope that it will be useful,             *
- *   but WITHOUT ANY WARRANTY; without even the implied warranty of         *
- *   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the          *
- *   GNU Lesser General Public License for more details.                    *
- *                                                                          *
- *   You should have received a copy of the GNU Lesser General Public       *
- *   License along with EDGESec. If not, see <http://www.gnu.org/licenses/>.*
- ****************************************************************************/
+/**
+ * @file
+ * @author Alexandru Mereacre
+ * @date 2021
+ * @copyright
+ * SPDX-FileCopyrightText: © 2021 NQMCyber Ltd and edgesec contributors
+ * SPDX-License-Identifier: LGPL-3.0-or-later
+ */
 
 /**
  * @file subscriber_events.c

--- a/src/supervisor/subscriber_events.h
+++ b/src/supervisor/subscriber_events.h
@@ -5,7 +5,6 @@
  * @copyright
  * SPDX-FileCopyrightText: © 2021 NQMCyber Ltd and edgesec contributors
  * SPDX-License-Identifier: LGPL-3.0-or-later
- *
  * @brief File containing the definition of the subscriber events structure.
  */
 

--- a/src/supervisor/supervisor.c
+++ b/src/supervisor/supervisor.c
@@ -5,7 +5,6 @@
  * @copyright
  * SPDX-FileCopyrightText: © 2020 NQMCyber Ltd and edgesec contributors
  * SPDX-License-Identifier: LGPL-3.0-or-later
- *
  * @brief File containing the implementation of the supervisor service.
  */
 

--- a/src/supervisor/supervisor.c
+++ b/src/supervisor/supervisor.c
@@ -6,7 +6,6 @@
  * SPDX-FileCopyrightText: © 2020 NQMCyber Ltd and edgesec contributors
  * SPDX-License-Identifier: LGPL-3.0-or-later
  *
- * @author Alexandru Mereacre
  * @brief File containing the implementation of the supervisor service.
  */
 

--- a/src/supervisor/supervisor.c
+++ b/src/supervisor/supervisor.c
@@ -1,21 +1,11 @@
-/****************************************************************************
- * Copyright (C) 2020 by NQMCyber Ltd                                       *
- *                                                                          *
- * This file is part of EDGESec.                                            *
- *                                                                          *
- *   EDGESec is free software: you can redistribute it and/or modify it     *
- *   under the terms of the GNU Lesser General Public License as published  *
- *   by the Free Software Foundation, either version 3 of the License, or   *
- *   (at your option) any later version.                                    *
- *                                                                          *
- *   EDGESec is distributed in the hope that it will be useful,             *
- *   but WITHOUT ANY WARRANTY; without even the implied warranty of         *
- *   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the          *
- *   GNU Lesser General Public License for more details.                    *
- *                                                                          *
- *   You should have received a copy of the GNU Lesser General Public       *
- *   License along with EDGESec. If not, see <http://www.gnu.org/licenses/>.*
- ****************************************************************************/
+/**
+ * @file
+ * @author Alexandru Mereacre
+ * @date 2020
+ * @copyright
+ * SPDX-FileCopyrightText: © 2020 NQMCyber Ltd and edgesec contributors
+ * SPDX-License-Identifier: LGPL-3.0-or-later
+ */
 
 /**
  * @file supervisor.c

--- a/src/supervisor/supervisor.c
+++ b/src/supervisor/supervisor.c
@@ -5,10 +5,7 @@
  * @copyright
  * SPDX-FileCopyrightText: © 2020 NQMCyber Ltd and edgesec contributors
  * SPDX-License-Identifier: LGPL-3.0-or-later
- */
-
-/**
- * @file supervisor.c
+ *
  * @author Alexandru Mereacre
  * @brief File containing the implementation of the supervisor service.
  */

--- a/src/supervisor/supervisor.h
+++ b/src/supervisor/supervisor.h
@@ -6,7 +6,6 @@
  * SPDX-FileCopyrightText: © 2020 NQMCyber Ltd and edgesec contributors
  * SPDX-License-Identifier: LGPL-3.0-or-later
  *
- * @author Alexandru Mereacre
  * @brief File containing the definition of the supervisor service.
  */
 

--- a/src/supervisor/supervisor.h
+++ b/src/supervisor/supervisor.h
@@ -1,21 +1,11 @@
-/****************************************************************************
- * Copyright (C) 2020 by NQMCyber Ltd                                       *
- *                                                                          *
- * This file is part of EDGESec.                                            *
- *                                                                          *
- *   EDGESec is free software: you can redistribute it and/or modify it     *
- *   under the terms of the GNU Lesser General Public License as published  *
- *   by the Free Software Foundation, either version 3 of the License, or   *
- *   (at your option) any later version.                                    *
- *                                                                          *
- *   EDGESec is distributed in the hope that it will be useful,             *
- *   but WITHOUT ANY WARRANTY; without even the implied warranty of         *
- *   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the          *
- *   GNU Lesser General Public License for more details.                    *
- *                                                                          *
- *   You should have received a copy of the GNU Lesser General Public       *
- *   License along with EDGESec. If not, see <http://www.gnu.org/licenses/>.*
- ****************************************************************************/
+/**
+ * @file
+ * @author Alexandru Mereacre
+ * @date 2020
+ * @copyright
+ * SPDX-FileCopyrightText: © 2020 NQMCyber Ltd and edgesec contributors
+ * SPDX-License-Identifier: LGPL-3.0-or-later
+ */
 
 /**
  * @file supervisor.c

--- a/src/supervisor/supervisor.h
+++ b/src/supervisor/supervisor.h
@@ -5,10 +5,7 @@
  * @copyright
  * SPDX-FileCopyrightText: © 2020 NQMCyber Ltd and edgesec contributors
  * SPDX-License-Identifier: LGPL-3.0-or-later
- */
-
-/**
- * @file supervisor.c
+ *
  * @author Alexandru Mereacre
  * @brief File containing the definition of the supervisor service.
  */

--- a/src/supervisor/supervisor.h
+++ b/src/supervisor/supervisor.h
@@ -5,7 +5,6 @@
  * @copyright
  * SPDX-FileCopyrightText: © 2020 NQMCyber Ltd and edgesec contributors
  * SPDX-License-Identifier: LGPL-3.0-or-later
- *
  * @brief File containing the definition of the supervisor service.
  */
 

--- a/src/supervisor/supervisor_config.h
+++ b/src/supervisor/supervisor_config.h
@@ -5,7 +5,6 @@
  * @copyright
  * SPDX-FileCopyrightText: © 2020 NQMCyber Ltd and edgesec contributors
  * SPDX-License-Identifier: LGPL-3.0-or-later
- *
  * @brief File containing the definition of the supervisor service structure.
  */
 

--- a/src/supervisor/supervisor_config.h
+++ b/src/supervisor/supervisor_config.h
@@ -5,10 +5,7 @@
  * @copyright
  * SPDX-FileCopyrightText: © 2020 NQMCyber Ltd and edgesec contributors
  * SPDX-License-Identifier: LGPL-3.0-or-later
- */
-
-/**
- * @file supervisor_config.c
+ *
  * @author Alexandru Mereacre
  * @brief File containing the definition of the supervisor service structure.
  */

--- a/src/supervisor/supervisor_config.h
+++ b/src/supervisor/supervisor_config.h
@@ -6,7 +6,6 @@
  * SPDX-FileCopyrightText: © 2020 NQMCyber Ltd and edgesec contributors
  * SPDX-License-Identifier: LGPL-3.0-or-later
  *
- * @author Alexandru Mereacre
  * @brief File containing the definition of the supervisor service structure.
  */
 

--- a/src/supervisor/supervisor_config.h
+++ b/src/supervisor/supervisor_config.h
@@ -1,21 +1,11 @@
-/****************************************************************************
- * Copyright (C) 2020 by NQMCyber Ltd                                       *
- *                                                                          *
- * This file is part of EDGESec.                                            *
- *                                                                          *
- *   EDGESec is free software: you can redistribute it and/or modify it     *
- *   under the terms of the GNU Lesser General Public License as published  *
- *   by the Free Software Foundation, either version 3 of the License, or   *
- *   (at your option) any later version.                                    *
- *                                                                          *
- *   EDGESec is distributed in the hope that it will be useful,             *
- *   but WITHOUT ANY WARRANTY; without even the implied warranty of         *
- *   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the          *
- *   GNU Lesser General Public License for more details.                    *
- *                                                                          *
- *   You should have received a copy of the GNU Lesser General Public       *
- *   License along with EDGESec. If not, see <http://www.gnu.org/licenses/>.*
- ****************************************************************************/
+/**
+ * @file
+ * @author Alexandru Mereacre
+ * @date 2020
+ * @copyright
+ * SPDX-FileCopyrightText: © 2020 NQMCyber Ltd and edgesec contributors
+ * SPDX-License-Identifier: LGPL-3.0-or-later
+ */
 
 /**
  * @file supervisor_config.c

--- a/src/supervisor/system_commands.c
+++ b/src/supervisor/system_commands.c
@@ -5,7 +5,6 @@
  * @copyright
  * SPDX-FileCopyrightText: © 2021 NQMCyber Ltd and edgesec contributors
  * SPDX-License-Identifier: LGPL-3.0-or-later
- *
  * @brief File containing the implementation of the system commands.
  */
 #include <sys/un.h>

--- a/src/supervisor/system_commands.c
+++ b/src/supervisor/system_commands.c
@@ -1,21 +1,11 @@
-/****************************************************************************
- * Copyright (C) 2021 by NQMCyber Ltd                                       *
- *                                                                          *
- * This file is part of EDGESec.                                            *
- *                                                                          *
- *   EDGESec is free software: you can redistribute it and/or modify it     *
- *   under the terms of the GNU Lesser General Public License as published  *
- *   by the Free Software Foundation, either version 3 of the License, or   *
- *   (at your option) any later version.                                    *
- *                                                                          *
- *   EDGESec is distributed in the hope that it will be useful,             *
- *   but WITHOUT ANY WARRANTY; without even the implied warranty of         *
- *   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the          *
- *   GNU Lesser General Public License for more details.                    *
- *                                                                          *
- *   You should have received a copy of the GNU Lesser General Public       *
- *   License along with EDGESec. If not, see <http://www.gnu.org/licenses/>.*
- ****************************************************************************/
+/**
+ * @file
+ * @author Alexandru Mereacre
+ * @date 2021
+ * @copyright
+ * SPDX-FileCopyrightText: © 2021 NQMCyber Ltd and edgesec contributors
+ * SPDX-License-Identifier: LGPL-3.0-or-later
+ */
 
 /**
  * @file system_commands.c

--- a/src/supervisor/system_commands.c
+++ b/src/supervisor/system_commands.c
@@ -5,10 +5,7 @@
  * @copyright
  * SPDX-FileCopyrightText: © 2021 NQMCyber Ltd and edgesec contributors
  * SPDX-License-Identifier: LGPL-3.0-or-later
- */
-
-/**
- * @file system_commands.c
+ *
  * @author Alexandru Mereacre
  * @brief File containing the implementation of the system commands.
  */

--- a/src/supervisor/system_commands.c
+++ b/src/supervisor/system_commands.c
@@ -6,7 +6,6 @@
  * SPDX-FileCopyrightText: © 2021 NQMCyber Ltd and edgesec contributors
  * SPDX-License-Identifier: LGPL-3.0-or-later
  *
- * @author Alexandru Mereacre
  * @brief File containing the implementation of the system commands.
  */
 #include <sys/un.h>

--- a/src/supervisor/system_commands.h
+++ b/src/supervisor/system_commands.h
@@ -5,10 +5,7 @@
  * @copyright
  * SPDX-FileCopyrightText: © 2021 NQMCyber Ltd and edgesec contributors
  * SPDX-License-Identifier: LGPL-3.0-or-later
- */
-
-/**
- * @file system_commands.h
+ *
  * @author Alexandru Mereacre
  * @brief File containing the definition of the system commands.
  */

--- a/src/supervisor/system_commands.h
+++ b/src/supervisor/system_commands.h
@@ -6,7 +6,6 @@
  * SPDX-FileCopyrightText: © 2021 NQMCyber Ltd and edgesec contributors
  * SPDX-License-Identifier: LGPL-3.0-or-later
  *
- * @author Alexandru Mereacre
  * @brief File containing the definition of the system commands.
  */
 

--- a/src/supervisor/system_commands.h
+++ b/src/supervisor/system_commands.h
@@ -5,7 +5,6 @@
  * @copyright
  * SPDX-FileCopyrightText: © 2021 NQMCyber Ltd and edgesec contributors
  * SPDX-License-Identifier: LGPL-3.0-or-later
- *
  * @brief File containing the definition of the system commands.
  */
 

--- a/src/supervisor/system_commands.h
+++ b/src/supervisor/system_commands.h
@@ -1,21 +1,11 @@
-/****************************************************************************
- * Copyright (C) 2021 by NQMCyber Ltd                                       *
- *                                                                          *
- * This file is part of EDGESec.                                            *
- *                                                                          *
- *   EDGESec is free software: you can redistribute it and/or modify it     *
- *   under the terms of the GNU Lesser General Public License as published  *
- *   by the Free Software Foundation, either version 3 of the License, or   *
- *   (at your option) any later version.                                    *
- *                                                                          *
- *   EDGESec is distributed in the hope that it will be useful,             *
- *   but WITHOUT ANY WARRANTY; without even the implied warranty of         *
- *   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the          *
- *   GNU Lesser General Public License for more details.                    *
- *                                                                          *
- *   You should have received a copy of the GNU Lesser General Public       *
- *   License along with EDGESec. If not, see <http://www.gnu.org/licenses/>.*
- ****************************************************************************/
+/**
+ * @file
+ * @author Alexandru Mereacre
+ * @date 2021
+ * @copyright
+ * SPDX-FileCopyrightText: © 2021 NQMCyber Ltd and edgesec contributors
+ * SPDX-License-Identifier: LGPL-3.0-or-later
+ */
 
 /**
  * @file system_commands.h

--- a/src/utils/allocs.c
+++ b/src/utils/allocs.c
@@ -6,7 +6,6 @@
  * SPDX-FileCopyrightText: © 2020 NQMCyber Ltd and edgesec contributors
  * SPDX-License-Identifier: LGPL-3.0-or-later
  *
- * @author Alexandru Mereacre
  * @brief File containing the implementation of the allocs functionalities.
  */
 

--- a/src/utils/allocs.c
+++ b/src/utils/allocs.c
@@ -1,21 +1,11 @@
-/****************************************************************************
- * Copyright (C) 2020 by NQMCyber Ltd                                       *
- *                                                                          *
- * This file is part of EDGESec.                                            *
- *                                                                          *
- *   EDGESec is free software: you can redistribute it and/or modify it     *
- *   under the terms of the GNU Lesser General Public License as published  *
- *   by the Free Software Foundation, either version 3 of the License, or   *
- *   (at your option) any later version.                                    *
- *                                                                          *
- *   EDGESec is distributed in the hope that it will be useful,             *
- *   but WITHOUT ANY WARRANTY; without even the implied warranty of         *
- *   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the          *
- *   GNU Lesser General Public License for more details.                    *
- *                                                                          *
- *   You should have received a copy of the GNU Lesser General Public       *
- *   License along with EDGESec. If not, see <http://www.gnu.org/licenses/>.*
- ****************************************************************************/
+/**
+ * @file
+ * @author Alexandru Mereacre
+ * @date 2020
+ * @copyright
+ * SPDX-FileCopyrightText: © 2020 NQMCyber Ltd and edgesec contributors
+ * SPDX-License-Identifier: LGPL-3.0-or-later
+ */
 
 /**
  * @file allocs.c

--- a/src/utils/allocs.c
+++ b/src/utils/allocs.c
@@ -5,10 +5,7 @@
  * @copyright
  * SPDX-FileCopyrightText: © 2020 NQMCyber Ltd and edgesec contributors
  * SPDX-License-Identifier: LGPL-3.0-or-later
- */
-
-/**
- * @file allocs.c
+ *
  * @author Alexandru Mereacre
  * @brief File containing the implementation of the allocs functionalities.
  */

--- a/src/utils/allocs.c
+++ b/src/utils/allocs.c
@@ -5,7 +5,6 @@
  * @copyright
  * SPDX-FileCopyrightText: © 2020 NQMCyber Ltd and edgesec contributors
  * SPDX-License-Identifier: LGPL-3.0-or-later
- *
  * @brief File containing the implementation of the allocs functionalities.
  */
 

--- a/src/utils/allocs.h
+++ b/src/utils/allocs.h
@@ -1,21 +1,11 @@
-/****************************************************************************
- * Copyright (C) 2020 by NQMCyber Ltd                                       *
- *                                                                          *
- * This file is part of EDGESec.                                            *
- *                                                                          *
- *   EDGESec is free software: you can redistribute it and/or modify it     *
- *   under the terms of the GNU Lesser General Public License as published  *
- *   by the Free Software Foundation, either version 3 of the License, or   *
- *   (at your option) any later version.                                    *
- *                                                                          *
- *   EDGESec is distributed in the hope that it will be useful,             *
- *   but WITHOUT ANY WARRANTY; without even the implied warranty of         *
- *   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the          *
- *   GNU Lesser General Public License for more details.                    *
- *                                                                          *
- *   You should have received a copy of the GNU Lesser General Public       *
- *   License along with EDGESec. If not, see <http://www.gnu.org/licenses/>.*
- ****************************************************************************/
+/**
+ * @file
+ * @author Alexandru Mereacre
+ * @date 2020
+ * @copyright
+ * SPDX-FileCopyrightText: © 2020 NQMCyber Ltd and edgesec contributors
+ * SPDX-License-Identifier: LGPL-3.0-or-later
+ */
 
 /**
  * @file allocs.h

--- a/src/utils/allocs.h
+++ b/src/utils/allocs.h
@@ -5,7 +5,6 @@
  * @copyright
  * SPDX-FileCopyrightText: © 2020 NQMCyber Ltd and edgesec contributors
  * SPDX-License-Identifier: LGPL-3.0-or-later
- *
  * @brief File containing the definition of the allocs functionalities.
  */
 #ifndef ALLOCS_H

--- a/src/utils/allocs.h
+++ b/src/utils/allocs.h
@@ -6,7 +6,6 @@
  * SPDX-FileCopyrightText: © 2020 NQMCyber Ltd and edgesec contributors
  * SPDX-License-Identifier: LGPL-3.0-or-later
  *
- * @author Alexandru Mereacre
  * @brief File containing the definition of the allocs functionalities.
  */
 #ifndef ALLOCS_H

--- a/src/utils/allocs.h
+++ b/src/utils/allocs.h
@@ -5,10 +5,7 @@
  * @copyright
  * SPDX-FileCopyrightText: © 2020 NQMCyber Ltd and edgesec contributors
  * SPDX-License-Identifier: LGPL-3.0-or-later
- */
-
-/**
- * @file allocs.h
+ *
  * @author Alexandru Mereacre
  * @brief File containing the definition of the allocs functionalities.
  */

--- a/src/utils/cryptou.c
+++ b/src/utils/cryptou.c
@@ -1,21 +1,11 @@
-/****************************************************************************
- * Copyright (C) 2021 by NQMCyber Ltd                                       *
- *                                                                          *
- * This file is part of EDGESec.                                            *
- *                                                                          *
- *   EDGESec is free software: you can redistribute it and/or modify it     *
- *   under the terms of the GNU Lesser General Public License as published  *
- *   by the Free Software Foundation, either version 3 of the License, or   *
- *   (at your option) any later version.                                    *
- *                                                                          *
- *   EDGESec is distributed in the hope that it will be useful,             *
- *   but WITHOUT ANY WARRANTY; without even the implied warranty of         *
- *   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the          *
- *   GNU Lesser General Public License for more details.                    *
- *                                                                          *
- *   You should have received a copy of the GNU Lesser General Public       *
- *   License along with EDGESec. If not, see <http://www.gnu.org/licenses/>.*
- ****************************************************************************/
+/**
+ * @file
+ * @author Alexandru Mereacre
+ * @date 2021
+ * @copyright
+ * SPDX-FileCopyrightText: © 2021 NQMCyber Ltd and edgesec contributors
+ * SPDX-License-Identifier: LGPL-3.0-or-later
+ */
 
 /**
  * @file cryptou.c

--- a/src/utils/cryptou.c
+++ b/src/utils/cryptou.c
@@ -5,7 +5,6 @@
  * @copyright
  * SPDX-FileCopyrightText: © 2021 NQMCyber Ltd and edgesec contributors
  * SPDX-License-Identifier: LGPL-3.0-or-later
- *
  * @brief File containing the implementation of the cryptographic utilities.
  */
 

--- a/src/utils/cryptou.c
+++ b/src/utils/cryptou.c
@@ -5,10 +5,7 @@
  * @copyright
  * SPDX-FileCopyrightText: © 2021 NQMCyber Ltd and edgesec contributors
  * SPDX-License-Identifier: LGPL-3.0-or-later
- */
-
-/**
- * @file cryptou.c
+ *
  * @author Alexandru Mereacre
  * @brief File containing the implementation of the cryptographic utilities.
  */

--- a/src/utils/cryptou.c
+++ b/src/utils/cryptou.c
@@ -6,7 +6,6 @@
  * SPDX-FileCopyrightText: © 2021 NQMCyber Ltd and edgesec contributors
  * SPDX-License-Identifier: LGPL-3.0-or-later
  *
- * @author Alexandru Mereacre
  * @brief File containing the implementation of the cryptographic utilities.
  */
 

--- a/src/utils/cryptou.h
+++ b/src/utils/cryptou.h
@@ -5,10 +5,7 @@
  * @copyright
  * SPDX-FileCopyrightText: © 2021 NQMCyber Ltd and edgesec contributors
  * SPDX-License-Identifier: LGPL-3.0-or-later
- */
-
-/**
- * @file cryptou.h
+ *
  * @author Alexandru Mereacre
  * @brief File containing the definition of the cryptographic utilities.
  */

--- a/src/utils/cryptou.h
+++ b/src/utils/cryptou.h
@@ -6,7 +6,6 @@
  * SPDX-FileCopyrightText: © 2021 NQMCyber Ltd and edgesec contributors
  * SPDX-License-Identifier: LGPL-3.0-or-later
  *
- * @author Alexandru Mereacre
  * @brief File containing the definition of the cryptographic utilities.
  */
 

--- a/src/utils/cryptou.h
+++ b/src/utils/cryptou.h
@@ -1,21 +1,11 @@
-/****************************************************************************
- * Copyright (C) 2021 by NQMCyber Ltd                                       *
- *                                                                          *
- * This file is part of EDGESec.                                            *
- *                                                                          *
- *   EDGESec is free software: you can redistribute it and/or modify it     *
- *   under the terms of the GNU Lesser General Public License as published  *
- *   by the Free Software Foundation, either version 3 of the License, or   *
- *   (at your option) any later version.                                    *
- *                                                                          *
- *   EDGESec is distributed in the hope that it will be useful,             *
- *   but WITHOUT ANY WARRANTY; without even the implied warranty of         *
- *   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the          *
- *   GNU Lesser General Public License for more details.                    *
- *                                                                          *
- *   You should have received a copy of the GNU Lesser General Public       *
- *   License along with EDGESec. If not, see <http://www.gnu.org/licenses/>.*
- ****************************************************************************/
+/**
+ * @file
+ * @author Alexandru Mereacre
+ * @date 2021
+ * @copyright
+ * SPDX-FileCopyrightText: © 2021 NQMCyber Ltd and edgesec contributors
+ * SPDX-License-Identifier: LGPL-3.0-or-later
+ */
 
 /**
  * @file cryptou.h

--- a/src/utils/cryptou.h
+++ b/src/utils/cryptou.h
@@ -5,7 +5,6 @@
  * @copyright
  * SPDX-FileCopyrightText: © 2021 NQMCyber Ltd and edgesec contributors
  * SPDX-License-Identifier: LGPL-3.0-or-later
- *
  * @brief File containing the definition of the cryptographic utilities.
  */
 

--- a/src/utils/ename.h
+++ b/src/utils/ename.h
@@ -6,7 +6,6 @@
  * SPDX-FileCopyrightText: © 2020 NQMCyber Ltd and edgesec contributors
  * SPDX-License-Identifier: LGPL-3.0-or-later
  *
- * @author Alexandru Mereacre
  * @brief error strings from errno.h include file.
  */
 

--- a/src/utils/ename.h
+++ b/src/utils/ename.h
@@ -5,7 +5,6 @@
  * @copyright
  * SPDX-FileCopyrightText: © 2020 NQMCyber Ltd and edgesec contributors
  * SPDX-License-Identifier: LGPL-3.0-or-later
- *
  * @brief error strings from errno.h include file.
  */
 

--- a/src/utils/ename.h
+++ b/src/utils/ename.h
@@ -1,21 +1,11 @@
-/****************************************************************************
- * Copyright (C) 2020 by NQMCyber Ltd                                       *
- *                                                                          *
- * This file is part of EDGESec.                                            *
- *                                                                          *
- *   EDGESec is free software: you can redistribute it and/or modify it     *
- *   under the terms of the GNU Lesser General Public License as published  *
- *   by the Free Software Foundation, either version 3 of the License, or   *
- *   (at your option) any later version.                                    *
- *                                                                          *
- *   EDGESec is distributed in the hope that it will be useful,             *
- *   but WITHOUT ANY WARRANTY; without even the implied warranty of         *
- *   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the          *
- *   GNU Lesser General Public License for more details.                    *
- *                                                                          *
- *   You should have received a copy of the GNU Lesser General Public       *
- *   License along with EDGESec. If not, see <http://www.gnu.org/licenses/>.*
- ****************************************************************************/
+/**
+ * @file
+ * @author Alexandru Mereacre
+ * @date 2020
+ * @copyright
+ * SPDX-FileCopyrightText: © 2020 NQMCyber Ltd and edgesec contributors
+ * SPDX-License-Identifier: LGPL-3.0-or-later
+ */
 
 /**
  * @file ename.h

--- a/src/utils/ename.h
+++ b/src/utils/ename.h
@@ -5,10 +5,7 @@
  * @copyright
  * SPDX-FileCopyrightText: © 2020 NQMCyber Ltd and edgesec contributors
  * SPDX-License-Identifier: LGPL-3.0-or-later
- */
-
-/**
- * @file ename.h
+ *
  * @author Alexandru Mereacre
  * @brief error strings from errno.h include file.
  */

--- a/src/utils/hash.c
+++ b/src/utils/hash.c
@@ -5,10 +5,7 @@
  * @copyright
  * SPDX-FileCopyrightText: © 2021 NQMCyber Ltd and edgesec contributors
  * SPDX-License-Identifier: LGPL-3.0-or-later
- */
-
-/**
- * @file hash.c
+ *
  * @author Alexandru Mereacre
  * @brief File containing the implementation of the hash functions.
  */

--- a/src/utils/hash.c
+++ b/src/utils/hash.c
@@ -6,7 +6,6 @@
  * SPDX-FileCopyrightText: © 2021 NQMCyber Ltd and edgesec contributors
  * SPDX-License-Identifier: LGPL-3.0-or-later
  *
- * @author Alexandru Mereacre
  * @brief File containing the implementation of the hash functions.
  */
 #include <stdio.h>

--- a/src/utils/hash.c
+++ b/src/utils/hash.c
@@ -5,7 +5,6 @@
  * @copyright
  * SPDX-FileCopyrightText: © 2021 NQMCyber Ltd and edgesec contributors
  * SPDX-License-Identifier: LGPL-3.0-or-later
- *
  * @brief File containing the implementation of the hash functions.
  */
 #include <stdio.h>

--- a/src/utils/hash.c
+++ b/src/utils/hash.c
@@ -1,21 +1,11 @@
-/****************************************************************************
- * Copyright (C) 2021 by NQMCyber Ltd                                       *
- *                                                                          *
- * This file is part of EDGESec.                                            *
- *                                                                          *
- *   EDGESec is free software: you can redistribute it and/or modify it     *
- *   under the terms of the GNU Lesser General Public License as published  *
- *   by the Free Software Foundation, either version 3 of the License, or   *
- *   (at your option) any later version.                                    *
- *                                                                          *
- *   EDGESec is distributed in the hope that it will be useful,             *
- *   but WITHOUT ANY WARRANTY; without even the implied warranty of         *
- *   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the          *
- *   GNU Lesser General Public License for more details.                    *
- *                                                                          *
- *   You should have received a copy of the GNU Lesser General Public       *
- *   License along with EDGESec. If not, see <http://www.gnu.org/licenses/>.*
- ****************************************************************************/
+/**
+ * @file
+ * @author Alexandru Mereacre
+ * @date 2021
+ * @copyright
+ * SPDX-FileCopyrightText: © 2021 NQMCyber Ltd and edgesec contributors
+ * SPDX-License-Identifier: LGPL-3.0-or-later
+ */
 
 /**
  * @file hash.c

--- a/src/utils/hash.h
+++ b/src/utils/hash.h
@@ -5,10 +5,7 @@
  * @copyright
  * SPDX-FileCopyrightText: © 2021 NQMCyber Ltd and edgesec contributors
  * SPDX-License-Identifier: LGPL-3.0-or-later
- */
-
-/**
- * @file hash.h
+ *
  * @author Alexandru Mereacre
  * @brief File containing the definition of the hash functions.
  */

--- a/src/utils/hash.h
+++ b/src/utils/hash.h
@@ -5,7 +5,6 @@
  * @copyright
  * SPDX-FileCopyrightText: © 2021 NQMCyber Ltd and edgesec contributors
  * SPDX-License-Identifier: LGPL-3.0-or-later
- *
  * @brief File containing the definition of the hash functions.
  */
 

--- a/src/utils/hash.h
+++ b/src/utils/hash.h
@@ -6,7 +6,6 @@
  * SPDX-FileCopyrightText: © 2021 NQMCyber Ltd and edgesec contributors
  * SPDX-License-Identifier: LGPL-3.0-or-later
  *
- * @author Alexandru Mereacre
  * @brief File containing the definition of the hash functions.
  */
 

--- a/src/utils/hash.h
+++ b/src/utils/hash.h
@@ -1,21 +1,11 @@
-/****************************************************************************
- * Copyright (C) 2021 by NQMCyber Ltd                                       *
- *                                                                          *
- * This file is part of EDGESec.                                            *
- *                                                                          *
- *   EDGESec is free software: you can redistribute it and/or modify it     *
- *   under the terms of the GNU Lesser General Public License as published  *
- *   by the Free Software Foundation, either version 3 of the License, or   *
- *   (at your option) any later version.                                    *
- *                                                                          *
- *   EDGESec is distributed in the hope that it will be useful,             *
- *   but WITHOUT ANY WARRANTY; without even the implied warranty of         *
- *   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the          *
- *   GNU Lesser General Public License for more details.                    *
- *                                                                          *
- *   You should have received a copy of the GNU Lesser General Public       *
- *   License along with EDGESec. If not, see <http://www.gnu.org/licenses/>.*
- ****************************************************************************/
+/**
+ * @file
+ * @author Alexandru Mereacre
+ * @date 2021
+ * @copyright
+ * SPDX-FileCopyrightText: © 2021 NQMCyber Ltd and edgesec contributors
+ * SPDX-License-Identifier: LGPL-3.0-or-later
+ */
 
 /**
  * @file hash.h

--- a/src/utils/hashmap.c
+++ b/src/utils/hashmap.c
@@ -6,7 +6,6 @@
  * SPDX-FileCopyrightText: © 2020 NQMCyber Ltd and edgesec contributors
  * SPDX-License-Identifier: LGPL-3.0-or-later
  *
- * @author Alexandru Mereacre
  * @brief File containing the implementation of the hashmap utilities.
  */
 

--- a/src/utils/hashmap.c
+++ b/src/utils/hashmap.c
@@ -5,10 +5,7 @@
  * @copyright
  * SPDX-FileCopyrightText: © 2020 NQMCyber Ltd and edgesec contributors
  * SPDX-License-Identifier: LGPL-3.0-or-later
- */
-
-/**
- * @file hashmap.c
+ *
  * @author Alexandru Mereacre
  * @brief File containing the implementation of the hashmap utilities.
  */

--- a/src/utils/hashmap.c
+++ b/src/utils/hashmap.c
@@ -1,21 +1,11 @@
-/****************************************************************************
- * Copyright (C) 2020 by NQMCyber Ltd                                       *
- *                                                                          *
- * This file is part of EDGESec.                                            *
- *                                                                          *
- *   EDGESec is free software: you can redistribute it and/or modify it     *
- *   under the terms of the GNU Lesser General Public License as published  *
- *   by the Free Software Foundation, either version 3 of the License, or   *
- *   (at your option) any later version.                                    *
- *                                                                          *
- *   EDGESec is distributed in the hope that it will be useful,             *
- *   but WITHOUT ANY WARRANTY; without even the implied warranty of         *
- *   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the          *
- *   GNU Lesser General Public License for more details.                    *
- *                                                                          *
- *   You should have received a copy of the GNU Lesser General Public       *
- *   License along with EDGESec. If not, see <http://www.gnu.org/licenses/>.*
- ****************************************************************************/
+/**
+ * @file
+ * @author Alexandru Mereacre
+ * @date 2020
+ * @copyright
+ * SPDX-FileCopyrightText: © 2020 NQMCyber Ltd and edgesec contributors
+ * SPDX-License-Identifier: LGPL-3.0-or-later
+ */
 
 /**
  * @file hashmap.c

--- a/src/utils/hashmap.c
+++ b/src/utils/hashmap.c
@@ -5,7 +5,6 @@
  * @copyright
  * SPDX-FileCopyrightText: © 2020 NQMCyber Ltd and edgesec contributors
  * SPDX-License-Identifier: LGPL-3.0-or-later
- *
  * @brief File containing the implementation of the hashmap utilities.
  */
 

--- a/src/utils/hashmap.h
+++ b/src/utils/hashmap.h
@@ -5,7 +5,6 @@
  * @copyright
  * SPDX-FileCopyrightText: © 2020 NQMCyber Ltd and edgesec contributors
  * SPDX-License-Identifier: LGPL-3.0-or-later
- *
  * @brief File containing the definition of the hashmap utilities.
  */
 

--- a/src/utils/hashmap.h
+++ b/src/utils/hashmap.h
@@ -5,10 +5,7 @@
  * @copyright
  * SPDX-FileCopyrightText: © 2020 NQMCyber Ltd and edgesec contributors
  * SPDX-License-Identifier: LGPL-3.0-or-later
- */
-
-/**
- * @file hashmap.h
+ *
  * @author Alexandru Mereacre
  * @brief File containing the definition of the hashmap utilities.
  */

--- a/src/utils/hashmap.h
+++ b/src/utils/hashmap.h
@@ -6,7 +6,6 @@
  * SPDX-FileCopyrightText: © 2020 NQMCyber Ltd and edgesec contributors
  * SPDX-License-Identifier: LGPL-3.0-or-later
  *
- * @author Alexandru Mereacre
  * @brief File containing the definition of the hashmap utilities.
  */
 

--- a/src/utils/hashmap.h
+++ b/src/utils/hashmap.h
@@ -1,21 +1,11 @@
-/****************************************************************************
- * Copyright (C) 2020 by NQMCyber Ltd                                       *
- *                                                                          *
- * This file is part of EDGESec.                                            *
- *                                                                          *
- *   EDGESec is free software: you can redistribute it and/or modify it     *
- *   under the terms of the GNU Lesser General Public License as published  *
- *   by the Free Software Foundation, either version 3 of the License, or   *
- *   (at your option) any later version.                                    *
- *                                                                          *
- *   EDGESec is distributed in the hope that it will be useful,             *
- *   but WITHOUT ANY WARRANTY; without even the implied warranty of         *
- *   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the          *
- *   GNU Lesser General Public License for more details.                    *
- *                                                                          *
- *   You should have received a copy of the GNU Lesser General Public       *
- *   License along with EDGESec. If not, see <http://www.gnu.org/licenses/>.*
- ****************************************************************************/
+/**
+ * @file
+ * @author Alexandru Mereacre
+ * @date 2020
+ * @copyright
+ * SPDX-FileCopyrightText: © 2020 NQMCyber Ltd and edgesec contributors
+ * SPDX-License-Identifier: LGPL-3.0-or-later
+ */
 
 /**
  * @file hashmap.h

--- a/src/utils/iface.c
+++ b/src/utils/iface.c
@@ -5,10 +5,7 @@
  * @copyright
  * SPDX-FileCopyrightText: © 2020 NQMCyber Ltd and edgesec contributors
  * SPDX-License-Identifier: LGPL-3.0-or-later
- */
-
-/**
- * @file iface.c
+ *
  * @author Alexandru Mereacre
  * @brief File containing the implementation of the network interface utilities.
  */

--- a/src/utils/iface.c
+++ b/src/utils/iface.c
@@ -1,21 +1,11 @@
-/****************************************************************************
- * Copyright (C) 2020 by NQMCyber Ltd                                       *
- *                                                                          *
- * This file is part of EDGESec.                                            *
- *                                                                          *
- *   EDGESec is free software: you can redistribute it and/or modify it     *
- *   under the terms of the GNU Lesser General Public License as published  *
- *   by the Free Software Foundation, either version 3 of the License, or   *
- *   (at your option) any later version.                                    *
- *                                                                          *
- *   EDGESec is distributed in the hope that it will be useful,             *
- *   but WITHOUT ANY WARRANTY; without even the implied warranty of         *
- *   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the          *
- *   GNU Lesser General Public License for more details.                    *
- *                                                                          *
- *   You should have received a copy of the GNU Lesser General Public       *
- *   License along with EDGESec. If not, see <http://www.gnu.org/licenses/>.*
- ****************************************************************************/
+/**
+ * @file
+ * @author Alexandru Mereacre
+ * @date 2020
+ * @copyright
+ * SPDX-FileCopyrightText: © 2020 NQMCyber Ltd and edgesec contributors
+ * SPDX-License-Identifier: LGPL-3.0-or-later
+ */
 
 /**
  * @file iface.c

--- a/src/utils/iface.c
+++ b/src/utils/iface.c
@@ -6,7 +6,6 @@
  * SPDX-FileCopyrightText: © 2020 NQMCyber Ltd and edgesec contributors
  * SPDX-License-Identifier: LGPL-3.0-or-later
  *
- * @author Alexandru Mereacre
  * @brief File containing the implementation of the network interface utilities.
  */
 

--- a/src/utils/iface.c
+++ b/src/utils/iface.c
@@ -5,7 +5,6 @@
  * @copyright
  * SPDX-FileCopyrightText: © 2020 NQMCyber Ltd and edgesec contributors
  * SPDX-License-Identifier: LGPL-3.0-or-later
- *
  * @brief File containing the implementation of the network interface utilities.
  */
 

--- a/src/utils/iface.h
+++ b/src/utils/iface.h
@@ -1,21 +1,11 @@
-/****************************************************************************
- * Copyright (C) 2020 by NQMCyber Ltd                                       *
- *                                                                          *
- * This file is part of EDGESec.                                            *
- *                                                                          *
- *   EDGESec is free software: you can redistribute it and/or modify it     *
- *   under the terms of the GNU Lesser General Public License as published  *
- *   by the Free Software Foundation, either version 3 of the License, or   *
- *   (at your option) any later version.                                    *
- *                                                                          *
- *   EDGESec is distributed in the hope that it will be useful,             *
- *   but WITHOUT ANY WARRANTY; without even the implied warranty of         *
- *   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the          *
- *   GNU Lesser General Public License for more details.                    *
- *                                                                          *
- *   You should have received a copy of the GNU Lesser General Public       *
- *   License along with EDGESec. If not, see <http://www.gnu.org/licenses/>.*
- ****************************************************************************/
+/**
+ * @file
+ * @author Alexandru Mereacre
+ * @date 2020
+ * @copyright
+ * SPDX-FileCopyrightText: © 2020 NQMCyber Ltd and edgesec contributors
+ * SPDX-License-Identifier: LGPL-3.0-or-later
+ */
 
 /**
  * @file iface.h

--- a/src/utils/iface.h
+++ b/src/utils/iface.h
@@ -5,10 +5,7 @@
  * @copyright
  * SPDX-FileCopyrightText: © 2020 NQMCyber Ltd and edgesec contributors
  * SPDX-License-Identifier: LGPL-3.0-or-later
- */
-
-/**
- * @file iface.h
+ *
  * @author Alexandru Mereacre
  * @brief File containing the definition of the network interface utilities.
  */

--- a/src/utils/iface.h
+++ b/src/utils/iface.h
@@ -6,7 +6,6 @@
  * SPDX-FileCopyrightText: © 2020 NQMCyber Ltd and edgesec contributors
  * SPDX-License-Identifier: LGPL-3.0-or-later
  *
- * @author Alexandru Mereacre
  * @brief File containing the definition of the network interface utilities.
  */
 

--- a/src/utils/iface.h
+++ b/src/utils/iface.h
@@ -5,7 +5,6 @@
  * @copyright
  * SPDX-FileCopyrightText: © 2020 NQMCyber Ltd and edgesec contributors
  * SPDX-License-Identifier: LGPL-3.0-or-later
- *
  * @brief File containing the definition of the network interface utilities.
  */
 

--- a/src/utils/iface_mapper.c
+++ b/src/utils/iface_mapper.c
@@ -5,10 +5,7 @@
  * @copyright
  * SPDX-FileCopyrightText: © 2022 NQMCyber Ltd and edgesec contributors
  * SPDX-License-Identifier: LGPL-3.0-or-later
- */
-
-/**
- * @file iface_mapper.c
+ *
  * @author Alexandru Mereacre
  * @brief File containing the implementation of the interface mapper utilities.
  */

--- a/src/utils/iface_mapper.c
+++ b/src/utils/iface_mapper.c
@@ -6,7 +6,6 @@
  * SPDX-FileCopyrightText: © 2022 NQMCyber Ltd and edgesec contributors
  * SPDX-License-Identifier: LGPL-3.0-or-later
  *
- * @author Alexandru Mereacre
  * @brief File containing the implementation of the interface mapper utilities.
  */
 

--- a/src/utils/iface_mapper.c
+++ b/src/utils/iface_mapper.c
@@ -5,7 +5,6 @@
  * @copyright
  * SPDX-FileCopyrightText: © 2022 NQMCyber Ltd and edgesec contributors
  * SPDX-License-Identifier: LGPL-3.0-or-later
- *
  * @brief File containing the implementation of the interface mapper utilities.
  */
 

--- a/src/utils/iface_mapper.c
+++ b/src/utils/iface_mapper.c
@@ -1,21 +1,11 @@
-/****************************************************************************
- * Copyright (C) 2022 by NQMCyber Ltd                                       *
- *                                                                          *
- * This file is part of EDGESec.                                            *
- *                                                                          *
- *   EDGESec is free software: you can redistribute it and/or modify it     *
- *   under the terms of the GNU Lesser General Public License as published  *
- *   by the Free Software Foundation, either version 3 of the License, or   *
- *   (at your option) any later version.                                    *
- *                                                                          *
- *   EDGESec is distributed in the hope that it will be useful,             *
- *   but WITHOUT ANY WARRANTY; without even the implied warranty of         *
- *   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the          *
- *   GNU Lesser General Public License for more details.                    *
- *                                                                          *
- *   You should have received a copy of the GNU Lesser General Public       *
- *   License along with EDGESec. If not, see <http://www.gnu.org/licenses/>.*
- ****************************************************************************/
+/**
+ * @file
+ * @author Alexandru Mereacre
+ * @date 2022
+ * @copyright
+ * SPDX-FileCopyrightText: © 2022 NQMCyber Ltd and edgesec contributors
+ * SPDX-License-Identifier: LGPL-3.0-or-later
+ */
 
 /**
  * @file iface_mapper.c

--- a/src/utils/iface_mapper.h
+++ b/src/utils/iface_mapper.h
@@ -1,21 +1,11 @@
-/****************************************************************************
- * Copyright (C) 2022 by NQMCyber Ltd                                       *
- *                                                                          *
- * This file is part of EDGESec.                                            *
- *                                                                          *
- *   EDGESec is free software: you can redistribute it and/or modify it     *
- *   under the terms of the GNU Lesser General Public License as published  *
- *   by the Free Software Foundation, either version 3 of the License, or   *
- *   (at your option) any later version.                                    *
- *                                                                          *
- *   EDGESec is distributed in the hope that it will be useful,             *
- *   but WITHOUT ANY WARRANTY; without even the implied warranty of         *
- *   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the          *
- *   GNU Lesser General Public License for more details.                    *
- *                                                                          *
- *   You should have received a copy of the GNU Lesser General Public       *
- *   License along with EDGESec. If not, see <http://www.gnu.org/licenses/>.*
- ****************************************************************************/
+/**
+ * @file
+ * @author Alexandru Mereacre
+ * @date 2022
+ * @copyright
+ * SPDX-FileCopyrightText: © 2022 NQMCyber Ltd and edgesec contributors
+ * SPDX-License-Identifier: LGPL-3.0-or-later
+ */
 
 /**
  * @file iface_mapper.h

--- a/src/utils/iface_mapper.h
+++ b/src/utils/iface_mapper.h
@@ -6,7 +6,6 @@
  * SPDX-FileCopyrightText: © 2022 NQMCyber Ltd and edgesec contributors
  * SPDX-License-Identifier: LGPL-3.0-or-later
  *
- * @author Alexandru Mereacre
  * @brief File containing the definition of the interface mapper utilities.
  */
 

--- a/src/utils/iface_mapper.h
+++ b/src/utils/iface_mapper.h
@@ -5,10 +5,7 @@
  * @copyright
  * SPDX-FileCopyrightText: © 2022 NQMCyber Ltd and edgesec contributors
  * SPDX-License-Identifier: LGPL-3.0-or-later
- */
-
-/**
- * @file iface_mapper.h
+ *
  * @author Alexandru Mereacre
  * @brief File containing the definition of the interface mapper utilities.
  */

--- a/src/utils/iface_mapper.h
+++ b/src/utils/iface_mapper.h
@@ -5,7 +5,6 @@
  * @copyright
  * SPDX-FileCopyrightText: © 2022 NQMCyber Ltd and edgesec contributors
  * SPDX-License-Identifier: LGPL-3.0-or-later
- *
  * @brief File containing the definition of the interface mapper utilities.
  */
 

--- a/src/utils/ifaceu.c
+++ b/src/utils/ifaceu.c
@@ -5,10 +5,7 @@
  * @copyright
  * SPDX-FileCopyrightText: © 2020 NQMCyber Ltd and edgesec contributors
  * SPDX-License-Identifier: LGPL-3.0-or-later
- */
-
-/**
- * @file ifaceu.c
+ *
  * @author Alexandru Mereacre
  * @brief File containing the implementation of the network interface utilities.
  */

--- a/src/utils/ifaceu.c
+++ b/src/utils/ifaceu.c
@@ -6,7 +6,6 @@
  * SPDX-FileCopyrightText: © 2020 NQMCyber Ltd and edgesec contributors
  * SPDX-License-Identifier: LGPL-3.0-or-later
  *
- * @author Alexandru Mereacre
  * @brief File containing the implementation of the network interface utilities.
  */
 

--- a/src/utils/ifaceu.c
+++ b/src/utils/ifaceu.c
@@ -1,21 +1,11 @@
-/****************************************************************************
- * Copyright (C) 2020 by NQMCyber Ltd                                       *
- *                                                                          *
- * This file is part of EDGESec.                                            *
- *                                                                          *
- *   EDGESec is free software: you can redistribute it and/or modify it     *
- *   under the terms of the GNU Lesser General Public License as published  *
- *   by the Free Software Foundation, either version 3 of the License, or   *
- *   (at your option) any later version.                                    *
- *                                                                          *
- *   EDGESec is distributed in the hope that it will be useful,             *
- *   but WITHOUT ANY WARRANTY; without even the implied warranty of         *
- *   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the          *
- *   GNU Lesser General Public License for more details.                    *
- *                                                                          *
- *   You should have received a copy of the GNU Lesser General Public       *
- *   License along with EDGESec. If not, see <http://www.gnu.org/licenses/>.*
- ****************************************************************************/
+/**
+ * @file
+ * @author Alexandru Mereacre
+ * @date 2020
+ * @copyright
+ * SPDX-FileCopyrightText: © 2020 NQMCyber Ltd and edgesec contributors
+ * SPDX-License-Identifier: LGPL-3.0-or-later
+ */
 
 /**
  * @file ifaceu.c

--- a/src/utils/ifaceu.c
+++ b/src/utils/ifaceu.c
@@ -5,7 +5,6 @@
  * @copyright
  * SPDX-FileCopyrightText: © 2020 NQMCyber Ltd and edgesec contributors
  * SPDX-License-Identifier: LGPL-3.0-or-later
- *
  * @brief File containing the implementation of the network interface utilities.
  */
 

--- a/src/utils/ifaceu.h
+++ b/src/utils/ifaceu.h
@@ -5,10 +5,7 @@
  * @copyright
  * SPDX-FileCopyrightText: © 2020 NQMCyber Ltd and edgesec contributors
  * SPDX-License-Identifier: LGPL-3.0-or-later
- */
-
-/**
- * @file ifaceu.h
+ *
  * @author Alexandru Mereacre
  * @brief File containing the definition of the network interface utilities.
  */

--- a/src/utils/ifaceu.h
+++ b/src/utils/ifaceu.h
@@ -1,21 +1,11 @@
-/****************************************************************************
- * Copyright (C) 2020 by NQMCyber Ltd                                       *
- *                                                                          *
- * This file is part of EDGESec.                                            *
- *                                                                          *
- *   EDGESec is free software: you can redistribute it and/or modify it     *
- *   under the terms of the GNU Lesser General Public License as published  *
- *   by the Free Software Foundation, either version 3 of the License, or   *
- *   (at your option) any later version.                                    *
- *                                                                          *
- *   EDGESec is distributed in the hope that it will be useful,             *
- *   but WITHOUT ANY WARRANTY; without even the implied warranty of         *
- *   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the          *
- *   GNU Lesser General Public License for more details.                    *
- *                                                                          *
- *   You should have received a copy of the GNU Lesser General Public       *
- *   License along with EDGESec. If not, see <http://www.gnu.org/licenses/>.*
- ****************************************************************************/
+/**
+ * @file
+ * @author Alexandru Mereacre
+ * @date 2020
+ * @copyright
+ * SPDX-FileCopyrightText: © 2020 NQMCyber Ltd and edgesec contributors
+ * SPDX-License-Identifier: LGPL-3.0-or-later
+ */
 
 /**
  * @file ifaceu.h

--- a/src/utils/ifaceu.h
+++ b/src/utils/ifaceu.h
@@ -6,7 +6,6 @@
  * SPDX-FileCopyrightText: © 2020 NQMCyber Ltd and edgesec contributors
  * SPDX-License-Identifier: LGPL-3.0-or-later
  *
- * @author Alexandru Mereacre
  * @brief File containing the definition of the network interface utilities.
  */
 

--- a/src/utils/ifaceu.h
+++ b/src/utils/ifaceu.h
@@ -5,7 +5,6 @@
  * @copyright
  * SPDX-FileCopyrightText: © 2020 NQMCyber Ltd and edgesec contributors
  * SPDX-License-Identifier: LGPL-3.0-or-later
- *
  * @brief File containing the definition of the network interface utilities.
  */
 

--- a/src/utils/ipgen.c
+++ b/src/utils/ipgen.c
@@ -6,7 +6,6 @@
  * SPDX-FileCopyrightText: © 2022 NQMCyber Ltd and edgesec contributors
  * SPDX-License-Identifier: LGPL-3.0-or-later
  *
- * @author Alexandru Mereacre
  * @brief File containing the definition of the ip generic interface utilities.
  */
 

--- a/src/utils/ipgen.c
+++ b/src/utils/ipgen.c
@@ -5,7 +5,6 @@
  * @copyright
  * SPDX-FileCopyrightText: © 2022 NQMCyber Ltd and edgesec contributors
  * SPDX-License-Identifier: LGPL-3.0-or-later
- *
  * @brief File containing the definition of the ip generic interface utilities.
  */
 

--- a/src/utils/ipgen.c
+++ b/src/utils/ipgen.c
@@ -5,10 +5,7 @@
  * @copyright
  * SPDX-FileCopyrightText: © 2022 NQMCyber Ltd and edgesec contributors
  * SPDX-License-Identifier: LGPL-3.0-or-later
- */
-
-/**
- * @file ipgen.h
+ *
  * @author Alexandru Mereacre
  * @brief File containing the definition of the ip generic interface utilities.
  */

--- a/src/utils/ipgen.c
+++ b/src/utils/ipgen.c
@@ -1,21 +1,11 @@
-/****************************************************************************
- * Copyright (C) 2022 by NQMCyber Ltd                                       *
- *                                                                          *
- * This file is part of EDGESec.                                            *
- *                                                                          *
- *   EDGESec is free software: you can redistribute it and/or modify it     *
- *   under the terms of the GNU Lesser General Public License as published  *
- *   by the Free Software Foundation, either version 3 of the License, or   *
- *   (at your option) any later version.                                    *
- *                                                                          *
- *   EDGESec is distributed in the hope that it will be useful,             *
- *   but WITHOUT ANY WARRANTY; without even the implied warranty of         *
- *   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the          *
- *   GNU Lesser General Public License for more details.                    *
- *                                                                          *
- *   You should have received a copy of the GNU Lesser General Public       *
- *   License along with EDGESec. If not, see <http://www.gnu.org/licenses/>.*
- ****************************************************************************/
+/**
+ * @file
+ * @author Alexandru Mereacre
+ * @date 2022
+ * @copyright
+ * SPDX-FileCopyrightText: © 2022 NQMCyber Ltd and edgesec contributors
+ * SPDX-License-Identifier: LGPL-3.0-or-later
+ */
 
 /**
  * @file ipgen.h

--- a/src/utils/ipgen.h
+++ b/src/utils/ipgen.h
@@ -6,7 +6,6 @@
  * SPDX-FileCopyrightText: © 2022 NQMCyber Ltd and edgesec contributors
  * SPDX-License-Identifier: LGPL-3.0-or-later
  *
- * @author Alexandru Mereacre
  * @brief File containing the definition of the ip generic interface utilities.
  */
 

--- a/src/utils/ipgen.h
+++ b/src/utils/ipgen.h
@@ -5,7 +5,6 @@
  * @copyright
  * SPDX-FileCopyrightText: © 2022 NQMCyber Ltd and edgesec contributors
  * SPDX-License-Identifier: LGPL-3.0-or-later
- *
  * @brief File containing the definition of the ip generic interface utilities.
  */
 

--- a/src/utils/ipgen.h
+++ b/src/utils/ipgen.h
@@ -5,10 +5,7 @@
  * @copyright
  * SPDX-FileCopyrightText: © 2022 NQMCyber Ltd and edgesec contributors
  * SPDX-License-Identifier: LGPL-3.0-or-later
- */
-
-/**
- * @file ipgen.h
+ *
  * @author Alexandru Mereacre
  * @brief File containing the definition of the ip generic interface utilities.
  */

--- a/src/utils/ipgen.h
+++ b/src/utils/ipgen.h
@@ -1,21 +1,11 @@
-/****************************************************************************
- * Copyright (C) 2022 by NQMCyber Ltd                                       *
- *                                                                          *
- * This file is part of EDGESec.                                            *
- *                                                                          *
- *   EDGESec is free software: you can redistribute it and/or modify it     *
- *   under the terms of the GNU Lesser General Public License as published  *
- *   by the Free Software Foundation, either version 3 of the License, or   *
- *   (at your option) any later version.                                    *
- *                                                                          *
- *   EDGESec is distributed in the hope that it will be useful,             *
- *   but WITHOUT ANY WARRANTY; without even the implied warranty of         *
- *   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the          *
- *   GNU Lesser General Public License for more details.                    *
- *                                                                          *
- *   You should have received a copy of the GNU Lesser General Public       *
- *   License along with EDGESec. If not, see <http://www.gnu.org/licenses/>.*
- ****************************************************************************/
+/**
+ * @file
+ * @author Alexandru Mereacre
+ * @date 2022
+ * @copyright
+ * SPDX-FileCopyrightText: © 2022 NQMCyber Ltd and edgesec contributors
+ * SPDX-License-Identifier: LGPL-3.0-or-later
+ */
 
 /**
  * @file ipgen.h

--- a/src/utils/iptables.c
+++ b/src/utils/iptables.c
@@ -5,7 +5,6 @@
  * @copyright
  * SPDX-FileCopyrightText: © 2020 NQMCyber Ltd and edgesec contributors
  * SPDX-License-Identifier: LGPL-3.0-or-later
- *
  * @brief File containing the implementation of the IP tables utilities.
  */
 

--- a/src/utils/iptables.c
+++ b/src/utils/iptables.c
@@ -6,7 +6,6 @@
  * SPDX-FileCopyrightText: © 2020 NQMCyber Ltd and edgesec contributors
  * SPDX-License-Identifier: LGPL-3.0-or-later
  *
- * @author Alexandru Mereacre
  * @brief File containing the implementation of the IP tables utilities.
  */
 

--- a/src/utils/iptables.c
+++ b/src/utils/iptables.c
@@ -1,21 +1,11 @@
-/****************************************************************************
- * Copyright (C) 2020 by NQMCyber Ltd                                       *
- *                                                                          *
- * This file is part of EDGESec.                                            *
- *                                                                          *
- *   EDGESec is free software: you can redistribute it and/or modify it     *
- *   under the terms of the GNU Lesser General Public License as published  *
- *   by the Free Software Foundation, either version 3 of the License, or   *
- *   (at your option) any later version.                                    *
- *                                                                          *
- *   EDGESec is distributed in the hope that it will be useful,             *
- *   but WITHOUT ANY WARRANTY; without even the implied warranty of         *
- *   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the          *
- *   GNU Lesser General Public License for more details.                    *
- *                                                                          *
- *   You should have received a copy of the GNU Lesser General Public       *
- *   License along with EDGESec. If not, see <http://www.gnu.org/licenses/>.*
- ****************************************************************************/
+/**
+ * @file
+ * @author Alexandru Mereacre
+ * @date 2020
+ * @copyright
+ * SPDX-FileCopyrightText: © 2020 NQMCyber Ltd and edgesec contributors
+ * SPDX-License-Identifier: LGPL-3.0-or-later
+ */
 
 /**
  * @file iptables.c

--- a/src/utils/iptables.c
+++ b/src/utils/iptables.c
@@ -5,10 +5,7 @@
  * @copyright
  * SPDX-FileCopyrightText: © 2020 NQMCyber Ltd and edgesec contributors
  * SPDX-License-Identifier: LGPL-3.0-or-later
- */
-
-/**
- * @file iptables.c
+ *
  * @author Alexandru Mereacre
  * @brief File containing the implementation of the IP tables utilities.
  */

--- a/src/utils/iptables.h
+++ b/src/utils/iptables.h
@@ -5,7 +5,6 @@
  * @copyright
  * SPDX-FileCopyrightText: © 2020 NQMCyber Ltd and edgesec contributors
  * SPDX-License-Identifier: LGPL-3.0-or-later
- *
  * @brief File containing the definition of the IP tables utilities.
  */
 

--- a/src/utils/iptables.h
+++ b/src/utils/iptables.h
@@ -5,10 +5,7 @@
  * @copyright
  * SPDX-FileCopyrightText: © 2020 NQMCyber Ltd and edgesec contributors
  * SPDX-License-Identifier: LGPL-3.0-or-later
- */
-
-/**
- * @file iptables.h
+ *
  * @author Alexandru Mereacre
  * @brief File containing the definition of the IP tables utilities.
  */

--- a/src/utils/iptables.h
+++ b/src/utils/iptables.h
@@ -6,7 +6,6 @@
  * SPDX-FileCopyrightText: © 2020 NQMCyber Ltd and edgesec contributors
  * SPDX-License-Identifier: LGPL-3.0-or-later
  *
- * @author Alexandru Mereacre
  * @brief File containing the definition of the IP tables utilities.
  */
 

--- a/src/utils/iptables.h
+++ b/src/utils/iptables.h
@@ -1,21 +1,11 @@
-/****************************************************************************
- * Copyright (C) 2020 by NQMCyber Ltd                                       *
- *                                                                          *
- * This file is part of EDGESec.                                            *
- *                                                                          *
- *   EDGESec is free software: you can redistribute it and/or modify it     *
- *   under the terms of the GNU Lesser General Public License as published  *
- *   by the Free Software Foundation, either version 3 of the License, or   *
- *   (at your option) any later version.                                    *
- *                                                                          *
- *   EDGESec is distributed in the hope that it will be useful,             *
- *   but WITHOUT ANY WARRANTY; without even the implied warranty of         *
- *   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the          *
- *   GNU Lesser General Public License for more details.                    *
- *                                                                          *
- *   You should have received a copy of the GNU Lesser General Public       *
- *   License along with EDGESec. If not, see <http://www.gnu.org/licenses/>.*
- ****************************************************************************/
+/**
+ * @file
+ * @author Alexandru Mereacre
+ * @date 2020
+ * @copyright
+ * SPDX-FileCopyrightText: © 2020 NQMCyber Ltd and edgesec contributors
+ * SPDX-License-Identifier: LGPL-3.0-or-later
+ */
 
 /**
  * @file iptables.h

--- a/src/utils/net.c
+++ b/src/utils/net.c
@@ -1,21 +1,11 @@
-/****************************************************************************
- * Copyright (C) 2022 by NQMCyber Ltd                                       *
- *                                                                          *
- * This file is part of EDGESec.                                            *
- *                                                                          *
- *   EDGESec is free software: you can redistribute it and/or modify it     *
- *   under the terms of the GNU Lesser General Public License as published  *
- *   by the Free Software Foundation, either version 3 of the License, or   *
- *   (at your option) any later version.                                    *
- *                                                                          *
- *   EDGESec is distributed in the hope that it will be useful,             *
- *   but WITHOUT ANY WARRANTY; without even the implied warranty of         *
- *   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the          *
- *   GNU Lesser General Public License for more details.                    *
- *                                                                          *
- *   You should have received a copy of the GNU Lesser General Public       *
- *   License along with EDGESec. If not, see <http://www.gnu.org/licenses/>.*
- ****************************************************************************/
+/**
+ * @file
+ * @author Alexandru Mereacre
+ * @date 2022
+ * @copyright
+ * SPDX-FileCopyrightText: © 2022 NQMCyber Ltd and edgesec contributors
+ * SPDX-License-Identifier: LGPL-3.0-or-later
+ */
 
 /**
  * @file net.c

--- a/src/utils/net.c
+++ b/src/utils/net.c
@@ -5,10 +5,7 @@
  * @copyright
  * SPDX-FileCopyrightText: © 2022 NQMCyber Ltd and edgesec contributors
  * SPDX-License-Identifier: LGPL-3.0-or-later
- */
-
-/**
- * @file net.c
+ *
  * @author Alexandru Mereacre
  * @brief File containing the implementation of the network utilities.
  */

--- a/src/utils/net.c
+++ b/src/utils/net.c
@@ -6,7 +6,6 @@
  * SPDX-FileCopyrightText: © 2022 NQMCyber Ltd and edgesec contributors
  * SPDX-License-Identifier: LGPL-3.0-or-later
  *
- * @author Alexandru Mereacre
  * @brief File containing the implementation of the network utilities.
  */
 

--- a/src/utils/net.c
+++ b/src/utils/net.c
@@ -5,7 +5,6 @@
  * @copyright
  * SPDX-FileCopyrightText: © 2022 NQMCyber Ltd and edgesec contributors
  * SPDX-License-Identifier: LGPL-3.0-or-later
- *
  * @brief File containing the implementation of the network utilities.
  */
 

--- a/src/utils/net.h
+++ b/src/utils/net.h
@@ -6,7 +6,6 @@
  * SPDX-FileCopyrightText: © 2022 NQMCyber Ltd and edgesec contributors
  * SPDX-License-Identifier: LGPL-3.0-or-later
  *
- * @author Alexandru Mereacre
  * @brief File containing the definition of the network utilities.
  */
 

--- a/src/utils/net.h
+++ b/src/utils/net.h
@@ -5,7 +5,6 @@
  * @copyright
  * SPDX-FileCopyrightText: © 2022 NQMCyber Ltd and edgesec contributors
  * SPDX-License-Identifier: LGPL-3.0-or-later
- *
  * @brief File containing the definition of the network utilities.
  */
 

--- a/src/utils/net.h
+++ b/src/utils/net.h
@@ -5,10 +5,7 @@
  * @copyright
  * SPDX-FileCopyrightText: © 2022 NQMCyber Ltd and edgesec contributors
  * SPDX-License-Identifier: LGPL-3.0-or-later
- */
-
-/**
- * @file net.h
+ *
  * @author Alexandru Mereacre
  * @brief File containing the definition of the network utilities.
  */

--- a/src/utils/net.h
+++ b/src/utils/net.h
@@ -1,21 +1,11 @@
-/****************************************************************************
- * Copyright (C) 2022 by NQMCyber Ltd                                       *
- *                                                                          *
- * This file is part of EDGESec.                                            *
- *                                                                          *
- *   EDGESec is free software: you can redistribute it and/or modify it     *
- *   under the terms of the GNU Lesser General Public License as published  *
- *   by the Free Software Foundation, either version 3 of the License, or   *
- *   (at your option) any later version.                                    *
- *                                                                          *
- *   EDGESec is distributed in the hope that it will be useful,             *
- *   but WITHOUT ANY WARRANTY; without even the implied warranty of         *
- *   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the          *
- *   GNU Lesser General Public License for more details.                    *
- *                                                                          *
- *   You should have received a copy of the GNU Lesser General Public       *
- *   License along with EDGESec. If not, see <http://www.gnu.org/licenses/>.*
- ****************************************************************************/
+/**
+ * @file
+ * @author Alexandru Mereacre
+ * @date 2022
+ * @copyright
+ * SPDX-FileCopyrightText: © 2022 NQMCyber Ltd and edgesec contributors
+ * SPDX-License-Identifier: LGPL-3.0-or-later
+ */
 
 /**
  * @file net.h

--- a/src/utils/nl.c
+++ b/src/utils/nl.c
@@ -6,7 +6,6 @@
  * SPDX-FileCopyrightText: © 2022 NQMCyber Ltd and edgesec contributors
  * SPDX-License-Identifier: LGPL-3.0-or-later
  *
- * @author Alexandru Mereacre
  * @brief File containing the implementation of the netlink utilities.
  */
 

--- a/src/utils/nl.c
+++ b/src/utils/nl.c
@@ -5,10 +5,7 @@
  * @copyright
  * SPDX-FileCopyrightText: © 2022 NQMCyber Ltd and edgesec contributors
  * SPDX-License-Identifier: LGPL-3.0-or-later
- */
-
-/**
- * @file nl.c
+ *
  * @author Alexandru Mereacre
  * @brief File containing the implementation of the netlink utilities.
  */

--- a/src/utils/nl.c
+++ b/src/utils/nl.c
@@ -1,21 +1,11 @@
-/****************************************************************************
- * Copyright (C) 2022 by NQMCyber Ltd                                       *
- *                                                                          *
- * This file is part of EDGESec.                                            *
- *                                                                          *
- *   EDGESec is free software: you can redistribute it and/or modify it     *
- *   under the terms of the GNU Lesser General Public License as published  *
- *   by the Free Software Foundation, either version 3 of the License, or   *
- *   (at your option) any later version.                                    *
- *                                                                          *
- *   EDGESec is distributed in the hope that it will be useful,             *
- *   but WITHOUT ANY WARRANTY; without even the implied warranty of         *
- *   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the          *
- *   GNU Lesser General Public License for more details.                    *
- *                                                                          *
- *   You should have received a copy of the GNU Lesser General Public       *
- *   License along with EDGESec. If not, see <http://www.gnu.org/licenses/>.*
- ****************************************************************************/
+/**
+ * @file
+ * @author Alexandru Mereacre
+ * @date 2022
+ * @copyright
+ * SPDX-FileCopyrightText: © 2022 NQMCyber Ltd and edgesec contributors
+ * SPDX-License-Identifier: LGPL-3.0-or-later
+ */
 
 /**
  * @file nl.c

--- a/src/utils/nl.c
+++ b/src/utils/nl.c
@@ -5,7 +5,6 @@
  * @copyright
  * SPDX-FileCopyrightText: © 2022 NQMCyber Ltd and edgesec contributors
  * SPDX-License-Identifier: LGPL-3.0-or-later
- *
  * @brief File containing the implementation of the netlink utilities.
  */
 

--- a/src/utils/nl.h
+++ b/src/utils/nl.h
@@ -6,7 +6,6 @@
  * SPDX-FileCopyrightText: © 2022 NQMCyber Ltd and edgesec contributors
  * SPDX-License-Identifier: LGPL-3.0-or-later
  *
- * @author Alexandru Mereacre
  * @brief File containing the definition of the netlink utilities.
  */
 

--- a/src/utils/nl.h
+++ b/src/utils/nl.h
@@ -5,7 +5,6 @@
  * @copyright
  * SPDX-FileCopyrightText: © 2022 NQMCyber Ltd and edgesec contributors
  * SPDX-License-Identifier: LGPL-3.0-or-later
- *
  * @brief File containing the definition of the netlink utilities.
  */
 

--- a/src/utils/nl.h
+++ b/src/utils/nl.h
@@ -5,10 +5,7 @@
  * @copyright
  * SPDX-FileCopyrightText: © 2022 NQMCyber Ltd and edgesec contributors
  * SPDX-License-Identifier: LGPL-3.0-or-later
- */
-
-/**
- * @file nl.h
+ *
  * @author Alexandru Mereacre
  * @brief File containing the definition of the netlink utilities.
  */

--- a/src/utils/nl.h
+++ b/src/utils/nl.h
@@ -1,21 +1,11 @@
-/****************************************************************************
- * Copyright (C) 2022 by NQMCyber Ltd                                       *
- *                                                                          *
- * This file is part of EDGESec.                                            *
- *                                                                          *
- *   EDGESec is free software: you can redistribute it and/or modify it     *
- *   under the terms of the GNU Lesser General Public License as published  *
- *   by the Free Software Foundation, either version 3 of the License, or   *
- *   (at your option) any later version.                                    *
- *                                                                          *
- *   EDGESec is distributed in the hope that it will be useful,             *
- *   but WITHOUT ANY WARRANTY; without even the implied warranty of         *
- *   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the          *
- *   GNU Lesser General Public License for more details.                    *
- *                                                                          *
- *   You should have received a copy of the GNU Lesser General Public       *
- *   License along with EDGESec. If not, see <http://www.gnu.org/licenses/>.*
- ****************************************************************************/
+/**
+ * @file
+ * @author Alexandru Mereacre
+ * @date 2022
+ * @copyright
+ * SPDX-FileCopyrightText: © 2022 NQMCyber Ltd and edgesec contributors
+ * SPDX-License-Identifier: LGPL-3.0-or-later
+ */
 
 /**
  * @file nl.h

--- a/src/utils/os.h
+++ b/src/utils/os.h
@@ -5,7 +5,6 @@
  * @copyright
  * SPDX-FileCopyrightText: © 2020 NQMCyber Ltd and edgesec contributors
  * SPDX-License-Identifier: LGPL-3.0-or-later
- *
  * @brief File containing the definition of the os functionalities.
  */
 

--- a/src/utils/os.h
+++ b/src/utils/os.h
@@ -1,21 +1,11 @@
-/****************************************************************************
- * Copyright (C) 2020 by NQMCyber Ltd                                       *
- *                                                                          *
- * This file is part of EDGESec.                                            *
- *                                                                          *
- *   EDGESec is free software: you can redistribute it and/or modify it     *
- *   under the terms of the GNU Lesser General Public License as published  *
- *   by the Free Software Foundation, either version 3 of the License, or   *
- *   (at your option) any later version.                                    *
- *                                                                          *
- *   EDGESec is distributed in the hope that it will be useful,             *
- *   but WITHOUT ANY WARRANTY; without even the implied warranty of         *
- *   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the          *
- *   GNU Lesser General Public License for more details.                    *
- *                                                                          *
- *   You should have received a copy of the GNU Lesser General Public       *
- *   License along with EDGESec. If not, see <http://www.gnu.org/licenses/>.*
- ****************************************************************************/
+/**
+ * @file
+ * @author Alexandru Mereacre
+ * @date 2020
+ * @copyright
+ * SPDX-FileCopyrightText: © 2020 NQMCyber Ltd and edgesec contributors
+ * SPDX-License-Identifier: LGPL-3.0-or-later
+ */
 
 /**
  * @file os.h

--- a/src/utils/os.h
+++ b/src/utils/os.h
@@ -5,10 +5,7 @@
  * @copyright
  * SPDX-FileCopyrightText: © 2020 NQMCyber Ltd and edgesec contributors
  * SPDX-License-Identifier: LGPL-3.0-or-later
- */
-
-/**
- * @file os.h
+ *
  * @author Alexandru Mereacre
  * @brief File containing the definition of the os functionalities.
  */

--- a/src/utils/os.h
+++ b/src/utils/os.h
@@ -6,7 +6,6 @@
  * SPDX-FileCopyrightText: © 2020 NQMCyber Ltd and edgesec contributors
  * SPDX-License-Identifier: LGPL-3.0-or-later
  *
- * @author Alexandru Mereacre
  * @brief File containing the definition of the os functionalities.
  */
 

--- a/src/utils/sockctl.c
+++ b/src/utils/sockctl.c
@@ -5,10 +5,7 @@
  * @copyright
  * SPDX-FileCopyrightText: © 2020 NQMCyber Ltd and edgesec contributors
  * SPDX-License-Identifier: LGPL-3.0-or-later
- */
-
-/**
- * @file sockctl.c
+ *
  * @author Alexandru Mereacre
  * @brief File containing the implementation of the socket control utils.
  */

--- a/src/utils/sockctl.c
+++ b/src/utils/sockctl.c
@@ -6,7 +6,6 @@
  * SPDX-FileCopyrightText: © 2020 NQMCyber Ltd and edgesec contributors
  * SPDX-License-Identifier: LGPL-3.0-or-later
  *
- * @author Alexandru Mereacre
  * @brief File containing the implementation of the socket control utils.
  */
 

--- a/src/utils/sockctl.c
+++ b/src/utils/sockctl.c
@@ -5,7 +5,6 @@
  * @copyright
  * SPDX-FileCopyrightText: © 2020 NQMCyber Ltd and edgesec contributors
  * SPDX-License-Identifier: LGPL-3.0-or-later
- *
  * @brief File containing the implementation of the socket control utils.
  */
 

--- a/src/utils/sockctl.c
+++ b/src/utils/sockctl.c
@@ -1,21 +1,11 @@
-/****************************************************************************
- * Copyright (C) 2020 by NQMCyber Ltd                                       *
- *                                                                          *
- * This file is part of EDGESec.                                            *
- *                                                                          *
- *   EDGESec is free software: you can redistribute it and/or modify it     *
- *   under the terms of the GNU Lesser General Public License as published  *
- *   by the Free Software Foundation, either version 3 of the License, or   *
- *   (at your option) any later version.                                    *
- *                                                                          *
- *   EDGESec is distributed in the hope that it will be useful,             *
- *   but WITHOUT ANY WARRANTY; without even the implied warranty of         *
- *   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the          *
- *   GNU Lesser General Public License for more details.                    *
- *                                                                          *
- *   You should have received a copy of the GNU Lesser General Public       *
- *   License along with EDGESec. If not, see <http://www.gnu.org/licenses/>.*
- ****************************************************************************/
+/**
+ * @file
+ * @author Alexandru Mereacre
+ * @date 2020
+ * @copyright
+ * SPDX-FileCopyrightText: © 2020 NQMCyber Ltd and edgesec contributors
+ * SPDX-License-Identifier: LGPL-3.0-or-later
+ */
 
 /**
  * @file sockctl.c

--- a/src/utils/sockctl.h
+++ b/src/utils/sockctl.h
@@ -5,10 +5,7 @@
  * @copyright
  * SPDX-FileCopyrightText: © 2020 NQMCyber Ltd and edgesec contributors
  * SPDX-License-Identifier: LGPL-3.0-or-later
- */
-
-/**
- * @file sockctl.h
+ *
  * @author Alexandru Mereacre
  * @brief File containing the definition of the socket control utilities.
  */

--- a/src/utils/sockctl.h
+++ b/src/utils/sockctl.h
@@ -5,7 +5,6 @@
  * @copyright
  * SPDX-FileCopyrightText: © 2020 NQMCyber Ltd and edgesec contributors
  * SPDX-License-Identifier: LGPL-3.0-or-later
- *
  * @brief File containing the definition of the socket control utilities.
  */
 

--- a/src/utils/sockctl.h
+++ b/src/utils/sockctl.h
@@ -6,7 +6,6 @@
  * SPDX-FileCopyrightText: © 2020 NQMCyber Ltd and edgesec contributors
  * SPDX-License-Identifier: LGPL-3.0-or-later
  *
- * @author Alexandru Mereacre
  * @brief File containing the definition of the socket control utilities.
  */
 

--- a/src/utils/sockctl.h
+++ b/src/utils/sockctl.h
@@ -1,21 +1,11 @@
-/****************************************************************************
- * Copyright (C) 2020 by NQMCyber Ltd                                       *
- *                                                                          *
- * This file is part of EDGESec.                                            *
- *                                                                          *
- *   EDGESec is free software: you can redistribute it and/or modify it     *
- *   under the terms of the GNU Lesser General Public License as published  *
- *   by the Free Software Foundation, either version 3 of the License, or   *
- *   (at your option) any later version.                                    *
- *                                                                          *
- *   EDGESec is distributed in the hope that it will be useful,             *
- *   but WITHOUT ANY WARRANTY; without even the implied warranty of         *
- *   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the          *
- *   GNU Lesser General Public License for more details.                    *
- *                                                                          *
- *   You should have received a copy of the GNU Lesser General Public       *
- *   License along with EDGESec. If not, see <http://www.gnu.org/licenses/>.*
- ****************************************************************************/
+/**
+ * @file
+ * @author Alexandru Mereacre
+ * @date 2020
+ * @copyright
+ * SPDX-FileCopyrightText: © 2020 NQMCyber Ltd and edgesec contributors
+ * SPDX-License-Identifier: LGPL-3.0-or-later
+ */
 
 /**
  * @file sockctl.h

--- a/src/utils/sqliteu.c
+++ b/src/utils/sqliteu.c
@@ -6,7 +6,6 @@
  * SPDX-FileCopyrightText: © 2021 NQMCyber Ltd and edgesec contributors
  * SPDX-License-Identifier: LGPL-3.0-or-later
  *
- * @author Alexandru Mereacre
  * @brief File containing the implementation of the sqlite utilities.
  */
 #include <stdio.h>

--- a/src/utils/sqliteu.c
+++ b/src/utils/sqliteu.c
@@ -5,10 +5,7 @@
  * @copyright
  * SPDX-FileCopyrightText: © 2021 NQMCyber Ltd and edgesec contributors
  * SPDX-License-Identifier: LGPL-3.0-or-later
- */
-
-/**
- * @file sqliteu.c
+ *
  * @author Alexandru Mereacre
  * @brief File containing the implementation of the sqlite utilities.
  */

--- a/src/utils/sqliteu.c
+++ b/src/utils/sqliteu.c
@@ -5,7 +5,6 @@
  * @copyright
  * SPDX-FileCopyrightText: © 2021 NQMCyber Ltd and edgesec contributors
  * SPDX-License-Identifier: LGPL-3.0-or-later
- *
  * @brief File containing the implementation of the sqlite utilities.
  */
 #include <stdio.h>

--- a/src/utils/sqliteu.c
+++ b/src/utils/sqliteu.c
@@ -1,21 +1,11 @@
-/****************************************************************************
- * Copyright (C) 2021 by NQMCyber Ltd                                       *
- *                                                                          *
- * This file is part of EDGESec.                                            *
- *                                                                          *
- *   EDGESec is free software: you can redistribute it and/or modify it     *
- *   under the terms of the GNU Lesser General Public License as published  *
- *   by the Free Software Foundation, either version 3 of the License, or   *
- *   (at your option) any later version.                                    *
- *                                                                          *
- *   EDGESec is distributed in the hope that it will be useful,             *
- *   but WITHOUT ANY WARRANTY; without even the implied warranty of         *
- *   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the          *
- *   GNU Lesser General Public License for more details.                    *
- *                                                                          *
- *   You should have received a copy of the GNU Lesser General Public       *
- *   License along with EDGESec. If not, see <http://www.gnu.org/licenses/>.*
- ****************************************************************************/
+/**
+ * @file
+ * @author Alexandru Mereacre
+ * @date 2021
+ * @copyright
+ * SPDX-FileCopyrightText: © 2021 NQMCyber Ltd and edgesec contributors
+ * SPDX-License-Identifier: LGPL-3.0-or-later
+ */
 
 /**
  * @file sqliteu.c

--- a/src/utils/sqliteu.h
+++ b/src/utils/sqliteu.h
@@ -6,7 +6,6 @@
  * SPDX-FileCopyrightText: © 2021 NQMCyber Ltd and edgesec contributors
  * SPDX-License-Identifier: LGPL-3.0-or-later
  *
- * @author Alexandru Mereacre
  * @brief File containing the definition of the sqlite utilities.
  */
 

--- a/src/utils/sqliteu.h
+++ b/src/utils/sqliteu.h
@@ -5,7 +5,6 @@
  * @copyright
  * SPDX-FileCopyrightText: © 2021 NQMCyber Ltd and edgesec contributors
  * SPDX-License-Identifier: LGPL-3.0-or-later
- *
  * @brief File containing the definition of the sqlite utilities.
  */
 

--- a/src/utils/sqliteu.h
+++ b/src/utils/sqliteu.h
@@ -1,21 +1,11 @@
-/****************************************************************************
- * Copyright (C) 2021 by NQMCyber Ltd                                       *
- *                                                                          *
- * This file is part of EDGESec.                                            *
- *                                                                          *
- *   EDGESec is free software: you can redistribute it and/or modify it     *
- *   under the terms of the GNU Lesser General Public License as published  *
- *   by the Free Software Foundation, either version 3 of the License, or   *
- *   (at your option) any later version.                                    *
- *                                                                          *
- *   EDGESec is distributed in the hope that it will be useful,             *
- *   but WITHOUT ANY WARRANTY; without even the implied warranty of         *
- *   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the          *
- *   GNU Lesser General Public License for more details.                    *
- *                                                                          *
- *   You should have received a copy of the GNU Lesser General Public       *
- *   License along with EDGESec. If not, see <http://www.gnu.org/licenses/>.*
- ****************************************************************************/
+/**
+ * @file
+ * @author Alexandru Mereacre
+ * @date 2021
+ * @copyright
+ * SPDX-FileCopyrightText: © 2021 NQMCyber Ltd and edgesec contributors
+ * SPDX-License-Identifier: LGPL-3.0-or-later
+ */
 
 /**
  * @file sqliteu.h

--- a/src/utils/sqliteu.h
+++ b/src/utils/sqliteu.h
@@ -5,10 +5,7 @@
  * @copyright
  * SPDX-FileCopyrightText: © 2021 NQMCyber Ltd and edgesec contributors
  * SPDX-License-Identifier: LGPL-3.0-or-later
- */
-
-/**
- * @file sqliteu.h
+ *
  * @author Alexandru Mereacre
  * @brief File containing the definition of the sqlite utilities.
  */

--- a/src/utils/squeue.c
+++ b/src/utils/squeue.c
@@ -1,21 +1,11 @@
-/****************************************************************************
- * Copyright (C) 2021 by NQMCyber Ltd                                       *
- *                                                                          *
- * This file is part of EDGESec.                                            *
- *                                                                          *
- *   EDGESec is free software: you can redistribute it and/or modify it     *
- *   under the terms of the GNU Lesser General Public License as published  *
- *   by the Free Software Foundation, either version 3 of the License, or   *
- *   (at your option) any later version.                                    *
- *                                                                          *
- *   EDGESec is distributed in the hope that it will be useful,             *
- *   but WITHOUT ANY WARRANTY; without even the implied warranty of         *
- *   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the          *
- *   GNU Lesser General Public License for more details.                    *
- *                                                                          *
- *   You should have received a copy of the GNU Lesser General Public       *
- *   License along with EDGESec. If not, see <http://www.gnu.org/licenses/>.*
- ****************************************************************************/
+/**
+ * @file
+ * @author Alexandru Mereacre
+ * @date 2021
+ * @copyright
+ * SPDX-FileCopyrightText: © 2021 NQMCyber Ltd and edgesec contributors
+ * SPDX-License-Identifier: LGPL-3.0-or-later
+ */
 
 /**
  * @file squeue.c

--- a/src/utils/squeue.c
+++ b/src/utils/squeue.c
@@ -5,10 +5,7 @@
  * @copyright
  * SPDX-FileCopyrightText: © 2021 NQMCyber Ltd and edgesec contributors
  * SPDX-License-Identifier: LGPL-3.0-or-later
- */
-
-/**
- * @file squeue.c
+ *
  * @author Alexandru Mereacre
  * @brief File containing the implementation of the string queue utilities.
  */

--- a/src/utils/squeue.c
+++ b/src/utils/squeue.c
@@ -6,7 +6,6 @@
  * SPDX-FileCopyrightText: © 2021 NQMCyber Ltd and edgesec contributors
  * SPDX-License-Identifier: LGPL-3.0-or-later
  *
- * @author Alexandru Mereacre
  * @brief File containing the implementation of the string queue utilities.
  */
 

--- a/src/utils/squeue.c
+++ b/src/utils/squeue.c
@@ -5,7 +5,6 @@
  * @copyright
  * SPDX-FileCopyrightText: © 2021 NQMCyber Ltd and edgesec contributors
  * SPDX-License-Identifier: LGPL-3.0-or-later
- *
  * @brief File containing the implementation of the string queue utilities.
  */
 

--- a/src/utils/squeue.h
+++ b/src/utils/squeue.h
@@ -6,7 +6,6 @@
  * SPDX-FileCopyrightText: © 2021 NQMCyber Ltd and edgesec contributors
  * SPDX-License-Identifier: LGPL-3.0-or-later
  *
- * @author Alexandru Mereacre
  * @brief File containing the definition of the string queue utilities.
  */
 

--- a/src/utils/squeue.h
+++ b/src/utils/squeue.h
@@ -5,10 +5,7 @@
  * @copyright
  * SPDX-FileCopyrightText: © 2021 NQMCyber Ltd and edgesec contributors
  * SPDX-License-Identifier: LGPL-3.0-or-later
- */
-
-/**
- * @file squeue.h
+ *
  * @author Alexandru Mereacre
  * @brief File containing the definition of the string queue utilities.
  */

--- a/src/utils/squeue.h
+++ b/src/utils/squeue.h
@@ -5,7 +5,6 @@
  * @copyright
  * SPDX-FileCopyrightText: © 2021 NQMCyber Ltd and edgesec contributors
  * SPDX-License-Identifier: LGPL-3.0-or-later
- *
  * @brief File containing the definition of the string queue utilities.
  */
 

--- a/src/utils/squeue.h
+++ b/src/utils/squeue.h
@@ -1,21 +1,11 @@
-/****************************************************************************
- * Copyright (C) 2021 by NQMCyber Ltd                                       *
- *                                                                          *
- * This file is part of EDGESec.                                            *
- *                                                                          *
- *   EDGESec is free software: you can redistribute it and/or modify it     *
- *   under the terms of the GNU Lesser General Public License as published  *
- *   by the Free Software Foundation, either version 3 of the License, or   *
- *   (at your option) any later version.                                    *
- *                                                                          *
- *   EDGESec is distributed in the hope that it will be useful,             *
- *   but WITHOUT ANY WARRANTY; without even the implied warranty of         *
- *   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the          *
- *   GNU Lesser General Public License for more details.                    *
- *                                                                          *
- *   You should have received a copy of the GNU Lesser General Public       *
- *   License along with EDGESec. If not, see <http://www.gnu.org/licenses/>.*
- ****************************************************************************/
+/**
+ * @file
+ * @author Alexandru Mereacre
+ * @date 2021
+ * @copyright
+ * SPDX-FileCopyrightText: © 2021 NQMCyber Ltd and edgesec contributors
+ * SPDX-License-Identifier: LGPL-3.0-or-later
+ */
 
 /**
  * @file squeue.h

--- a/src/utils/uci_wrt.c
+++ b/src/utils/uci_wrt.c
@@ -1,21 +1,11 @@
-/****************************************************************************
- * Copyright (C) 2022 by NQMCyber Ltd                                       *
- *                                                                          *
- * This file is part of EDGESec.                                            *
- *                                                                          *
- *   EDGESec is free software: you can redistribute it and/or modify it     *
- *   under the terms of the GNU Lesser General Public License as published  *
- *   by the Free Software Foundation, either version 3 of the License, or   *
- *   (at your option) any later version.                                    *
- *                                                                          *
- *   EDGESec is distributed in the hope that it will be useful,             *
- *   but WITHOUT ANY WARRANTY; without even the implied warranty of         *
- *   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the          *
- *   GNU Lesser General Public License for more details.                    *
- *                                                                          *
- *   You should have received a copy of the GNU Lesser General Public       *
- *   License along with EDGESec. If not, see <http://www.gnu.org/licenses/>.*
- ****************************************************************************/
+/**
+ * @file
+ * @author Alexandru Mereacre
+ * @date 2022
+ * @copyright
+ * SPDX-FileCopyrightText: © 2022 NQMCyber Ltd and edgesec contributors
+ * SPDX-License-Identifier: LGPL-3.0-or-later
+ */
 
 /**
  * @file uci.c

--- a/src/utils/uci_wrt.c
+++ b/src/utils/uci_wrt.c
@@ -5,7 +5,6 @@
  * @copyright
  * SPDX-FileCopyrightText: © 2022 NQMCyber Ltd and edgesec contributors
  * SPDX-License-Identifier: LGPL-3.0-or-later
- *
  * @brief File containing the implementation of the uci utilities.
  */
 

--- a/src/utils/uci_wrt.c
+++ b/src/utils/uci_wrt.c
@@ -6,7 +6,6 @@
  * SPDX-FileCopyrightText: © 2022 NQMCyber Ltd and edgesec contributors
  * SPDX-License-Identifier: LGPL-3.0-or-later
  *
- * @author Alexandru Mereacre
  * @brief File containing the implementation of the uci utilities.
  */
 

--- a/src/utils/uci_wrt.c
+++ b/src/utils/uci_wrt.c
@@ -5,10 +5,7 @@
  * @copyright
  * SPDX-FileCopyrightText: © 2022 NQMCyber Ltd and edgesec contributors
  * SPDX-License-Identifier: LGPL-3.0-or-later
- */
-
-/**
- * @file uci.c
+ *
  * @author Alexandru Mereacre
  * @brief File containing the implementation of the uci utilities.
  */

--- a/src/utils/uci_wrt.h
+++ b/src/utils/uci_wrt.h
@@ -5,10 +5,7 @@
  * @copyright
  * SPDX-FileCopyrightText: © 2022 NQMCyber Ltd and edgesec contributors
  * SPDX-License-Identifier: LGPL-3.0-or-later
- */
-
-/**
- * @file uci.h
+ *
  * @author Alexandru Mereacre
  * @brief File containing the definition of the uci utilities.
  */

--- a/src/utils/uci_wrt.h
+++ b/src/utils/uci_wrt.h
@@ -1,21 +1,11 @@
-/****************************************************************************
- * Copyright (C) 2022 by NQMCyber Ltd                                       *
- *                                                                          *
- * This file is part of EDGESec.                                            *
- *                                                                          *
- *   EDGESec is free software: you can redistribute it and/or modify it     *
- *   under the terms of the GNU Lesser General Public License as published  *
- *   by the Free Software Foundation, either version 3 of the License, or   *
- *   (at your option) any later version.                                    *
- *                                                                          *
- *   EDGESec is distributed in the hope that it will be useful,             *
- *   but WITHOUT ANY WARRANTY; without even the implied warranty of         *
- *   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the          *
- *   GNU Lesser General Public License for more details.                    *
- *                                                                          *
- *   You should have received a copy of the GNU Lesser General Public       *
- *   License along with EDGESec. If not, see <http://www.gnu.org/licenses/>.*
- ****************************************************************************/
+/**
+ * @file
+ * @author Alexandru Mereacre
+ * @date 2022
+ * @copyright
+ * SPDX-FileCopyrightText: © 2022 NQMCyber Ltd and edgesec contributors
+ * SPDX-License-Identifier: LGPL-3.0-or-later
+ */
 
 /**
  * @file uci.h

--- a/src/utils/uci_wrt.h
+++ b/src/utils/uci_wrt.h
@@ -5,7 +5,6 @@
  * @copyright
  * SPDX-FileCopyrightText: © 2022 NQMCyber Ltd and edgesec contributors
  * SPDX-License-Identifier: LGPL-3.0-or-later
- *
  * @brief File containing the definition of the uci utilities.
  */
 

--- a/src/utils/uci_wrt.h
+++ b/src/utils/uci_wrt.h
@@ -6,7 +6,6 @@
  * SPDX-FileCopyrightText: © 2022 NQMCyber Ltd and edgesec contributors
  * SPDX-License-Identifier: LGPL-3.0-or-later
  *
- * @author Alexandru Mereacre
  * @brief File containing the definition of the uci utilities.
  */
 


### PR DESCRIPTION
Instead of having a massive license header in our source files, I compressed them into tags supported by Doxygen. This means that the copyright info can now be seen in Doxygen.

The new copyright info is:

```c++
/**
 * @copyright
 * SPDX-FileCopyrightText: © {$YEAR} NQMCyber Ltd and edgesec contributors
 * SPDX-License-Identifier: LGPL-3.0-or-later
 */
```

The SPDX ID is what's used by many open-source projects, such as the Linux kernel: https://lwn.net/Articles/739183/

Additionally, I've removed the `<filename>` from `@file <filename>`, since Doxygen defaults to the current filename, is the `<filename>` specifier is empty.

Does part of #177 (the license renaming part)