### PR TITLE
build: remove invalid comma in test/capture cmake

### DIFF
--- a/tests/capture/CMakeLists.txt
+++ b/tests/capture/CMakeLists.txt
@@ -1,7 +1,7 @@
 add_subdirectory(./middlewares)
 
 include_directories (
-  "${PROJECT_SOURCE_DIR}/src",
+  "${PROJECT_SOURCE_DIR}/src"
 )
 
 add_executable(test_capture_service test_capture_service.c)


### PR DESCRIPTION
My fault, I forgot commans weren't allowed in cmake files, and I didn't see the warning that cmake printed.