### PR TITLE
Sqllock

### DIFF
--- a/src/capture/capture_service.c
+++ b/src/capture/capture_service.c
@@ -76,6 +76,8 @@ int run_capture(struct capture_middleware_context *context) {
 
   ret = sqlite3_open(context->config.capture_db_path, &db);
 
+  sqlite3_busy_timeout(db, DB_BUSY_TIMEOUT);
+
   if (ret != SQLITE_OK) {
     log_error("Cannot open database: %s", sqlite3_errmsg(db));
     sqlite3_close(db);

--- a/src/capture/capture_service.h
+++ b/src/capture/capture_service.h
@@ -19,6 +19,8 @@
 #include "pcap_service.h"
 #include "capture_config.h"
 
+#define DB_BUSY_TIMEOUT 5000 // Sets the sqlite busy timeout in milliseconds
+
 struct capture_middleware_context {
   struct capture_conf config;
   UT_array *handlers;

--- a/src/capture/middlewares/header_middleware/sqlite_header.c
+++ b/src/capture/middlewares/header_middleware/sqlite_header.c
@@ -605,146 +605,58 @@ int init_sqlite_header_db(sqlite3 *db) {
 
   log_debug("sqlite autocommit mode=%d", sqlite3_get_autocommit(db));
 
-  rc = check_table_exists(db, "eth");
-
-  if (rc == 0) {
-    log_debug("eth table doesn't exist creating...");
-    if (execute_sqlite_query(db, ETH_CREATE_TABLE) < 0) {
-      log_error("execute_sqlite_query fail");
-      return -1;
-    }
-  } else if (rc < 0) {
-    log_error("check_table_exists fail");
+  if (execute_sqlite_query(db, ETH_CREATE_TABLE) < 0) {
+    log_error("execute_sqlite_query fail");
     return -1;
   }
 
-  rc = check_table_exists(db, "arp");
-
-  if (rc == 0) {
-    log_debug("arp table doesn't exist creating...");
-    if (execute_sqlite_query(db, ARP_CREATE_TABLE) < 0) {
-      log_error("execute_sqlite_query fail");
-      return -1;
-    }
-  } else if (rc < 0) {
-    log_error("check_table_exists fail");
+  if (execute_sqlite_query(db, ARP_CREATE_TABLE) < 0) {
+    log_error("execute_sqlite_query fail");
     return -1;
   }
 
-  rc = check_table_exists(db, "ip4");
-
-  if (rc == 0) {
-    log_debug("ip4 table doesn't exist creating...");
-    if (execute_sqlite_query(db, IP4_CREATE_TABLE) < 0) {
-      log_error("execute_sqlite_query fail");
-      return -1;
-    }
-  } else if (rc < 0) {
-    log_error("check_table_exists fail");
+  if (execute_sqlite_query(db, IP4_CREATE_TABLE) < 0) {
+    log_error("execute_sqlite_query fail");
     return -1;
   }
 
-  rc = check_table_exists(db, "ip6");
-
-  if (rc == 0) {
-    log_debug("ip6 table doesn't exist creating...");
-    if (execute_sqlite_query(db, IP6_CREATE_TABLE) < 0) {
-      log_error("execute_sqlite_query fail");
-      return -1;
-    }
-  } else if (rc < 0) {
-    log_error("check_table_exists fail");
+  if (execute_sqlite_query(db, IP6_CREATE_TABLE) < 0) {
+    log_error("execute_sqlite_query fail");
     return -1;
   }
 
-  rc = check_table_exists(db, "tcp");
-
-  if (rc == 0) {
-    log_debug("tcp table doesn't exist creating...");
-    if (execute_sqlite_query(db, TCP_CREATE_TABLE) < 0) {
-      log_error("execute_sqlite_query fail");
-      return -1;
-    }
-  } else if (rc < 0) {
-    log_error("check_table_exists fail");
+  if (execute_sqlite_query(db, TCP_CREATE_TABLE) < 0) {
+    log_error("execute_sqlite_query fail");
     return -1;
   }
 
-  rc = check_table_exists(db, "udp");
-
-  if (rc == 0) {
-    log_debug("udp table doesn't exist creating...");
-    if (execute_sqlite_query(db, UDP_CREATE_TABLE) < 0) {
-      log_error("execute_sqlite_query fail");
-      return -1;
-    }
-  } else if (rc < 0) {
-    log_error("check_table_exists fail");
+  if (execute_sqlite_query(db, UDP_CREATE_TABLE) < 0) {
+    log_error("execute_sqlite_query fail");
     return -1;
   }
 
-  rc = check_table_exists(db, "icmp4");
-
-  if (rc == 0) {
-    log_debug("icmp4 table doesn't exist creating...");
-    if (execute_sqlite_query(db, ICMP4_CREATE_TABLE) < 0) {
-      log_error("execute_sqlite_query fail");
-      return -1;
-    }
-  } else if (rc < 0) {
-    log_error("check_table_exists fail");
+  if (execute_sqlite_query(db, ICMP4_CREATE_TABLE) < 0) {
+    log_error("execute_sqlite_query fail");
     return -1;
   }
 
-  rc = check_table_exists(db, "icmp6");
-
-  if (rc == 0) {
-    log_debug("icmp6 table doesn't exist creating...");
-    if (execute_sqlite_query(db, ICMP6_CREATE_TABLE) < 0) {
-      log_error("execute_sqlite_query fail");
-      return -1;
-    }
-  } else if (rc < 0) {
-    log_error("check_table_exists fail");
+  if (execute_sqlite_query(db, ICMP6_CREATE_TABLE) < 0) {
+    log_error("execute_sqlite_query fail");
     return -1;
   }
 
-  rc = check_table_exists(db, "dns");
-
-  if (rc == 0) {
-    log_debug("dns table doesn't exist creating...");
-    if (execute_sqlite_query(db, DNS_CREATE_TABLE) < 0) {
-      log_error("execute_sqlite_query fail");
-      return -1;
-    }
-  } else if (rc < 0) {
-    log_error("check_table_exists fail");
+  if (execute_sqlite_query(db, DNS_CREATE_TABLE) < 0) {
+    log_error("execute_sqlite_query fail");
     return -1;
   }
 
-  rc = check_table_exists(db, "mdns");
-
-  if (rc == 0) {
-    log_debug("mdns table doesn't exist creating...");
-    if (execute_sqlite_query(db, MDNS_CREATE_TABLE) < 0) {
-      log_error("execute_sqlite_query fail");
-      return -1;
-    }
-  } else if (rc < 0) {
-    log_error("check_table_exists fail");
+  if (execute_sqlite_query(db, MDNS_CREATE_TABLE) < 0) {
+    log_error("execute_sqlite_query fail");
     return -1;
   }
 
-  rc = check_table_exists(db, "dhcp");
-
-  if (rc == 0) {
-    log_debug("dhcp table doesn't exist creating...");
-    if (execute_sqlite_query(db, DHCP_CREATE_TABLE) < 0) {
-      log_error("execute_sqlite_query fail");
-      return -1;
-    }
-  } else if (rc < 0) {
-    log_error("check_table_exists fail");
+  if (execute_sqlite_query(db, DHCP_CREATE_TABLE) < 0) {
+    log_error("execute_sqlite_query fail");
     return -1;
   }
 

--- a/src/capture/middlewares/header_middleware/sqlite_header.c
+++ b/src/capture/middlewares/header_middleware/sqlite_header.c
@@ -595,6 +595,13 @@ int save_packet_statement(sqlite3 *db, struct tuple_packet *tp) {
 }
 
 int init_sqlite_header_db(sqlite3 *db) {
+  const char *tables[] = {
+      ETH_CREATE_TABLE,   ARP_CREATE_TABLE,   IP4_CREATE_TABLE,
+      IP6_CREATE_TABLE,   TCP_CREATE_TABLE,   UDP_CREATE_TABLE,
+      ICMP4_CREATE_TABLE, ICMP6_CREATE_TABLE, DNS_CREATE_TABLE,
+      MDNS_CREATE_TABLE,  DHCP_CREATE_TABLE,
+  };
+
   if (db == NULL) {
     log_error("db param is NULL");
     return -1;
@@ -602,59 +609,11 @@ int init_sqlite_header_db(sqlite3 *db) {
 
   log_debug("sqlite autocommit mode=%d", sqlite3_get_autocommit(db));
 
-  if (execute_sqlite_query(db, ETH_CREATE_TABLE) < 0) {
-    log_error("execute_sqlite_query fail");
-    return -1;
-  }
-
-  if (execute_sqlite_query(db, ARP_CREATE_TABLE) < 0) {
-    log_error("execute_sqlite_query fail");
-    return -1;
-  }
-
-  if (execute_sqlite_query(db, IP4_CREATE_TABLE) < 0) {
-    log_error("execute_sqlite_query fail");
-    return -1;
-  }
-
-  if (execute_sqlite_query(db, IP6_CREATE_TABLE) < 0) {
-    log_error("execute_sqlite_query fail");
-    return -1;
-  }
-
-  if (execute_sqlite_query(db, TCP_CREATE_TABLE) < 0) {
-    log_error("execute_sqlite_query fail");
-    return -1;
-  }
-
-  if (execute_sqlite_query(db, UDP_CREATE_TABLE) < 0) {
-    log_error("execute_sqlite_query fail");
-    return -1;
-  }
-
-  if (execute_sqlite_query(db, ICMP4_CREATE_TABLE) < 0) {
-    log_error("execute_sqlite_query fail");
-    return -1;
-  }
-
-  if (execute_sqlite_query(db, ICMP6_CREATE_TABLE) < 0) {
-    log_error("execute_sqlite_query fail");
-    return -1;
-  }
-
-  if (execute_sqlite_query(db, DNS_CREATE_TABLE) < 0) {
-    log_error("execute_sqlite_query fail");
-    return -1;
-  }
-
-  if (execute_sqlite_query(db, MDNS_CREATE_TABLE) < 0) {
-    log_error("execute_sqlite_query fail");
-    return -1;
-  }
-
-  if (execute_sqlite_query(db, DHCP_CREATE_TABLE) < 0) {
-    log_error("execute_sqlite_query fail");
-    return -1;
+  for (size_t i = 0; i < STRLEN(tables); i++) {
+    if (execute_sqlite_query(db, tables[i]) < 0) {
+      log_error("execute_sqlite_query fail: %s", tables[i]);
+      return -1;
+    }
   }
 
   return 0;

--- a/src/capture/middlewares/header_middleware/sqlite_header.c
+++ b/src/capture/middlewares/header_middleware/sqlite_header.c
@@ -595,9 +595,6 @@ int save_packet_statement(sqlite3 *db, struct tuple_packet *tp) {
 }
 
 int init_sqlite_header_db(sqlite3 *db) {
-
-  int rc;
-
   if (db == NULL) {
     log_error("db param is NULL");
     return -1;

--- a/src/capture/middlewares/header_middleware/sqlite_header.h
+++ b/src/capture/middlewares/header_middleware/sqlite_header.h
@@ -25,19 +25,19 @@
 #define MAX_DB_NAME 100
 
 #define ETH_CREATE_TABLE                                                       \
-  "CREATE TABLE eth (timestamp INTEGER NOT NULL, id TEXT NOT NULL, "           \
-  "caplen INTEGER, length INTEGER, ifname TEXT, "                              \
+  "CREATE TABLE IF NOT EXISTS eth (timestamp INTEGER NOT NULL, "               \
+  "id TEXT NOT NULL, caplen INTEGER, length INTEGER, ifname TEXT, "            \
   "ether_dhost TEXT, ether_shost TEXT, ether_type INTEGER, PRIMARY KEY "       \
   "(timestamp, id));"
 
 #define ARP_CREATE_TABLE                                                       \
-  "CREATE TABLE arp (id TEXT, "                                                \
+  "CREATE TABLE IF NOT EXISTS arp (id TEXT, "                                  \
   "ar_hrd INTEGER, ar_pro INTEGER, ar_hln INTEGER, "                           \
   "ar_pln INTEGER, ar_op INTEGER, arp_sha TEXT, arp_spa TEXT, "                \
   "arp_tha TEXT, arp_tpa TEXT, PRIMARY KEY (id));"
 
 #define IP4_CREATE_TABLE                                                       \
-  "CREATE TABLE ip4 (id TEXT NOT NULL, "                                       \
+  "CREATE TABLE IF NOT EXISTS ip4 (id TEXT NOT NULL, "                         \
   "ip_hl INTEGER, ip_v INTEGER, ip_tos INTEGER, ip_len INTEGER, ip_id "        \
   "INTEGER, "                                                                  \
   "ip_off INTEGER, ip_ttl INTEGER, ip_p INTEGER, ip_sum INTEGER, ip_src "      \
@@ -45,13 +45,13 @@
   "ip_dst TEXT, PRIMARY KEY (id));"
 
 #define IP6_CREATE_TABLE                                                       \
-  "CREATE TABLE ip6 (id TEXT NOT NULL, "                                       \
+  "CREATE TABLE IF NOT EXISTS ip6 (id TEXT NOT NULL, "                         \
   "ip6_un1_flow INTEGER, ip6_un1_plen INTEGER, ip6_un1_nxt INTEGER, "          \
   "ip6_un1_hlim INTEGER, "                                                     \
   "ip6_un2_vfc INTEGER, ip6_src TEXT, ip6_dst TEXT, PRIMARY KEY (id));"
 
 #define TCP_CREATE_TABLE                                                       \
-  "CREATE TABLE tcp (id TEXT NOT NULL, "                                       \
+  "CREATE TABLE IF NOT EXISTS tcp (id TEXT NOT NULL, "                         \
   "source INTEGER, dest INTEGER, seq INTEGER, ack_seq INTEGER, res1 INTEGER, " \
   "doff INTEGER, fin INTEGER, "                                                \
   "syn INTEGER, rst INTEGER, psh INTEGER, ack INTEGER, urg INTEGER, window "   \
@@ -59,34 +59,34 @@
   "urg_ptr INTEGER, PRIMARY KEY (id));"
 
 #define UDP_CREATE_TABLE                                                       \
-  "CREATE TABLE udp (id TEXT NOT NULL, "                                       \
+  "CREATE TABLE IF NOT EXISTS udp (id TEXT NOT NULL, "                         \
   "source INTEGER, dest INTEGER, len INTEGER, check_p INTEGER, PRIMARY KEY "   \
   "(id));"
 
 #define ICMP4_CREATE_TABLE                                                     \
-  "CREATE TABLE icmp4 (id TEXT NOT NULL, "                                     \
+  "CREATE TABLE IF NOT EXISTS icmp4 (id TEXT NOT NULL, "                       \
   "type INTEGER, code INTEGER, checksum INTEGER, gateway INTEGER, PRIMARY "    \
   "KEY (id));"
 
 #define ICMP6_CREATE_TABLE                                                     \
-  "CREATE TABLE icmp6 (id TEXT NOT NULL, "                                     \
+  "CREATE TABLE IF NOT EXISTS icmp6 (id TEXT NOT NULL, "                       \
   "icmp6_type INTEGER, icmp6_code INTEGER, icmp6_cksum INTEGER, "              \
   "icmp6_un_data32 INTEGER, PRIMARY KEY (id));"
 
 #define DNS_CREATE_TABLE                                                       \
-  "CREATE TABLE dns (id TEXT NOT NULL, "                                       \
+  "CREATE TABLE IF NOT EXISTS dns (id TEXT NOT NULL, "                         \
   "tid INTEGER, flags INTEGER, nqueries INTEGER, nanswers INTEGER, nauth "     \
   "INTEGER, "                                                                  \
   "nother INTEGER, qname TEXT, PRIMARY KEY (id));"
 
 #define MDNS_CREATE_TABLE                                                      \
-  "CREATE TABLE mdns (id TEXT NOT NULL, "                                      \
+  "CREATE TABLE IF NOT EXISTS mdns (id TEXT NOT NULL, "                        \
   "tid INTEGER, flags INTEGER, nqueries INTEGER, nanswers INTEGER, nauth "     \
   "INTEGER, "                                                                  \
   "nother INTEGER, qname TEXT, PRIMARY KEY (id));"
 
 #define DHCP_CREATE_TABLE                                                      \
-  "CREATE TABLE dhcp (id TEXT NOT NULL, "                                      \
+  "CREATE TABLE IF NOT EXISTS dhcp (id TEXT NOT NULL, "                        \
   "op INTEGER, htype INTEGER, hlen INTEGER, hops INTEGER, xid INTEGER, secs "  \
   "INTEGER, flags INTEGER, "                                                   \
   "ciaddr TEXT, yiaddr TEXT, siaddr TEXT, giaddr TEXT, chaddr TEXT, "          \

--- a/src/capture/middlewares/pcap_middleware/sqlite_pcap.c
+++ b/src/capture/middlewares/pcap_middleware/sqlite_pcap.c
@@ -22,23 +22,13 @@
 #include "../../../utils/sqliteu.h"
 
 int init_sqlite_pcap_db(sqlite3 *db) {
-  int rc;
-
   if (db == NULL) {
     log_error("db param is NULL");
     return -1;
   }
 
-  rc = check_table_exists(db, PCAP_TABLE_NAME);
-
-  if (rc == 0) {
-    log_debug("pcap table doesn't exist creating...");
-    if (execute_sqlite_query(db, PCAP_CREATE_TABLE) < 0) {
-      log_error("execute_sqlite_query fail");
-      return -1;
-    }
-  } else if (rc < 0) {
-    log_error("check_table_exists fail");
+  if (execute_sqlite_query(db, PCAP_CREATE_TABLE) < 0) {
+    log_error("execute_sqlite_query fail");
     return -1;
   }
 

--- a/src/capture/middlewares/pcap_middleware/sqlite_pcap.h
+++ b/src/capture/middlewares/pcap_middleware/sqlite_pcap.h
@@ -20,7 +20,7 @@
 
 #define PCAP_TABLE_NAME "pcap"
 #define PCAP_CREATE_TABLE                                                      \
-  "CREATE TABLE " PCAP_TABLE_NAME                                              \
+  "CREATE TABLE IF NOT EXISTS " PCAP_TABLE_NAME                                \
   " (timestamp INTEGER NOT NULL, name TEXT NOT NULL, "                         \
   "caplen INTEGER, length INTEGER, "                                           \
   "PRIMARY KEY (name));"

--- a/src/utils/sqliteu.c
+++ b/src/utils/sqliteu.c
@@ -27,7 +27,7 @@ int execute_sqlite_query(sqlite3 *db, char *statement) {
   return 0;
 }
 
-int prepare_find_table(sqlite3 *db, char *table_name, sqlite3_stmt *res) {
+int prepare_find_table(sqlite3 *db, const char *table_name, sqlite3_stmt *res) {
   char *sql = "SELECT name FROM sqlite_master WHERE type='table' AND name=?;";
   int rc = sqlite3_prepare_v2(db, sql, -1, &res, 0);
 

--- a/src/utils/sqliteu.c
+++ b/src/utils/sqliteu.c
@@ -16,7 +16,7 @@
 
 #define SQLITE_EXEC_TRIES 10000
 
-int execute_sqlite_query(sqlite3 *db, char *statement) {
+int execute_sqlite_query(sqlite3 *db, const char *statement) {
   int rc = sqlite3_exec(db, statement, 0, 0, NULL);
 
   if (rc != SQLITE_OK) {

--- a/src/utils/sqliteu.h
+++ b/src/utils/sqliteu.h
@@ -23,7 +23,7 @@
  * @param statement The sqlite query statement.
  * @return int 0 on success, -1 on failure.
  */
-int execute_sqlite_query(sqlite3 *db, char *statement);
+int execute_sqlite_query(sqlite3 *db, const char *statement);
 
 /**
  * @brief Check if sqlite table exists

--- a/tests/capture/middlewares/CMakeLists.txt
+++ b/tests/capture/middlewares/CMakeLists.txt
@@ -5,6 +5,9 @@ set_target_properties(test_header_middleware
   LINK_FLAGS  "-Wl,--wrap=sqlite3_open"
 )
 
+add_executable(test_sqlite_header test_sqlite_header.c)
+target_link_libraries(test_sqlite_header PUBLIC SQLite::SQLite3 PRIVATE sqlite_header os log cmocka::cmocka)
+
 add_executable(test_packet_queue test_packet_queue.c)
 target_link_libraries(test_packet_queue PUBLIC PCAP::pcap SQLite::SQLite3 PRIVATE packet_queue os log cmocka::cmocka)
 
@@ -19,7 +22,12 @@ set_tests_properties(test_header_middleware
   PROPERTIES
   WILL_FAIL FALSE)
 
-  add_test(NAME test_packet_queue COMMAND test_packet_queue)
+add_test(NAME test_sqlite_header COMMAND test_sqlite_header)
+set_tests_properties(test_sqlite_header
+  PROPERTIES
+  WILL_FAIL FALSE)
+
+add_test(NAME test_packet_queue COMMAND test_packet_queue)
 set_tests_properties(test_packet_queue
   PROPERTIES
   WILL_FAIL FALSE)

--- a/tests/capture/middlewares/test_sqlite_header.c
+++ b/tests/capture/middlewares/test_sqlite_header.c
@@ -17,6 +17,7 @@
 #include "utils/sqliteu.h"
 #include "capture/middlewares/header_middleware/header_middleware.h"
 #include "capture/middlewares/header_middleware/sqlite_header.h"
+#include "capture/capture_service.h"
 
 char *test_header_db = "/tmp/test_header.sqlite";
 
@@ -26,6 +27,7 @@ void *test_sqlite_header_thread(void *arg) {
   sqlite3 *db;
 
   assert_int_equal(sqlite3_open(test_header_db, &db), SQLITE_OK);
+  assert_int_equal(sqlite3_busy_timeout(db, DB_BUSY_TIMEOUT), 0);
   assert_int_equal(init_sqlite_header_db(db), 0);
   sqlite3_close(db);
   return NULL;

--- a/tests/capture/middlewares/test_sqlite_header.c
+++ b/tests/capture/middlewares/test_sqlite_header.c
@@ -19,14 +19,14 @@
 #include "capture/middlewares/header_middleware/sqlite_header.h"
 #include "capture/capture_service.h"
 
-char *test_header_db = "/tmp/test_header.sqlite";
+char *test_capture_db = "/tmp/test_capture.sqlite";
 
 void *test_sqlite_header_thread(void *arg) {
   (void)arg;
 
   sqlite3 *db;
 
-  assert_int_equal(sqlite3_open(test_header_db, &db), SQLITE_OK);
+  assert_int_equal(sqlite3_open(test_capture_db, &db), SQLITE_OK);
   assert_int_equal(sqlite3_busy_timeout(db, DB_BUSY_TIMEOUT), 0);
   assert_int_equal(init_sqlite_header_db(db), 0);
   sqlite3_close(db);
@@ -38,7 +38,7 @@ static void test_init_sqlite_header_db(void **state) {
 
   pthread_t id1, id2, id3;
 
-  remove(test_header_db);
+  remove(test_capture_db);
 
   assert_int_equal(pthread_create(&id1, NULL, test_sqlite_header_thread, NULL),
                    0);

--- a/tests/capture/middlewares/test_sqlite_header.c
+++ b/tests/capture/middlewares/test_sqlite_header.c
@@ -1,0 +1,63 @@
+#define _GNU_SOURCE
+
+#include <sys/types.h>
+#include <sys/stat.h>
+#include <fcntl.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <stdarg.h>
+#include <string.h>
+#include <inttypes.h>
+#include <unistd.h>
+#include <setjmp.h>
+#include <cmocka.h>
+#include <pthread.h>
+
+#include "utils/log.h"
+#include "utils/sqliteu.h"
+#include "capture/middlewares/header_middleware/header_middleware.h"
+#include "capture/middlewares/header_middleware/sqlite_header.h"
+
+char *test_header_db = "/tmp/test_header.sqlite";
+
+void *test_sqlite_header_thread(void *arg) {
+  (void)arg;
+
+  sqlite3 *db;
+
+  assert_int_equal(sqlite3_open(test_header_db, &db), SQLITE_OK);
+  assert_int_equal(init_sqlite_header_db(db), 0);
+  sqlite3_close(db);
+  return NULL;
+}
+
+static void test_init_sqlite_header_db(void **state) {
+  (void)state;
+
+  pthread_t id1, id2, id3;
+
+  remove(test_header_db);
+
+  assert_int_equal(pthread_create(&id1, NULL, test_sqlite_header_thread, NULL),
+                   0);
+  assert_int_equal(pthread_create(&id2, NULL, test_sqlite_header_thread, NULL),
+                   0);
+  assert_int_equal(pthread_create(&id3, NULL, test_sqlite_header_thread, NULL),
+                   0);
+
+  assert_int_equal(pthread_join(id1, NULL), 0);
+  assert_int_equal(pthread_join(id2, NULL), 0);
+  assert_int_equal(pthread_join(id3, NULL), 0);
+}
+
+int main(int argc, char *argv[]) {
+  (void)argc;
+  (void)argv;
+
+  log_set_quiet(false);
+
+  const struct CMUnitTest tests[] = {
+      cmocka_unit_test(test_init_sqlite_header_db)};
+
+  return cmocka_run_group_tests(tests, NULL, NULL);
+}

--- a/tests/capture/middlewares/test_sqlite_pcap.c
+++ b/tests/capture/middlewares/test_sqlite_pcap.c
@@ -18,7 +18,7 @@
 #include "capture/middlewares/pcap_middleware/sqlite_pcap.h"
 #include "capture/capture_service.h"
 
-char *test_capture_db = "/tmp/test_capture.sqlite";
+char *test_capture_db = "/tmp/test_pcap.sqlite";
 
 void *test_sqlite_pcap_thread(void *arg) {
   (void)arg;

--- a/tests/capture/middlewares/test_sqlite_pcap.c
+++ b/tests/capture/middlewares/test_sqlite_pcap.c
@@ -11,20 +11,44 @@
 #include <unistd.h>
 #include <setjmp.h>
 #include <cmocka.h>
+#include <pthread.h>
 
 #include "utils/log.h"
 #include "utils/sqliteu.h"
 #include "capture/middlewares/pcap_middleware/sqlite_pcap.h"
+#include "capture/capture_service.h"
 
-static void test_open_sqlite_pcap_db(void **state) {
-  (void)state; /* unused */
+char *test_capture_db = "/tmp/test_capture.sqlite";
+
+void *test_sqlite_pcap_thread(void *arg) {
+  (void)arg;
+
   sqlite3 *db;
 
-  int ret = sqlite3_open(":memory:", &db);
-  assert_int_equal(ret, SQLITE_OK);
+  assert_int_equal(sqlite3_open(test_capture_db, &db), SQLITE_OK);
+  assert_int_equal(sqlite3_busy_timeout(db, DB_BUSY_TIMEOUT), 0);
   assert_int_equal(init_sqlite_pcap_db(db), 0);
-
   sqlite3_close(db);
+  return NULL;
+}
+
+static void test_init_sqlite_pcap_db(void **state) {
+  (void)state; /* unused */
+
+  pthread_t id1, id2, id3;
+
+  remove(test_capture_db);
+
+  assert_int_equal(pthread_create(&id1, NULL, test_sqlite_pcap_thread, NULL),
+                   0);
+  assert_int_equal(pthread_create(&id2, NULL, test_sqlite_pcap_thread, NULL),
+                   0);
+  assert_int_equal(pthread_create(&id3, NULL, test_sqlite_pcap_thread, NULL),
+                   0);
+
+  assert_int_equal(pthread_join(id1, NULL), 0);
+  assert_int_equal(pthread_join(id2, NULL), 0);
+  assert_int_equal(pthread_join(id3, NULL), 0);
 }
 
 static void test_save_sqlite_pcap_entry(void **state) {
@@ -46,7 +70,7 @@ int main(int argc, char *argv[]) {
   log_set_quiet(false);
 
   const struct CMUnitTest tests[] = {
-      cmocka_unit_test(test_open_sqlite_pcap_db),
+      cmocka_unit_test(test_init_sqlite_pcap_db),
       cmocka_unit_test(test_save_sqlite_pcap_entry)};
 
   return cmocka_run_group_tests(tests, NULL, NULL);


### PR DESCRIPTION
Solves the problem of sqlite race, where multiple threads are trying to create a table on the same database.

Solution:
 - Add a busy timeout, where sqlite pools for a given time (milliseconds)
 - Change `CRATE TABLE` to `CREATE IF NOT EXISTS`