### PR TITLE
build(debian): fix debian build when single out

### DIFF
--- a/debian/rules
+++ b/debian/rules
@@ -20,6 +20,11 @@ override_dh_auto_configure:
 		 -DUSE_UCI_SERVICE=OFF\
 		 -DBUILD_HOSTAPD=ON
 
+# make sure to always install into `debian/tmp` and use
+# *.install files, even if we only have one package
+override_dh_auto_install:
+	dh_auto_install --destdir debian/tmp
+
 # make sure to tell dh_shlibdeps about our private shared libs
 override_dh_shlibdeps:
 	dh_shlibdeps -l/usr/lib/$(DEB_HOST_GNU_TYPE)/edgesec


### PR DESCRIPTION
If there is only a single package in `debian/control`, by default, the `debian/*.install` files do nothing, since everything is installed by default.

This PR overrides `dh_auto_install` so that the same behaviour is used, whether building multiple packages or just the one.

Should fix this failing CI action: https://github.com/nqminds/edgesec/runs/7149699032?check_suite_focus=true