### PR TITLE
Fix failing WITH_CRYPT_SERVICE test

### DIFF
--- a/CMakePresets.json
+++ b/CMakePresets.json
@@ -212,6 +212,10 @@
     {
       "name": "linux-with-example-middlewares",
       "configurePreset": "linux-with-example-middlewares"
+    },
+    {
+      "name": "linux-with-crypt",
+      "configurePreset": "linux-with-crypt"
     }
   ]
 }

--- a/src/utils/sqliteu.c
+++ b/src/utils/sqliteu.c
@@ -27,38 +27,32 @@ int execute_sqlite_query(sqlite3 *db, const char *statement) {
   return 0;
 }
 
-int prepare_find_table(sqlite3 *db, const char *table_name, sqlite3_stmt *res) {
-  char *sql = "SELECT name FROM sqlite_master WHERE type='table' AND name=?;";
-  int rc = sqlite3_prepare_v2(db, sql, -1, &res, 0);
-
-  if (rc == SQLITE_OK) {
-    log_trace("%s", sql);
-    sqlite3_bind_text(res, 1, table_name, -1, NULL);
-  } else {
-    return -1 * rc;
-  }
-
-  return SQLITE_OK;
-}
-
-int check_table_exists(sqlite3 *db, char *table_name) {
+int check_table_exists(sqlite3 *db, const char *table_name) {
   sqlite3_stmt *res = NULL;
-  int rc;
 
-  if ((rc = prepare_find_table(db, table_name, res)) != SQLITE_OK) {
-    log_error("Failed to execute statement: %s", sqlite3_errmsg(db));
-    sqlite3_finalize(res);
+  const char *sql =
+      "SELECT name FROM sqlite_master WHERE type='table' AND name=?;";
+  if (sqlite3_prepare_v2(db, sql, -1, &res, 0) != SQLITE_OK) {
+    log_trace("Preparing %s failed due to %s", sql, sqlite3_errmsg(db));
     return -1;
   }
 
-  rc = sqlite3_step(res);
-
-  if (rc == SQLITE_ROW) {
-    log_trace("Found table %s", sqlite3_column_text(res, 0));
-    sqlite3_finalize(res);
-    return 1;
+  if (sqlite3_bind_text(res, 1, table_name, -1, SQLITE_STATIC) != SQLITE_OK) {
+    log_trace("Binding params failed due to %s", sqlite3_errmsg(db));
+    return -1;
   }
 
-  sqlite3_finalize(res);
-  return 0;
+  switch (sqlite3_step(res)) {
+    case SQLITE_ROW:
+      log_trace("Found table %s", sqlite3_column_text(res, 0));
+      sqlite3_finalize(res);
+      return 1;
+    case SQLITE_DONE:
+      sqlite3_finalize(res);
+      return 0;
+    default:
+      log_error("Failed to get results: %s", sqlite3_errmsg(db));
+      sqlite3_finalize(res);
+      return -1;
+  }
 }

--- a/src/utils/sqliteu.h
+++ b/src/utils/sqliteu.h
@@ -32,5 +32,5 @@ int execute_sqlite_query(sqlite3 *db, const char *statement);
  * @param table_name The table name
  * @return int 0 if it doesn't exist, 1 if it excists and -1 on failure
  */
-int check_table_exists(sqlite3 *db, char *table_name);
+int check_table_exists(sqlite3 *db, const char *table_name);
 #endif

--- a/tests/crypt/CMakeLists.txt
+++ b/tests/crypt/CMakeLists.txt
@@ -13,7 +13,7 @@ add_executable(test_crypt_service test_crypt_service.c)
 target_link_libraries(test_crypt_service PRIVATE crypt_service sqlite_crypt_writer sqliteu os log cmocka::cmocka)
 set_target_properties(test_crypt_service
   PROPERTIES
-  LINK_FLAGS  "-Wl,--wrap=sqlite3_open -Wl,--wrap=sqlite3_close -Wl,--wrap=crypto_decrypt -Wl,--wrap=init_hsm"
+  LINK_FLAGS  "-Wl,--wrap=crypto_decrypt -Wl,--wrap=init_hsm"
 )
 
 add_test(NAME test_sqlite_crypt_writer COMMAND test_sqlite_crypt_writer)

--- a/tests/crypt/test_crypt_service.c
+++ b/tests/crypt/test_crypt_service.c
@@ -50,6 +50,7 @@ static void test_load_crypt_service(void **state) {
   int rc = sqlite3_open("file::memory:?cache=shared", &db);
   assert_int_equal(rc, 0);
 
+  expect_function_call(__wrap_crypto_decrypt);
   ctx = load_crypt_service("file::memory:?cache=shared", "key", secret, 4);
   assert_non_null(ctx);
 

--- a/tests/crypt/test_crypt_service.c
+++ b/tests/crypt/test_crypt_service.c
@@ -16,33 +16,13 @@
 #include "utils/sqliteu.h"
 #include "crypt/crypt_service.h"
 
-static sqlite3 *global_db = NULL;
-
-extern int __real_sqlite3_close(sqlite3 *db);
 extern int __real_crypto_decrypt(uint8_t *in, int in_size, uint8_t *key,
                                  uint8_t *iv, uint8_t *out);
-extern int __real_sqlite3_open(const char *filename, sqlite3 **ppDb);
-
-int __wrap_sqlite3_open(const char *filename, sqlite3 **ppDb) {
-  if (strcmp(filename, "global_db") == 0) {
-    *ppDb = global_db;
-    return SQLITE_OK;
-  } else
-    return __real_sqlite3_open(":memory:", ppDb);
-}
 
 int __wrap_crypto_decrypt(uint8_t *in, int in_size, uint8_t *key, uint8_t *iv,
                           uint8_t *out) {
   function_called();
   return __real_crypto_decrypt(in, in_size, key, iv, out);
-}
-
-int __wrap_sqlite3_close(sqlite3 *db) {
-  if (db == global_db) {
-    return SQLITE_OK;
-  }
-
-  return __real_sqlite3_close(db);
 }
 
 struct hsm_context *__wrap_init_hsm(void) {
@@ -66,29 +46,33 @@ static void test_load_crypt_service(void **state) {
   ctx = load_crypt_service("", "key", secret, 0);
   assert_null(ctx);
 
-  __real_sqlite3_open(":memory:", &global_db);
-  ctx = load_crypt_service("global_db", "key", secret, 4);
+  sqlite3 *db = NULL;
+  int rc = sqlite3_open("file::memory:?cache=shared", &db);
+  assert_int_equal(rc, 0);
+
+  ctx = load_crypt_service("file::memory:?cache=shared", "key", secret, 4);
   assert_non_null(ctx);
 
   expect_function_call(__wrap_crypto_decrypt);
-  ctx1 = load_crypt_service("global_db", "key", secret, 4);
+  ctx1 = load_crypt_service("file::memory:?cache=shared", "key", secret, 4);
   assert_non_null(ctx1);
   free_crypt_service(ctx);
   free_crypt_service(ctx1);
-  __real_sqlite3_close(global_db);
-  global_db = NULL;
+  sqlite3_close(db);
+  db = NULL;
 
-  __real_sqlite3_open(":memory:", &global_db);
+  rc = sqlite3_open("file::memory:?cache=shared", &db);
+  assert_int_equal(rc, 0);
   ignore_function_calls(__wrap_crypto_decrypt);
-  ctx = load_crypt_service("global_db", "key", secret, 4);
+  ctx = load_crypt_service("file::memory:?cache=shared", "key", secret, 4);
   assert_non_null(ctx);
 
-  ctx1 = load_crypt_service("global_db", "key", secret1, 4);
+  ctx1 = load_crypt_service("file::memory:?cache=shared", "key", secret1, 4);
   assert_null(ctx1);
   free_crypt_service(ctx);
   free_crypt_service(ctx1);
-  __real_sqlite3_close(global_db);
-  global_db = NULL;
+  sqlite3_close(db);
+  db = NULL;
 }
 
 static void test_put_crypt_pair(void **state) {

--- a/tests/utils/CMakeLists.txt
+++ b/tests/utils/CMakeLists.txt
@@ -20,6 +20,9 @@ target_link_libraries(test_net PRIVATE net cmocka::cmocka)
 add_executable(test_os test_os.c)
 target_link_libraries(test_os PRIVATE os hashmap cmocka::cmocka)
 
+add_executable(test_sqliteu test_sqliteu.c)
+target_link_libraries(test_sqliteu PRIVATE sqliteu cmocka::cmocka)
+
 add_executable(test_hashmap test_hashmap.c)
 target_link_libraries(test_hashmap PRIVATE hashmap cmocka::cmocka)
 
@@ -62,6 +65,11 @@ add_test(NAME test_os COMMAND test_os)
 set_tests_properties(test_os
   PROPERTIES
   WILL_FAIL FALSE)
+
+add_test(NAME test_sqliteu COMMAND test_sqliteu)
+  set_tests_properties(test_sqliteu
+    PROPERTIES
+    WILL_FAIL FALSE)
 
 add_test(NAME test_hashmap COMMAND test_hashmap)
 set_tests_properties(test_hashmap

--- a/tests/utils/test_sqliteu.c
+++ b/tests/utils/test_sqliteu.c
@@ -1,0 +1,82 @@
+#include <stdarg.h>
+#include <stddef.h>
+#include <setjmp.h>
+#include <cmocka.h>
+
+#include "utils/sqliteu.h"
+
+static void test_execute_sqlite_query(void **state) {
+  (void)state; /* unused */
+
+  sqlite3 *db = NULL;
+  assert_int_equal(sqlite3_open(":memory:", &db), SQLITE_OK);
+
+  // check whether invalid statemens fail
+  assert_int_equal(execute_sqlite_query(db, "sqlite3 syntax error"), -1);
+
+  // check whether a table is added due to the command being ran
+  assert_int_equal(check_table_exists(db, "example"), 0);
+  assert_int_equal(execute_sqlite_query(db, "CREATE TABLE example(column);"),
+                   0);
+  assert_int_equal(check_table_exists(db, "example"), 1);
+
+  sqlite3_close(db);
+}
+
+static void test_check_table_exists(void **state) {
+  (void)state; /* unused */
+
+  sqlite3 *db = NULL;
+
+  // should throw an error since db is null
+  assert_int_equal(check_table_exists(db, "invalid-db"), -1);
+
+  assert_int_equal(sqlite3_open("file::memory:?cache=shared", &db), SQLITE_OK);
+  assert_int_equal(check_table_exists(db, "no-table"), 0);
+
+  execute_sqlite_query(db, "CREATE TABLE example(column);");
+  assert_int_equal(check_table_exists(db, "example"), 1);
+
+  // should throw an error, since can't check_table_exists on locked database
+  {
+    sqlite3 *db_connection_2 = NULL;
+    assert_int_equal(
+        sqlite3_open("file::memory:?cache=shared", &db_connection_2),
+        SQLITE_OK);
+
+    assert_int_equal(
+        execute_sqlite_query(db_connection_2, "BEGIN EXCLUSIVE TRANSACTION;"),
+        0);
+    assert_int_equal(check_table_exists(db, "example"), -1);
+    assert_int_equal(
+        execute_sqlite_query(db_connection_2, "COMMIT TRANSACTION;"), 0);
+
+    sqlite3_close(db_connection_2);
+  }
+
+  // should throw an error since table name is too long
+  {
+    // limit table name to certain length
+
+    int original_limit = sqlite3_limit(db, SQLITE_LIMIT_LENGTH, 1024);
+    char super_long_table_name[2048];
+    memset(super_long_table_name, 'a', 2048);
+    super_long_table_name[2047] = '\n';
+    assert_int_equal(check_table_exists(db, super_long_table_name), -1);
+    sqlite3_limit(db, SQLITE_LIMIT_LENGTH, original_limit);
+  }
+
+  sqlite3_close(db);
+}
+
+int main(int argc, char *argv[]) {
+  (void)argc;
+  (void)argv;
+
+  const struct CMUnitTest tests[] = {
+      cmocka_unit_test(test_check_table_exists),
+      cmocka_unit_test(test_execute_sqlite_query),
+  };
+
+  return cmocka_run_group_tests(tests, NULL, NULL);
+}


### PR DESCRIPTION
Adds CI tests for `linux-with-crypt`.

After adding these tests, I found that the tests were failing, since the `prepare_find_table` function was failing to find the `store` database, due to an `SQLITE_MISUSE` error.

I did a bit of refactoring to simplify the function and add error handling and the function and tests seem to work now.

**Draft until #227 is merged**