### PR TITLE
chore(deps): bump hostapd to v2.10

### DIFF
--- a/lib/hostapd.cmake
+++ b/lib/hostapd.cmake
@@ -28,14 +28,12 @@ if (BUILD_HOSTAPD AND NOT (BUILD_ONLY_DOCS))
 
   ExternalProject_Add(
     hostapd_externalproject
-    # can't use https since debian build doesn't like the https certificats of https://w1.fi
-    # not super secure since SHA1-ttered attack can be used to fake GIT_TAG with MITM attack
-    GIT_REPOSITORY git://w1.fi/hostap.git
-    GIT_TAG 81121319a9e5cfcd4531fda7ce869b113d79caa0 # From: Sun Nov 17 21:02:42 2019 +0200
+    URL https://w1.fi/releases/hostapd-2.10.tar.gz
+    URL_HASH SHA512=243baa82d621f859d2507d8d5beb0ebda15a75548a62451dc9bca42717dcc8607adac49b354919a41d8257d16d07ac7268203a79750db0cfb34b51f80ff1ce8f
     INSTALL_DIR "${HOSTAPD_INSTALL_DIR}"
     BUILD_IN_SOURCE true
     SOURCE_SUBDIR "hostapd" # we only care about hostapd, not the entire hostap dir
-    # copy over the configure file that contains our cross
+    # copy over the configure file that contains our cross-compile settings
     CONFIGURE_COMMAND
       cmake -E copy
         "${CMAKE_CURRENT_BINARY_DIR}/hostapd.config"


### PR DESCRIPTION
Bump hostapd to v2.10 instead of just using a git commit.

Support was added for OpenSSL 3.0 in hostapd v2.10, so we could try doing something with that too.

Full release notes are at:
https://lists.infradead.org/pipermail/hostap/2022-January/040148.html