### PR TITLE
fix(debian): remove `-s` opt from edgesec service

### DIFF
--- a/debian/edgesec.service
+++ b/debian/edgesec.service
@@ -6,7 +6,7 @@ After=network.target
 Type=simple
 Restart=always
 RestartSec=60
-ExecStart=/usr/bin/edgesec -c /etc/edgesec/config.ini -ddd -s 12345
+ExecStart=/usr/bin/edgesec -c /etc/edgesec/config.ini -ddd
 
 [Install]
 WantedBy=edgesec.target


### PR DESCRIPTION
The `-s` option only makes sense if edgesec is compiled with `USE_CRYPTO_SERVICE=true`, which it isn't normally. Using it now results in the error: `Command-line usage error: Unrecognized option -s`