### PR TITLE
build(docs): bump DOT_GRAPH_MAX_NODES to 128

### DIFF
--- a/docs/doxygen.cmake
+++ b/docs/doxygen.cmake
@@ -22,6 +22,8 @@ if (DOXYGEN_FOUND)
     # set(DOXYGEN_OUTPUT_DIRECTORY "${PROJECT_SOURCE_DIR}/docs")
     set(DOXYGEN_EXTRACT_ALL YES) # document even files missing `@file` command
 
+    # allows for more complitated include diagrams
+    set(DOXYGEN_DOT_GRAPH_MAX_NODES 128)
     set(doxygen_input_files
       "${PROJECT_SOURCE_DIR}/src" "${PROJECT_SOURCE_DIR}/docs" "${PROJECT_SOURCE_DIR}/README.md"
     )


### PR DESCRIPTION
Currently, there are 84 nodes in the include diagram for src/utils/os.h and we need to manually increase the limit if we want it to render.

After increasing the limit, we can see this very ~spaghetti-like~ beautiful diagram by looking at https://nqminds.github.io/edgesec/os_8h.html 
![image](https://user-images.githubusercontent.com/19716675/177190570-2d990cde-dd40-43b8-a1a5-46931ff1cd5f.png)

I mainly increased the limit to hide the warning that Doxygen printed.
