### PR TITLE
Fix CMake CMP0135 configure warning

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,6 +1,5 @@
-cmake_minimum_required(VERSION 3.14.0) # required by lib/sqlite.cmake
-
-cmake_policy(SET CMP0048 NEW)
+cmake_minimum_required(VERSION 3.14.0) # required for FindSQLite3
+cmake_policy(VERSION 3.14.0...3.24.0)
 
 project(EDGESEC
   VERSION 0.0.8

--- a/CMakeModules/CMakeToolchains/DefineOpenWRTSDKToolchain.cmake
+++ b/CMakeModules/CMakeToolchains/DefineOpenWRTSDKToolchain.cmake
@@ -34,6 +34,7 @@ to avoid redownloading the OpenWRT SDK.
 
 #]=======================================================================]
 cmake_minimum_required(VERSION 3.9.0)
+cmake_policy(VERSION 3.9.0...3.24.0)
 
 function(defineOpenwrtSDKToolchain)
     set(

--- a/lib/hostapd.cmake
+++ b/lib/hostapd.cmake
@@ -1,7 +1,6 @@
 # Builds hostapd using ExternalProject
 
 # v3.14.0+ is required by BUILD_IN_SOURCE + SOURCE_SUBDIR together
-cmake_minimum_required(VERSION 3.14.0)
 include(ExternalProject)
 
 if (BUILD_HOSTAPD AND NOT (BUILD_ONLY_DOCS))

--- a/lib/openssl.cmake
+++ b/lib/openssl.cmake
@@ -1,4 +1,3 @@
-cmake_minimum_required(VERSION 3.11.0) # required by FetchContent
 include(FetchContent)
 
 if (USE_CRYPTO_SERVICE)

--- a/lib/sqlite.cmake
+++ b/lib/sqlite.cmake
@@ -1,5 +1,4 @@
 # Compile libsqlite
-cmake_minimum_required(VERSION 3.14.0) # FindSQLite3.cmake is only in 3.14.0 and later
 include(CheckLibraryExists)
 include(ExternalProject)
 


### PR DESCRIPTION
On CMake v3.24.0, edgesec currently prints the following warning multiple times:

```
CMake Warning (dev) at /snap/cmake/1147/share/cmake-3.24/Modules/ExternalProject.cmake:3071 (message):
  The DOWNLOAD_EXTRACT_TIMESTAMP option was not given and policy CMP0135 is
  not set.  The policy's OLD behavior will be used.  When using a URL
  download, the timestamps of extracted files should preferably be that of
  the time of extraction, otherwise code that depends on the extracted
  contents might not be rebuilt if the URL changes.  The OLD behavior
  preserves the timestamps from the archive instead, but this is usually not
  what you want.  Update your project to the NEW behavior or specify the
  DOWNLOAD_EXTRACT_TIMESTAMP option with a value of true to avoid this
  robustness issue.
```

By setting `cmake_policy(VERSION 3.14.0...3.24.0)`, CMake will automatically enable all policies up to version `v3.24.0`, which hides these warnings.

We have to remove all the `cmake_minimum_required...` commands from the `lib/` directory, since otherwise they overwrite the settings from the root `CMakeLists.txt`.