### PR TITLE
test: test crypt_service if `USE_CRYPTO_SERVICE`

### DIFF
--- a/tests/crypt/CMakeLists.txt
+++ b/tests/crypt/CMakeLists.txt
@@ -21,9 +21,7 @@ set_tests_properties(test_sqlite_crypt_writer
   PROPERTIES
   WILL_FAIL FALSE)
 
-if (BUILD_OPENSSL_LIB)
-  add_test(NAME test_crypt_service COMMAND test_crypt_service)
-  set_tests_properties(test_crypt_service
-    PROPERTIES
-    WILL_FAIL FALSE)
-endif ()
+add_test(NAME test_crypt_service COMMAND test_crypt_service)
+set_tests_properties(test_crypt_service
+  PROPERTIES
+  WILL_FAIL FALSE)


### PR DESCRIPTION
`tests/crypt` is only included if `USE_CRYPTO_SERVICE` is true, so it should be fine to run tests, even if `BUILD_OPENSSL_LIB` is false (it may be false if OpenSSL is already installed,  e.g. Ubuntu 22.04 already comes with OpenSSL 3.0)