### PR TITLE
Add code coverage GitHub Action

### DIFF
--- a/.github/workflows/create-debs.yml
+++ b/.github/workflows/create-debs.yml
@@ -61,6 +61,35 @@ jobs:
           retention-days: 7
           path: |
             ${{ runner.temp }}/edgesec-${{ matrix.cmake-preset }}/
+  coverage:
+    name: Code Coverage
+    needs:
+      - build
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      # we need to be able to write to a PR to make a comment
+      pull-requests: write
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v3
+      - name: Install Dependencies
+        shell: bash # we're using bash arrays here
+        run: |
+          sudo apt-get update
+          # we need lcov to generate coverage reports
+          sudo apt-get install devscripts equivs lcov -y # install mk-build-depends
+          sudo mk-build-deps --install --tool='apt-get -o Debug::pkgProblemResolver=yes --no-install-recommends --yes'  debian/control
+      - run: cmake --preset coverage
+      - run: cmake --build --preset coverage
+      - name: Report code coverage
+        uses: zgosalvez/github-actions-report-lcov@v1
+        with:
+          coverage-files: build/coverage/*.info
+          minimum-coverage: 0
+          artifact-name: code-coverage-report
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+
   build-deb:
     name: Build Debian Package
     # building a deb is super slow, but we're a public repo now, so it's free!!

--- a/.github/workflows/create-debs.yml
+++ b/.github/workflows/create-debs.yml
@@ -82,13 +82,11 @@ jobs:
           sudo mk-build-deps --install --tool='apt-get -o Debug::pkgProblemResolver=yes --no-install-recommends --yes'  debian/control
       - run: cmake --preset coverage
       - run: cmake --build --preset coverage
-      - name: Report code coverage
-        uses: zgosalvez/github-actions-report-lcov@v1
+      - name: Upload coverage to Codecov
+        uses: codecov/codecov-action@v3
         with:
-          coverage-files: build/coverage/*.info
-          minimum-coverage: 0
-          artifact-name: code-coverage-report
-          github-token: ${{ secrets.GITHUB_TOKEN }}
+          files: build/coverage/coverage.info
+          fail_ci_if_error: true
 
   build-deb:
     name: Build Debian Package

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -80,6 +80,7 @@ if (USE_CRYPTO_SERVICE)
 endif ()
 
 option(USE_ZYMKEY4_HSM "Use the Zymkey4 HSM" OFF)
+option(CONFIGURE_COVERAGE "Configure for code coverage (requires lcov)" OFF)
 
 # Set a default build type if none was specified
 if(NOT CMAKE_BUILD_TYPE AND NOT CMAKE_CONFIGURATION_TYPES)
@@ -123,10 +124,6 @@ set(CMAKE_C_STANDARD 11) # we use C11 raw-strings
 set(CMAKE_C_STANDARD_REQUIRED TRUE)
 set(CMAKE_C_EXTENSIONS ON) # We use GNU C specific features
 set(CMAKE_C_FLAGS "-Wunused-variable -Wall -Wextra")
-
-# set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -fprofile-arcs")
-# set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -ftest-coverage")
-# set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -DDEBUG_LIBNL")
 
 set(CMAKE_CXX_STANDARD 11)
 set(CMAKE_CXX_STANDARD_REQUIRED ON)
@@ -172,10 +169,21 @@ configure_file(
 include(doxygen)
 
 if (NOT BUILD_ONLY_DOCS)
-  add_subdirectory(src)
   if (NOT CMAKE_CROSSCOMPILING)
+    if (CONFIGURE_COVERAGE)
+      include(CodeCoverage)
+      # enable before the src() flag to enable code coverage
+      append_coverage_compiler_flags()
+      setup_target_for_coverage_lcov(
+        NAME coverage
+        EXECUTABLE ctest -j "${PROCESSOR_COUNT}"
+        EXCLUDE "${PROJECT_SOURCE_DIR}/lib/*"
+      )
+    endif()
+
     add_subdirectory(tests)
   endif ()
+  add_subdirectory(src)
   include(install)
 endif ()
 

--- a/CMakePresets.json
+++ b/CMakePresets.json
@@ -36,6 +36,15 @@
       }
     },
     {
+      "name": "coverage",
+      "displayName": "Code-Coverage",
+      "description": "Configure for code coverage",
+      "inherits": "linux",
+      "cacheVariables": {
+        "CONFIGURE_COVERAGE": true
+      }
+    },
+    {
       "name": "linux-with-crypt",
       "inherits": "default",
       "displayName": "Linux (with crypto service)",
@@ -181,6 +190,14 @@
     {
       "name": "openwrt-21.02.1/bcm27xx/bcm2710",
       "configurePreset": "openwrt-21.02.1/bcm27xx/bcm2710"
+    },
+    {
+      "name": "coverage",
+      "configurePreset": "coverage",
+      "targets": [
+        "all",
+        "coverage"
+      ]
     }
   ],
   "testPresets": [

--- a/debian/copyright
+++ b/debian/copyright
@@ -10,6 +10,11 @@ Files: *
 Copyright: 2020-2021, NquiringMinds Ltd.
 License: LGPL-3+
 
+Files: CMakeModules/CodeCoverage.cmake
+Copyright: 2012 - 2017, Lars Bilke
+License: BSD-3-clause
+Source: https://github.com/bilke/cmake-modules/blob/master/CodeCoverage.cmake
+
 Files: CMakeModules/FindLibUUID.cmake
 Copyright: 2000-2022 Kitware, Inc. and Contributors
 License: BSD-3-clause


### PR DESCRIPTION
It seems like the `CMake/CodeCoverage.cmake` file wasn't being used, so I quickly added a GitHub Action for it.

Currently, the coverage action runs after all tests pass, since it only makes sense to check coverage if tests pass. I've also kept it as a separate `cmake` action, as it requires `lcov`, which is not normally installed by people.