### PR TITLE
Use `debian/control` to install dependencies

### DIFF
--- a/.github/workflows/create-debs.yml
+++ b/.github/workflows/create-debs.yml
@@ -26,24 +26,9 @@ jobs:
       - name: Install Dependencies
         shell: bash # we're using bash arrays here
         run: |
-          build_dependencies=(
-            cmake # build-tool
-            git # required to download dependencies
-            ca-certificates # required for git+https downloads
-            doxygen texinfo graphviz # documentation
-            build-essential # C and C++ compilers
-            libnl-genl-3-dev libnl-route-3-dev # netlink dependencies
-            autopoint gettext # required by libuuid
-            autoconf # required by compile_sqlite.sh
-            libtool-bin # required by autoconf somewhere
-            pkg-config # seems to be required by nDPI
-            libjson-c-dev # mystery requirement
-            flex bison # required by pcap
-            libssl-dev # required by hostapd only. We compile OpenSSL 3 for EDGESec
-            libcmocka-dev # cmocka, can be removed if -DBUILD_CMOCKA_LIB=ON
-            libmnl-dev # libmnl, can be removed if -DBUILD_LIBMNL_LIB=ON
-          )
-          sudo apt install -y "${build_dependencies[@]}"
+          sudo apt-get update
+          sudo apt-get install devscripts equivs -y # install mk-build-depends
+          sudo mk-build-deps --install --tool='apt-get -o Debug::pkgProblemResolver=yes --no-install-recommends --yes'  debian/control
       - name: Configure
         run: |
           cmake -B build/ --preset "${{ matrix.cmake-preset }}"

--- a/Dockerfile
+++ b/Dockerfile
@@ -4,10 +4,16 @@ FROM ubuntu:22.04
 ENV TZ=Europe
 RUN ln -snf /usr/share/zoneinfo/$TZ /etc/localtime && echo $TZ > /etc/timezone
 
-RUN apt update && apt install -y tzdata wget cmake git ca-certificates doxygen texinfo graphviz build-essential automake autopoint gettext autoconf libtool-bin pkg-config libjson-c-dev flex bison
 RUN mkdir /opt/EDGESec
 
 WORKDIR /opt
+
+COPY ./debian/control ./debian/control
+
+
+# install dependencies
+RUN apt-get update && apt-get install devscripts equivs wget -y && \
+    mk-build-deps --install --tool='apt-get -o Debug::pkgProblemResolver=yes --no-install-recommends --yes' ./debian/control
 
 RUN wget https://github.com/richfelker/musl-cross-make/archive/master.tar.gz
 RUN tar xzf master.tar.gz

--- a/Dockerfile
+++ b/Dockerfile
@@ -15,7 +15,7 @@ COPY ./debian/control ./debian/control
 RUN apt-get update && apt-get install devscripts equivs wget -y && \
     mk-build-deps --install --tool='apt-get -o Debug::pkgProblemResolver=yes --no-install-recommends --yes' ./debian/control
 
-RUN wget https://github.com/richfelker/musl-cross-make/archive/master.tar.gz
+ADD https://github.com/richfelker/musl-cross-make/archive/master.tar.gz ./master.tar.gz
 RUN tar xzf master.tar.gz
 WORKDIR /opt/musl-cross-make-master
 COPY ./config.mak ./

--- a/README.md
+++ b/README.md
@@ -21,7 +21,7 @@ You can use [`mk-build-deps`](https://manpages.ubuntu.com/manpages/focal/man1/mk
 to automatically install these build-dependencies.
 
 ```bash
-sudo apt install devscripts # install mk-build-depends
+sudo apt install devscripts equivs # install mk-build-depends
 sudo mk-build-deps --install debian/control
 ```
 


### PR DESCRIPTION
Our `debian/control` file has all the files required to build edgesec on a Debian PC. We should use this to control all dependency management.