### PR TITLE
ci: fix non-existing cmake preset

### DIFF
--- a/.github/workflows/create-debs.yml
+++ b/.github/workflows/create-debs.yml
@@ -18,7 +18,7 @@ jobs:
           - linux # Normal linux tests
           - linux-with-crypt # Tests whether crypto service works
           - linux-with-example-middlewares # tests whether example capture middlewares work
-          - openwrt/mvebu/cortexa9 # Tests whether OpenWRT ARM 32-bit target works
+          - openwrt/mvebu/default # Tests whether OpenWRT ARM 32-bit target works
     runs-on: ubuntu-latest
     steps:
       - name: Checkout code


### PR DESCRIPTION
Fixes the non-existing cmake preset in the CI tests.

Fixes: https://github.com/nqminds/edgesec/commit/8c3090a85ec21de8fee94df59db4751a5bb1f641