### PR TITLE
OpenWRT Raspberry Pi 3 Toolchain Preset

### DIFF
--- a/.github/workflows/create-debs.yml
+++ b/.github/workflows/create-debs.yml
@@ -19,6 +19,7 @@ jobs:
           - linux-with-crypt # Tests whether crypto service works
           - linux-with-example-middlewares # tests whether example capture middlewares work
           - openwrt/mvebu/default # Tests whether OpenWRT ARM 32-bit target works
+          - openwrt-21.02.1/bcm27xx/bcm2710 # Raspberry Pi 3 for OpenWRT 21.02.1
     runs-on: ubuntu-latest
     steps:
       - name: Checkout code

--- a/CMakeModules/CMakeToolchains/openwrt-21.02.1-bcm27xx-bcm2710.cmake
+++ b/CMakeModules/CMakeToolchains/openwrt-21.02.1-bcm27xx-bcm2710.cmake
@@ -1,0 +1,13 @@
+include("${CMAKE_CURRENT_LIST_DIR}/DefineOpenWRTSDKToolchain.cmake")
+
+defineOpenwrtSDKToolchain(
+    URL https://downloads.openwrt.org/releases/21.02.1/targets/bcm27xx/bcm2710/openwrt-sdk-21.02.1-bcm27xx-bcm2710_gcc-8.4.0_musl.Linux-x86_64.tar.xz
+    # sha256 from https://downloads.openwrt.org/releases/21.02.1/targets/bcm27xx/bcm2710/sha256sums
+    URL_HASH SHA256=de4cd5463db552b4eb8877daf90ae922833fd6ead598db58cc7ff4c71b229ef6
+    TOOLCHAIN_DIR toolchain-aarch64_cortex-a53_gcc-8.4.0_musl
+    TARGET_DIR target-aarch64_cortex-a53_musl
+    GNU_TARGET aarch64-openwrt-linux-musl
+    # normally this is the first word of $GNU_TARGET
+    # This should be the ouput of `uname -m` when you run OpenWRT, e.g. arm
+    SYSTEM_PROCESSOR aarch64
+)

--- a/CMakePresets.json
+++ b/CMakePresets.json
@@ -128,6 +128,13 @@
       "displayName": "OpenWRT ath79/generic OpenWRT 21",
       "description": "OpenWRT ath79/generic OpenWRT 21 (uses uci)",
       "toolchainFile": "${sourceDir}/CMakeModules/CMakeToolchains/openwrt-21-ath79-generic.cmake"
+    },
+    {
+      "name": "openwrt-21.02.1/bcm27xx/bcm2710",
+      "inherits": "openwrt/default",
+      "displayName": "OpenWRT bcm27xx/bcm2710 OpenWRT 21.02.1",
+      "description": "Raspberry Pi 3B+ OpenWRT bcm27xx/bcm2710 OpenWRT 21.02.1",
+      "toolchainFile": "${sourceDir}/CMakeModules/CMakeToolchains/openwrt-21.02.1-bcm27xx-bcm2710.cmake"
     }
   ],
   "buildPresets": [
@@ -170,6 +177,10 @@
     {
       "name": "openwrt-21/ath79/generic",
       "configurePreset": "openwrt-21/ath79/generic"
+    },
+    {
+      "name": "openwrt-21.02.1/bcm27xx/bcm2710",
+      "configurePreset": "openwrt-21.02.1/bcm27xx/bcm2710"
     }
   ],
   "testPresets": [


### PR DESCRIPTION
Adds the CMakePreset `openwrt-21.02.1/bcm27xx/bcm2710`, which is compiled for `bcm27xx/bcm2710` (Raspberry Pi 3) for `openwrt-21.02.1`, as discussed in https://github.com/nqminds/edgesec/issues/210#issuecomment-1198112852

Not currently documented (other than by running `cmake --list-presets`)

Ideally we would document how to create new presets from OpenWRT SDK releases, instead of us trying to individually add every single preset ourselves.