### PR TITLE
build(sqlite3): revert sqlite3 to v3.31.01

### DIFF
--- a/lib/sqlite.cmake
+++ b/lib/sqlite.cmake
@@ -23,8 +23,10 @@ else()
   message("Downloading and compiling our own libsqlite library")
   ExternalProject_Add(
     libsqlite
-    URL https://www.sqlite.org/2021/sqlite-autoconf-3360000.tar.gz
-    URL_HASH SHA256=bd90c3eb96bee996206b83be7065c9ce19aef38c3f4fb53073ada0d0b69bbce3
+    # v3.31.01 is the version supported by OpenWRT 19.07
+    # see https://github.com/openwrt/packages/blob/5a399f144891d6774611c9903f12059270b09ca8/libs/sqlite3/Makefile#L10-L11
+    URL https://www.sqlite.org/2020/sqlite-autoconf-3310100.tar.gz
+    URL_HASH SHA256=62284efebc05a76f909c580ffa5c008a7d22a1287285d68b7825a2b6b51949ae
     INSTALL_DIR "${LIBSQLITE_INSTALL_DIR}"
     CONFIGURE_COMMAND autoreconf -f -i <SOURCE_DIR>
     COMMAND


### PR DESCRIPTION
Reverts sqlite3 to v3.31.01 as that's the version supported by Openwrt 19.07.