### PR TITLE
build(openwrt): fix broken tests for OpenWRT

### DIFF
--- a/src/dhcp/CMakeLists.txt
+++ b/src/dhcp/CMakeLists.txt
@@ -3,10 +3,9 @@ include_directories (
 )
 
 add_library(dnsmasq dnsmasq.c)
+target_link_libraries(dnsmasq PRIVATE log os)
 if (USE_UCI_SERVICE)
-    target_link_libraries(dnsmasq PRIVATE log os squeue OpenWRT::UCI)
-else ()
-  target_link_libraries(dnsmasq PRIVATE log os)
+    target_link_libraries(dnsmasq PRIVATE squeue uci_wrt)
 endif ()
 
 

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -22,7 +22,7 @@ if (USE_MDNS_SERVICE)
 endif ()
 
 add_executable(test_runctl test_runctl.c)
-target_link_libraries(test_runctl PUBLIC SQLite::SQLite3 PRIVATE runctl log os mac_mapper cmocka::cmocka)
+target_link_libraries(test_runctl PUBLIC SQLite::SQLite3 PRIVATE runctl log os supervisor_config mac_mapper cmocka::cmocka)
 set(TEST_RUNCTL_PROPS "-Wl,--wrap=get_vlan_mapper -Wl,--wrap=eloop_run -Wl,--wrap=get_commands_paths -Wl,--wrap=hmap_str_keychar_get")
 set(TEST_RUNCTL_PROPS "${TEST_RUNCTL_PROPS} -Wl,--wrap=fw_init_context -Wl,--wrap=fw_set_ip_forward")
 if (USE_CRYPTO_SERVICE)


### PR DESCRIPTION
Make skips compiling tests when cross-compiling, so you will only encounter this error when compiling for x86_64 OpenWRT.

The issue was that `test_runctl.c` could not find "uci.h".

Adding `supervisor_config` as a dependency to `test_runctl` adds UCI to the include paths when needed.

(I also fixed the `dnsmasq` bit, since that had a linking error too)