### PR TITLE
fix(debian): compile enabled header middleware

### DIFF
--- a/debian/rules
+++ b/debian/rules
@@ -18,6 +18,7 @@ override_dh_auto_configure:
 		 -DBUILD_NETLINK_LIB=ON\
 		 -DUSE_NETLINK_SERVICE=ON\
 		 -DUSE_UCI_SERVICE=OFF\
+		 -DUSE_HEADER_MIDDLEWARE=ON\
 		 -DBUILD_HOSTAPD=ON
 
 # make sure to always install into `debian/tmp` and use


### PR DESCRIPTION
The header middleware allows capturing metadata from PCAP files, and would be useful to be included in the `.deb` file.

This will copy how we compile the OpenWRT version of edgesec, see https://github.com/nqminds/manysecured-openwrt-packages/blob/484ffebf2d21adfe21117ee4a8861a9af2dcfe2c/edgesec/Makefile#L62