### PR TITLE
docs: add badges for doxygen C docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,6 +4,8 @@
 [![Build Debian Packages](https://github.com/nqminds/edgesec/actions/workflows/create-debs.yml/badge.svg)](https://github.com/nqminds/edgesec/actions/workflows/create-debs.yml)
 [![GitHub release (latest SemVer including pre-releases)](https://img.shields.io/github/v/release/nqminds/edgesec?include_prereleases&label=latest&logo=github&sort=semver)](https://github.com/nqminds/nqm-ssh-tunnel/releases)
 [![GitHub license](https://img.shields.io/github/license/nqminds/edgesec)](https://github.com/nqminds/edgesec/blob/main/LICENSE)
+[![Documented with Doxygen](https://img.shields.io/badge/docs-Doxygen-blue.svg?foo&bar)](https://edgesec.info/doxygen/)
+[![GitHub Pages](https://github.com/nqminds/edgesec/actions/workflows/pages.yml/badge.svg)](https://github.com/nqminds/edgesec/actions/workflows/pages.yml)
 ![CMake](https://img.shields.io/badge/CMake-%23008FBA.svg?logo=cmake&logoColor=white)
 ![C11](https://img.shields.io/badge/C11-informational.svg?logo=c)
 [![OpenWRT package feed](https://img.shields.io/badge/OpenWRT%20Package%20Feed-%23002B49.svg?logo=OpenWrt&logoColor=white)](https://github.com/nqminds/manysecured-openwrt-packages)


### PR DESCRIPTION
Adds even more open-source badges for:

- [![Documented with Doxygen](https://img.shields.io/badge/docs-Doxygen-blue.svg?foo&bar)](https://edgesec.info/doxygen/)
  Links to https://edgesec.info/doxygen/, aka the page with the doxygen iframe.
- [![GitHub Pages](https://github.com/nqminds/edgesec/actions/workflows/pages.yml/badge.svg)](https://github.com/nqminds/edgesec/actions/workflows/pages.yml)
  Links to https://github.com/nqminds/edgesec/actions/workflows/pages.yml, e.g. the status of the GitHub Pages CI action

Although, we might be moving into the territory of too many open-source badges.