### PR TITLE
ci(deb): fix caching in pbuilder base

### DIFF
--- a/.github/workflows/create-debs.yml
+++ b/.github/workflows/create-debs.yml
@@ -81,7 +81,7 @@ jobs:
         with:
           path: |
             /var/cache/pbuilder/base.tgz
-          key: ${{ runner.os }}-${{ matrix.distribution }}
+          key: ${{ runner.os }}-${{ matrix.distribution }}-${{ matrix.architecture }}
       - name: Install dependencies
         run: |
           sudo apt-get update && sudo apt-get install pbuilder debhelper -y


### PR DESCRIPTION
Both the arm64 and amd64 code had the same cache key and were conflicting with each other.