### PR TITLE
ci: output on ctest failure

### DIFF
--- a/.github/workflows/create-debs.yml
+++ b/.github/workflows/create-debs.yml
@@ -41,7 +41,7 @@ jobs:
         name: Test
         run: |
           if ctest --list-presets | grep -s "${{ matrix.cmake-preset }}"; then
-            ctest --test-dir build/ --preset "${{ matrix.cmake-preset }}"
+            ctest --test-dir build/ --preset "${{ matrix.cmake-preset }}" --output-on-failure
             echo "::set-output name=tested::true"
           else
             echo "::set-output name=tested::false"

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -183,9 +183,14 @@ if (NOT BUILD_ONLY_DOCS)
       include(CodeCoverage)
       # enable before the src() flag to enable code coverage
       append_coverage_compiler_flags()
+
+      include(ProcessorCount)
+      ProcessorCount(PROCESSOR_COUNT)
+
       setup_target_for_coverage_lcov(
         NAME coverage
-        EXECUTABLE ctest -j "${PROCESSOR_COUNT}" --output-on-failure
+        EXECUTABLE ctest
+        EXECUTABLE_ARGS --output-on-failure -j "${PROCESSOR_COUNT}"
         EXCLUDE "${PROJECT_SOURCE_DIR}/lib/*"
       )
     endif()

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -185,7 +185,7 @@ if (NOT BUILD_ONLY_DOCS)
       append_coverage_compiler_flags()
       setup_target_for_coverage_lcov(
         NAME coverage
-        EXECUTABLE ctest -j "${PROCESSOR_COUNT}"
+        EXECUTABLE ctest -j "${PROCESSOR_COUNT}" --output-on-failure
         EXCLUDE "${PROJECT_SOURCE_DIR}/lib/*"
       )
     endif()


### PR DESCRIPTION
Prints the output of the test if a ctest test fails.

This will help with debugging failing CI tests.