### PR TITLE
Rename CMake project from `EDGESEC` to `edgesec`

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,6 +1,6 @@
 cmake_minimum_required(VERSION 3.14.0) # required by lib/sqlite.cmake
 
-project(EDGESEC C CXX)
+project(edgesec C CXX)
 
 list(APPEND CMAKE_MODULE_PATH "${CMAKE_CURRENT_SOURCE_DIR}/CMakeModules")
 list(APPEND CMAKE_MODULE_PATH "${CMAKE_CURRENT_SOURCE_DIR}/lib")

--- a/docs/doxygen.cmake
+++ b/docs/doxygen.cmake
@@ -20,8 +20,6 @@ if (DOXYGEN_FOUND)
     # currently unused, set if we want to use the `@dotfile` command
     # set(DOXYGEN_DOTFILE_DIRS "${PROJECT_SOURCE_DIR}/docs")
     # set(DOXYGEN_OUTPUT_DIRECTORY "${PROJECT_SOURCE_DIR}/docs")
-
-    set(DOXYGEN_PROJECT_NAME "edgesec") # defaults to EDGESEC
     set(DOXYGEN_EXTRACT_ALL YES) # document even files missing `@file` command
 
     if (BUILD_ONLY_DOCS)

--- a/src/ap/CMakeLists.txt
+++ b/src/ap/CMakeLists.txt
@@ -1,5 +1,5 @@
 include_directories (
-  "${EDGESEC_SOURCE_DIR}/src"
+  "${PROJECT_SOURCE_DIR}/src"
 )
 
 add_library(ap_config INTERFACE) # header-only library

--- a/src/capture/middlewares/cleaner_middleware/CMakeLists.txt
+++ b/src/capture/middlewares/cleaner_middleware/CMakeLists.txt
@@ -1,5 +1,5 @@
 include_directories (
-  "${EDGESEC_SOURCE_DIR}/src"
+  "${PROJECT_SOURCE_DIR}/src"
 )
 
 add_library(cleaner_middleware cleaner_middleware.c)

--- a/src/capture/middlewares/header_middleware/CMakeLists.txt
+++ b/src/capture/middlewares/header_middleware/CMakeLists.txt
@@ -1,5 +1,5 @@
 include_directories (
-  "${EDGESEC_SOURCE_DIR}/src"
+  "${PROJECT_SOURCE_DIR}/src"
 )
 
 # we include packet_decoder.h, so need to include its dependencies

--- a/src/capture/middlewares/pcap_middleware/CMakeLists.txt
+++ b/src/capture/middlewares/pcap_middleware/CMakeLists.txt
@@ -1,5 +1,5 @@
 include_directories (
-  "${EDGESEC_SOURCE_DIR}/src"
+  "${PROJECT_SOURCE_DIR}/src"
 )
 
 add_library(pcap_queue pcap_queue.c)

--- a/src/crypt/CMakeLists.txt
+++ b/src/crypt/CMakeLists.txt
@@ -1,5 +1,5 @@
 include_directories (
-  "${EDGESEC_SOURCE_DIR}/src"
+  "${PROJECT_SOURCE_DIR}/src"
 )
 
 add_library(sqlite_crypt_writer sqlite_crypt_writer.c)

--- a/src/dhcp/CMakeLists.txt
+++ b/src/dhcp/CMakeLists.txt
@@ -1,5 +1,5 @@
 include_directories (
-  "${EDGESEC_SOURCE_DIR}/src"
+  "${PROJECT_SOURCE_DIR}/src"
 )
 
 add_library(dnsmasq dnsmasq.c)

--- a/src/dns/CMakeLists.txt
+++ b/src/dns/CMakeLists.txt
@@ -1,5 +1,5 @@
 include_directories (
-  "${EDGESEC_SOURCE_DIR}/src"
+  "${PROJECT_SOURCE_DIR}/src"
 )
 
 add_library(command_mapper command_mapper.c)

--- a/src/firewall/CMakeLists.txt
+++ b/src/firewall/CMakeLists.txt
@@ -1,5 +1,5 @@
 include_directories (
-  "${EDGESEC_SOURCE_DIR}/src"
+  "${PROJECT_SOURCE_DIR}/src"
 )
 
 add_library(firewall_service firewall_service.c)

--- a/src/radius/CMakeLists.txt
+++ b/src/radius/CMakeLists.txt
@@ -1,5 +1,5 @@
 include_directories (
-  "${EDGESEC_SOURCE_DIR}/src"
+  "${PROJECT_SOURCE_DIR}/src"
 )
 
 add_library(md5_internal md5_internal.c)

--- a/src/supervisor/CMakeLists.txt
+++ b/src/supervisor/CMakeLists.txt
@@ -1,5 +1,5 @@
 include_directories (
-  "${EDGESEC_SOURCE_DIR}/src"
+  "${PROJECT_SOURCE_DIR}/src"
 )
 
 add_library(bridge_list bridge_list.c)

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -1,5 +1,5 @@
 include_directories (
-  "${EDGESEC_SOURCE_DIR}/src"
+  "${PROJECT_SOURCE_DIR}/src"
 )
 
 if (USE_CAPTURE_SERVICE)

--- a/tests/ap/CMakeLists.txt
+++ b/tests/ap/CMakeLists.txt
@@ -1,5 +1,5 @@
 include_directories(
-  "${EDGESEC_SOURCE_DIR}/src"
+  "${PROJECT_SOURCE_DIR}/src"
 )
 
 add_executable(test_hostapd test_hostapd.c)

--- a/tests/capture/CMakeLists.txt
+++ b/tests/capture/CMakeLists.txt
@@ -1,7 +1,7 @@
 add_subdirectory(./middlewares)
 
 include_directories (
-  "${EDGESEC_SOURCE_DIR}/src",
+  "${PROJECT_SOURCE_DIR}/src",
 )
 
 add_executable(test_capture_service test_capture_service.c)

--- a/tests/crypt/CMakeLists.txt
+++ b/tests/crypt/CMakeLists.txt
@@ -1,5 +1,5 @@
 include_directories (
-  "${EDGESEC_SOURCE_DIR}/src"
+  "${PROJECT_SOURCE_DIR}/src"
 )
 
 add_executable(test_sqlite_crypt_writer test_sqlite_crypt_writer.c)

--- a/tests/dhcp/CMakeLists.txt
+++ b/tests/dhcp/CMakeLists.txt
@@ -1,5 +1,5 @@
 include_directories(
-  "${EDGESEC_SOURCE_DIR}/src"
+  "${PROJECT_SOURCE_DIR}/src"
 )
 
 add_executable(test_dnsmasq test_dnsmasq.c)

--- a/tests/dns/CMakeLists.txt
+++ b/tests/dns/CMakeLists.txt
@@ -1,5 +1,5 @@
 include_directories(
-  "${EDGESEC_SOURCE_DIR}/src"
+  "${PROJECT_SOURCE_DIR}/src"
 )
 
 add_executable(test_mdns_list test_mdns_list.c)

--- a/tests/radius/CMakeLists.txt
+++ b/tests/radius/CMakeLists.txt
@@ -1,5 +1,5 @@
 include_directories(
-  "${EDGESEC_SOURCE_DIR}/src"
+  "${PROJECT_SOURCE_DIR}/src"
 )
 
 add_library(ip_addr ip_addr.c)

--- a/tests/supervisor/CMakeLists.txt
+++ b/tests/supervisor/CMakeLists.txt
@@ -1,5 +1,5 @@
 include_directories(
-  "${EDGESEC_SOURCE_DIR}/src"
+  "${PROJECT_SOURCE_DIR}/src"
 )
 
 add_executable(test_bridge_list test_bridge_list.c)

--- a/tests/system/CMakeLists.txt
+++ b/tests/system/CMakeLists.txt
@@ -1,5 +1,5 @@
 include_directories (
-  "${EDGESEC_SOURCE_DIR}/src"
+  "${PROJECT_SOURCE_DIR}/src"
 )
 
 add_executable(test_system_checks test_system_checks.c)

--- a/tests/utils/CMakeLists.txt
+++ b/tests/utils/CMakeLists.txt
@@ -1,5 +1,5 @@
 include_directories(
-  "${EDGESEC_SOURCE_DIR}/src"
+  "${PROJECT_SOURCE_DIR}/src"
 )
 
 if (USE_UCI_SERVICE)


### PR DESCRIPTION
Working on #177

Btw, it looks like the standard practice for naming projects in CMake is CamelCase, e.g. https://cmake.org/cmake/help/latest/variable/CMAKE_PROJECT_VERSION.html#variable:CMAKE_PROJECT_VERSION

Is it worth us naming the CMake project `Edgesec` instead? (I'll be honest, it looks very weird to me, but it might be worth it just to make it consistent with the rest of the CMake world)