### PR TITLE
ci(debs): build for ubuntu 22.04 jammy

### DIFF
--- a/.github/workflows/create-debs.yml
+++ b/.github/workflows/create-debs.yml
@@ -68,7 +68,10 @@ jobs:
     strategy:
       matrix:
         architecture: [arm64, amd64]
-        distribution: [focal]
+        distribution:
+          # focal and jammy are incompatible due to ABI incompatible libssl versions
+          - focal # uses libssl1.1
+          - jammy # uses libssl3
     env:
       OTHER_MIRROR:
         deb [arch=arm64] http://ports.ubuntu.com/ubuntu-ports ${{ matrix.distribution }} main universe | deb [arch=amd64] http://archive.ubuntu.com/ubuntu ${{ matrix.distribution }} main universe

--- a/.github/workflows/create-debs.yml
+++ b/.github/workflows/create-debs.yml
@@ -108,9 +108,12 @@ jobs:
       - name: Load output .deb name
         id: load-deb-name
         run: |
-          DEB_PATH="$(ls -rt '${{ runner.temp }}/pbuilder/result'/edgesec*.deb | head -1)"
-          echo " ::set-output name=deb-path::${DEB_PATH}"
-          echo " ::set-output name=deb-name::$(basename "${DEB_PATH}")"
+          OLD_DEB_PATH="$(ls -rt '${{ runner.temp }}/pbuilder/result'/edgesec*.deb | head -1)"
+          NEW_DEB_PATH="$(echo "$OLD_DEB_PATH" | sed -E 's/_(([[:digit:]]\.){0,2}[[:digit:]](-[A-Za-z0-9+.~])?)_/_\1_${{ matrix.distribution }}_/')"
+          mv "$OLD_DEB_PATH" "$NEW_DEB_PATH"
+          echo " ::set-output name=old-deb-path::${OLD_DEB_PATH}"
+          echo " ::set-output name=deb-path::${NEW_DEB_PATH}"
+          echo " ::set-output name=deb-name::$(basename "${NEW_DEB_PATH}")"
       - name: Archive built debs
         uses: actions/upload-artifact@v2
         with:


### PR DESCRIPTION
The focal .deb is incompatible with jammy, due to the libssl1.1 package being missing, as it was replaced with libssl3.

The only part of the edgesec that was using OpenSSL was:
  - the bundled hostapd
  - when compiled with `USE_CRYPTO_SERVICE=true`

As hostapd v2.10 is compatible with OpenSSL 3.0.0 (see #216), and `USE_CRYPTO_SERVICE=false` is normally disabled, upgrading the OpenSSL 3.0.0 shouldn't cause any disruption.

**Note**: In order to prevent the focal (Ubuntu 20.04) and jammy (Ubuntu 22.04) packages from having the same filenames, I changed the `.deb`s to have the filename pattern: `name_version_distribution_arch.deb`, so that `distribution` was included in the filename.

