### PR TITLE
Fix some more doxygen errors

### DIFF
--- a/src/capture/capture_service.h
+++ b/src/capture/capture_service.h
@@ -29,7 +29,7 @@ struct capture_middleware_context {
  * @brief Callback for pcap packet module
  *
  * @param ctx The capture context
- * @param ctx The pcap context
+ * @param pcap_ctx The pcap context
  * @param ltype The link type
  * @param header pcap header structure
  * @param packet Returned pcap packet

--- a/src/capture/middlewares/header_middleware/mdns_decoder.h
+++ b/src/capture/middlewares/header_middleware/mdns_decoder.h
@@ -36,7 +36,7 @@ struct mdns_answer_entry {
  * @param len The mdns payload length
  * @param first The starting index to the queries field
  * @param nqueries The number of queries
- * @param answers The queries array
+ * @param queries The queries array
  * @return 0 Success, -1 on failure
  */
 int decode_mdns_queries(uint8_t *payload, size_t len, size_t *first,

--- a/src/capture/middlewares/header_middleware/mdns_decoder.h
+++ b/src/capture/middlewares/header_middleware/mdns_decoder.h
@@ -34,9 +34,11 @@ struct mdns_answer_entry {
  *
  * @param payload The mdns payload
  * @param len The mdns payload length
- * @param first The starting index to the queries field
+ * @param[in,out] first The starting index to the queries field in the mdns @p
+ * payload. When done, this will be modified to be the starting index of the
+ * next field.
  * @param nqueries The number of queries
- * @param queries The queries array
+ * @param[in,out] queries The ::mdns_query_entry queries array
  * @return 0 Success, -1 on failure
  */
 int decode_mdns_queries(uint8_t *payload, size_t len, size_t *first,
@@ -47,9 +49,11 @@ int decode_mdns_queries(uint8_t *payload, size_t len, size_t *first,
  *
  * @param payload The mdns payload
  * @param len The mdns payload length
- * @param first The starting index to the answers field
+ * @param[in,out] first The starting index to the answers field in the mdns @p
+ * payload. When done, this will be modified to be the starting index of the
+ * next field.
  * @param nanswers The number of answers
- * @param answers The answers array
+ * @param[in,out] answers The ::mdns_answer_entry answers array
  * @return 0 Success, -1 on failure
  */
 int decode_mdns_answers(uint8_t *payload, size_t len, size_t *first,

--- a/src/capture/middlewares/header_middleware/packet_queue.h
+++ b/src/capture/middlewares/header_middleware/packet_queue.h
@@ -69,7 +69,7 @@ void free_packet_queue_el(struct packet_queue *el);
 /**
  * @brief Returns the packet queue length
  *
- * @param el The pointer to the packet queue
+ * @param queue The pointer to the packet queue
  * @return ssize_t The packet queue length
  */
 ssize_t get_packet_queue_length(struct packet_queue *queue);

--- a/src/capture/middlewares/pcap_middleware/pcap_queue.h
+++ b/src/capture/middlewares/pcap_middleware/pcap_queue.h
@@ -65,7 +65,7 @@ void free_pcap_queue_el(struct pcap_queue *el);
 /**
  * @brief Returns the pcap queue length
  *
- * @param el The pointer to the pcap queue
+ * @param queue The pointer to the pcap queue
  * @return ssize_t The pcap queue length
  */
 ssize_t get_pcap_queue_length(struct pcap_queue *queue);

--- a/src/crypt/sqlite_crypt_writer.h
+++ b/src/crypt/sqlite_crypt_writer.h
@@ -124,7 +124,7 @@ struct secrets_row *get_sqlite_secrets_row(sqlite3 *db, char *id);
 /**
  * @brief Frees a secrets row entry
  *
- * @param column The secrets row value
+ * @param row The secrets row value
  */
 void free_sqlite_secrets_row(struct secrets_row *row);
 #endif

--- a/src/crypt/sqlite_crypt_writer.h
+++ b/src/crypt/sqlite_crypt_writer.h
@@ -74,7 +74,7 @@ int open_sqlite_crypt_db(char *db_path, sqlite3 **sql);
 /**
  * @brief Closes the sqlite db
  *
- * @param ctx The sqlite db structure pointer
+ * @param db The sqlite db structure pointer
  */
 void free_sqlite_crypt_db(sqlite3 *db);
 

--- a/src/crypt/sqlite_crypt_writer.h
+++ b/src/crypt/sqlite_crypt_writer.h
@@ -108,7 +108,7 @@ struct store_row *get_sqlite_store_row(sqlite3 *db, const char *key);
 /**
  * @brief Frees a store row entry
  *
- * @param column The store row value
+ * @param row The store row value
  */
 void free_sqlite_store_row(struct store_row *row);
 

--- a/src/dns/mdns_mapper.h
+++ b/src/dns/mdns_mapper.h
@@ -54,7 +54,7 @@ int put_mdns_answer_mapper(hmap_mdns_conn **imap, uint8_t *ip,
 /**
  * @brief Frees the mDNS mapper connection object
  *
- * @param hmap mDNS mapper connection object
+ * @param imap mDNS mapper connection object
  */
 void free_mdns_mapper(hmap_mdns_conn **imap);
 

--- a/src/dns/mdns_service.h
+++ b/src/dns/mdns_service.h
@@ -39,7 +39,7 @@ struct mdns_context {
 /**
  * @brief Runs the mDNS forwarder service
  *
- * @param config The mDNS config structure
+ * @param context The mDNS context structure.
  * @return int 0 on success, -1 on failure
  */
 int run_mdns(struct mdns_context *context);

--- a/src/firewall/firewall_service.h
+++ b/src/firewall/firewall_service.h
@@ -29,6 +29,7 @@
  * @param hmap_bin_paths The Mapper for paths to systems binaries
  * @param config_ifinfo_array The @c config_ifinfo_array from @c struct
  * app_config
+ * @param nat_bridge The NAT bridge name
  * @param nat_interface The nat interface string
  * @param exec_firewall if true runs the firewall system commands
  * @param path The firewall bin path

--- a/src/supervisor/crypt_commands.h
+++ b/src/supervisor/crypt_commands.h
@@ -64,7 +64,7 @@ int gen_privkey_cmd(struct supervisor_context *context, char *keyid,
  * @brief GEN_PUBKEY command
  *
  * @param context The supervisor structure instance
- * @param certid The public id
+ * @param pubid The public id
  * @param keyid The private key id
  * @return 0 on success, -1 on failure
  */

--- a/src/supervisor/network_commands.h
+++ b/src/supervisor/network_commands.h
@@ -127,8 +127,7 @@ int remove_bridge_cmd(struct supervisor_context *context,
  * @param mac_addr The MAC address
  * @return int 0 on success, -1 on failure
  */
-int clear_bridges_cmd(struct supervisor_context *context,
-                      uint8_t *left_mac_addr);
+int clear_bridges_cmd(struct supervisor_context *context, uint8_t *mac_addr);
 
 /**
  * @brief REGISTER_TICKET command

--- a/src/supervisor/network_commands.h
+++ b/src/supervisor/network_commands.h
@@ -23,8 +23,8 @@
 /**
  * @brief Save a MAC entry into the mapper
  *
- * @param The supervisor context
- * @param The MAc connection structure
+ * @param context The supervisor context
+ * @param conn The MAc connection structure
  *
  * @return true on success, false on failure
  */

--- a/src/supervisor/network_commands.h
+++ b/src/supervisor/network_commands.h
@@ -33,7 +33,7 @@ bool save_mac_mapper(struct supervisor_context *context, struct mac_conn conn);
 /**
  * @brief Frees an allocated ticket
  *
- * @param The supervisor context
+ * @param context The supervisor context
  */
 void free_ticket(struct supervisor_context *context);
 

--- a/src/supervisor/sqlite_macconn_writer.h
+++ b/src/supervisor/sqlite_macconn_writer.h
@@ -49,7 +49,7 @@ int open_sqlite_macconn_db(char *db_path, sqlite3 **sql);
 /**
  * @brief Closes the sqlite db
  *
- * @param ctx The sqlite db structure pointer
+ * @param db The sqlite db structure pointer
  */
 void free_sqlite_macconn_db(sqlite3 *db);
 

--- a/src/utils/cryptou.h
+++ b/src/utils/cryptou.h
@@ -37,8 +37,8 @@ enum CRYPTO_KEY_TYPE { CRYPTO_KEY_NONE = 0, CRYPTO_KEY_RSA, CRYPTO_KEY_EC };
 /**
  * @brief Generate IV
  *
- * @param The output buffer
- * @param The IV size
+ * @param buf The output buffer
+ * @param iv_size The IV size
  * @return 1 on success, 0 on failure
  */
 int crypto_geniv(uint8_t *buf, int iv_size);


### PR DESCRIPTION
Fixes some more doxygen errors.

I was bored waiting for stuff to compile, so while I was waiting, I fixed the rest of the Doxygen errors.

It looks like all the remaining Doxygen errors are from `eloop.h` or `src/radius/*`, which use a different non-Doxygen documentation system ([kernel-doc](https://docs.kernel.org/doc-guide/kernel-doc.html)).