### PR TITLE
docs: add open-source badges

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,11 @@
 # edgesec
 
-[![Build Debian Packages](https://github.com/nqminds/edgesec/actions/workflows/create-debs.yml/badge.svg)](https://github.com/nqminds/edgesec/actions/workflows/create-debs.yml) ![Release](https://badgen.net/badge/release/0.0.8/blue?icon=color)
+[![GitHub release (latest stable SemVer)](https://img.shields.io/github/v/release/nqminds/edgesec?label=stable&logo=github&sort=semver)](https://github.com/nqminds/nqm-ssh-tunnel/releases)
+[![Build Debian Packages](https://github.com/nqminds/edgesec/actions/workflows/create-debs.yml/badge.svg)](https://github.com/nqminds/edgesec/actions/workflows/create-debs.yml)
+[![GitHub release (latest SemVer including pre-releases)](https://img.shields.io/github/v/release/nqminds/edgesec?include_prereleases&label=latest&logo=github&sort=semver)](https://github.com/nqminds/nqm-ssh-tunnel/releases)
+[![GitHub license](https://img.shields.io/github/license/nqminds/edgesec)](https://github.com/nqminds/edgesec/blob/main/LICENSE)
+![CMake](https://img.shields.io/badge/CMake-%23008FBA.svg?logo=cmake&logoColor=white)
+![C11](https://img.shields.io/badge/C11-informational.svg?logo=c)
 
 edgesec defines a new architecture and toolset for edge based routers addressing
 fundamental security weaknesses that impact current IP and IoT router implementations.


### PR DESCRIPTION
Adds the following badges:

Currently, the GitHub release badges don't show anything, since https://github.com/nqminds/edgesec/releases is empty.

Fixes #171

[![GitHub release (latest stable SemVer)](https://img.shields.io/github/v/release/nqminds/edgesec?label=stable&logo=github&sort=semver)](https://github.com/nqminds/nqm-ssh-tunnel/releases)
[![Build Debian Packages](https://github.com/nqminds/edgesec/actions/workflows/create-debs.yml/badge.svg)](https://github.com/nqminds/edgesec/actions/workflows/create-debs.yml)
[![GitHub release (latest SemVer including pre-releases)](https://img.shields.io/github/v/release/nqminds/edgesec?include_prereleases&label=latest&logo=github&sort=semver)](https://github.com/nqminds/nqm-ssh-tunnel/releases)
[![GitHub license](https://img.shields.io/github/license/nqminds/edgesec)](https://github.com/nqminds/edgesec/blob/main/LICENSE)
![CMake](https://img.shields.io/badge/CMake-%23008FBA.svg?logo=cmake&logoColor=white)
![C11](https://img.shields.io/badge/C11-informational.svg?logo=c)