### PR TITLE
build(docs): build dot files as SVGs, not PNGs

### DIFF
--- a/docs/doxygen.cmake
+++ b/docs/doxygen.cmake
@@ -20,6 +20,7 @@ if (DOXYGEN_FOUND)
     # currently unused, set if we want to use the `@dotfile` command
     # set(DOXYGEN_DOTFILE_DIRS "${PROJECT_SOURCE_DIR}/docs")
     # set(DOXYGEN_OUTPUT_DIRECTORY "${PROJECT_SOURCE_DIR}/docs")
+    set(DOXYGEN_DOT_IMAGE_FORMAT svg)
     set(DOXYGEN_EXTRACT_ALL YES) # document even files missing `@file` command
 
     set(doxygen_input_files


### PR DESCRIPTION
SVGs are smaller, text can be copy-and-pasted from, they can be zoomed in indefinitely, and best of all, the boxes are hyperlinks to their docs page.

![image](https://user-images.githubusercontent.com/19716675/177191709-2a2ab5dc-e251-4f50-a689-35609dcbec78.png)
