### PR TITLE
Test OpenWRT in CI

### DIFF
--- a/.github/workflows/create-debs.yml
+++ b/.github/workflows/create-debs.yml
@@ -32,16 +32,15 @@ jobs:
           sudo mk-build-deps --install --tool='apt-get -o Debug::pkgProblemResolver=yes --no-install-recommends --yes'  debian/control
       - name: Configure
         run: |
-          cmake -B build/ --preset "${{ matrix.cmake-preset }}" -DCONFIGURE_COVERAGE=BOOL:ON
+          cmake --preset "${{ matrix.cmake-preset }}" -DCONFIGURE_COVERAGE=BOOL:ON
       - name: Build
         run: |
-          # can't use --preset "${{ matrix.cmake-preset }}" since we want to specify a custom build dir
-          cmake --build build/ --parallel "$(($(nproc) + 1))"
+          cmake --build --preset "${{ matrix.cmake-preset }}" --parallel "$(($(nproc) + 1))"
       - id: test
         name: Test
         run: |
           if ctest --list-presets | grep -s "${{ matrix.cmake-preset }}"; then
-            ctest --test-dir build/ --preset "${{ matrix.cmake-preset }}" --output-on-failure
+            ctest --preset "${{ matrix.cmake-preset }}" --output-on-failure
             echo "::set-output name=tested::true"
           else
             echo "::set-output name=tested::false"
@@ -50,17 +49,21 @@ jobs:
         # code coverage only works if ctest works
         if: steps.test.outputs.tested == 'true'
         run: |
-          cmake --build build/ --parallel "$(($(nproc) + 1))" --target coverage
-          mv build/coverage.info "build/coverage-${{ matrix.cmake-preset }}.info"
+          cmake --build --preset "${{ matrix.cmake-preset }}" --parallel "$(($(nproc) + 1))" --target coverage
+          mv "build/${{ matrix.cmake-preset }}/coverage.info" "build/${{ matrix.cmake-preset }}/coverage-${{ matrix.cmake-preset }}.info"
+        env:
+          # --target coverage runs CTest internally, but it doesn't load our
+          # custom LD_LIBRARY_PATH from our ctest's cmake-presets file
+          LD_LIBRARY_PATH: ${{ github.workspace }}/build/${{ matrix.cmake-preset }}/lib/ubox/lib
       - name: Archive code coverage results
         if: steps.test.outputs.tested == 'true'
         uses: actions/upload-artifact@v3
         with:
           name: code-coverage-lcov
-          path: build/coverage-${{ matrix.cmake-preset }}.info
+          path: build/${{ matrix.cmake-preset }}/coverage-${{ matrix.cmake-preset }}.info
       - name: Install to ${{ runner.temp }}/edgesec-${{ matrix.cmake-preset }}/
         run: |
-          cmake --install build/ --prefix "${{ runner.temp }}/edgesec-${{ matrix.cmake-preset }}"
+          cmake --install "build/${{ matrix.cmake-preset }}" --prefix "${{ runner.temp }}/edgesec-${{ matrix.cmake-preset }}"
       - name: Escape invalid chars in artifact name
         id: escape_preset
         run: |

--- a/CMakePresets.json
+++ b/CMakePresets.json
@@ -199,6 +199,18 @@
     {
       "name": "linux-with-crypt",
       "configurePreset": "linux-with-crypt"
+    },
+    {
+      "name": "openwrt",
+      "configurePreset": "openwrt",
+      "environment": {
+        "LD_LIBRARY_PATH": "${sourceDir}/build/${presetName}/lib/ubox/lib"
+      }
+    },
+    {
+      "name": "openwrt-with-header",
+      "configurePreset": "openwrt-with-header",
+      "inherits": "openwrt"
     }
   ]
 }

--- a/src/utils/uci_wrt.c
+++ b/src/utils/uci_wrt.c
@@ -563,6 +563,9 @@ int uwrt_create_interface(struct uctx *context, char *ifname, char *type,
   sprintf(property, "network.%s=interface", ifname);
   utarray_push_back(properties, &property);
 
+  sprintf(property, "network.%s.ifname=%s", ifname, ifname);
+  utarray_push_back(properties, &property);
+
   sprintf(property, "network.%s.enabled=1", ifname);
   utarray_push_back(properties, &property);
 

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -2,6 +2,15 @@ include_directories (
   "${PROJECT_SOURCE_DIR}/src"
 )
 
+if (USE_UCI_SERVICE)
+  add_compile_definitions(TEST_UCI_CONFIG_DIR="${CMAKE_SOURCE_DIR}/tests/data/uci")
+  add_library(
+    __wrap_uwrt_init_context OBJECT ./utils/__wrap_uwrt_init_context.c
+  )
+  target_link_libraries(__wrap_uwrt_init_context PRIVATE uci_wrt)
+  target_link_options(__wrap_uwrt_init_context PUBLIC "-Wl,--wrap=uwrt_init_context")
+endif ()
+
 if (USE_CAPTURE_SERVICE)
   add_subdirectory(capture)
 endif ()
@@ -36,6 +45,9 @@ if (USE_RADIUS_SERVICE)
 endif()
 if (USE_MDNS_SERVICE)
   set(TEST_RUNCTL_PROPS "${TEST_RUNCTL_PROPS} -Wl,--wrap=run_mdns_thread")
+endif()
+if (USE_UCI_SERVICE)
+  target_link_libraries(test_runctl PUBLIC __wrap_uwrt_init_context)
 endif()
 
 set_target_properties(test_runctl PROPERTIES LINK_FLAGS ${TEST_RUNCTL_PROPS})

--- a/tests/ap/CMakeLists.txt
+++ b/tests/ap/CMakeLists.txt
@@ -9,6 +9,10 @@ set_target_properties(test_hostapd
   LINK_FLAGS  "-Wl,--wrap=kill_process -Wl,--wrap=signal_process -Wl,--wrap=reset_interface -Wl,--wrap=run_process -Wl,--wrap=list_dir -Wl,--wrap=check_sock_file_exists"
 )
 
+if (USE_UCI_SERVICE)
+  target_link_libraries(test_hostapd PRIVATE __wrap_uwrt_init_context)
+endif()
+
 add_executable(test_ap_service test_ap_service.c)
 target_link_libraries(test_ap_service PRIVATE ap_service hostapd iface os log cmocka::cmocka)
 # sqlite3.h required by src/supervisor/supervisor_config.h

--- a/tests/ap/test_hostapd.c
+++ b/tests/ap/test_hostapd.c
@@ -21,6 +21,9 @@
 #include "ap/ap_config.h"
 #include "ap/hostapd.h"
 
+// seems to be hard coded in hostapd.c
+#define WITH_HOSTAPD_UCI
+
 static char *test_hostapd_vlan_file = "/tmp/hostapd-test.vlan";
 static char *test_hostapd_conf_file = "/tmp/hostapd-test.conf";
 static char *test_hostapd_conf_content = "interface=wlan0\n"
@@ -98,6 +101,7 @@ static void test_generate_hostapd_conf(void **state) {
   struct apconf hconf;
   strcpy(hconf.ap_file_path, test_hostapd_conf_file);
   strcpy(hconf.interface, "wlan0");
+  strcpy(hconf.device, "wl0");
   strcpy(hconf.ssid, "IOTH_IMX7");
   strcpy(hconf.wpa_passphrase, "1234554321");
   strcpy(hconf.driver, "nl80211");
@@ -129,6 +133,10 @@ static void test_generate_hostapd_conf(void **state) {
   int ret = generate_hostapd_conf(&hconf, &rconf);
   assert_int_equal(ret, 0);
 
+#if (defined(WITH_UCI_SERVICE) && defined(WITH_HOSTAPD_UCI))
+  // no tests yet written
+#else
+  log_debug("Opening hostapd_conf_file at %s", test_hostapd_conf_file);
   FILE *fp = fopen(test_hostapd_conf_file, "r");
   assert_non_null(fp);
 
@@ -148,6 +156,7 @@ static void test_generate_hostapd_conf(void **state) {
 
   fclose(fp);
   free(buffer);
+#endif
 }
 
 static void test_generate_vlan_conf(void **state) {
@@ -190,7 +199,11 @@ static void test_run_ap_process(void **state) {
   strcpy(hconf.ap_file_path, test_hostapd_conf_file);
   strcpy(hconf.ap_log_path, test_ap_log_path);
 
+#if (defined(WITH_UCI_SERVICE) && defined(WITH_HOSTAPD_UCI))
+  // using hostapd uci doesn't kill hostapd
+#else
   expect_any(__wrap_kill_process, proc_name);
+#endif
   int ret = run_ap_process(&hconf);
   assert_int_equal(ret, 0);
 
@@ -209,7 +222,11 @@ static void test_kill_ap_process(void **state) {
   strcpy(hconf.ap_file_path, test_hostapd_conf_file);
   strcpy(hconf.ap_log_path, test_ap_log_path);
 
+#if (defined(WITH_UCI_SERVICE) && defined(WITH_HOSTAPD_UCI))
+  // using hostapd uci doesn't kill hostapd
+#else
   expect_any(__wrap_kill_process, proc_name);
+#endif
   int ret = run_ap_process(&hconf);
   assert_int_equal(ret, 0);
 
@@ -228,7 +245,11 @@ static void test_signal_ap_process(void **state) {
   strcpy(hconf.ap_file_path, test_hostapd_conf_file);
   strcpy(hconf.ap_log_path, test_ap_log_path);
 
+#if (defined(WITH_UCI_SERVICE) && defined(WITH_HOSTAPD_UCI))
+  // using hostapd uci doesn't kill hostapd
+#else
   expect_any(__wrap_kill_process, proc_name);
+#endif
   int ret = run_ap_process(&hconf);
   assert_int_equal(ret, 0);
 

--- a/tests/dhcp/CMakeLists.txt
+++ b/tests/dhcp/CMakeLists.txt
@@ -8,6 +8,9 @@ set_target_properties(test_dnsmasq
   PROPERTIES
   LINK_FLAGS  "-Wl,--wrap=kill_process -Wl,--wrap=run_process -Wl,--wrap=is_proc_running -Wl,--wrap=signal_process"
 )
+if (USE_UCI_SERVICE)
+  target_link_libraries(test_dnsmasq PRIVATE __wrap_uwrt_init_context)
+endif()
 
 add_executable(test_dhcp_service test_dhcp_service.c)
 target_link_libraries(test_dhcp_service PRIVATE dhcp_service dnsmasq log cmocka::cmocka)

--- a/tests/dhcp/test_dnsmasq.c
+++ b/tests/dhcp/test_dnsmasq.c
@@ -162,11 +162,14 @@ err:
 
 static void test_generate_dnsmasq_conf(void **state) {
   (void)state; /* unused */
-  struct dhcp_conf dconf;
-  UT_array *server_arr;
-  config_dhcpinfo_t el;
-
+  struct dhcp_conf dconf = {
+      // must manually set bridge_prefix, otherwise we'll be working with
+      // undefined memory
+      .bridge_prefix = "",
+  };
   utarray_new(dconf.config_dhcpinfo_array, &config_dhcpinfo_icd);
+
+  UT_array *server_arr;
   utarray_new(server_arr, &ut_str_icd);
 
   strcpy(dconf.dhcp_conf_path, test_dhcp_conf_path);
@@ -177,6 +180,7 @@ static void test_generate_dnsmasq_conf(void **state) {
   strncpy(dconf.wifi_interface, wifi_interface, WIFI_INTERFACE_STR_LEN);
   assert_null(dconf.wifi_interface[WIFI_INTERFACE_STR_LEN - 1]);
 
+  config_dhcpinfo_t el;
   assert_true(
       get_config_dhcpinfo("0,10.0.0.2,10.0.0.254,255.255.255.0,24h", &el));
   utarray_push_back(dconf.config_dhcpinfo_array, &el);
@@ -195,13 +199,19 @@ static void test_generate_dnsmasq_conf(void **state) {
   error_t ret = generate_dnsmasq_conf(&dconf, server_arr);
   assert_true(ret == 0);
 
-  char *fdata = NULL;
-  assert_int_equal(read_file_string(test_dhcp_conf_path, &fdata), 0);
+#ifdef WITH_UCI_SERVICE
+  // todo: add some tests for dnsmasq UCI conf
+#else
+  {
+    char *fdata = NULL;
+    assert_int_equal(read_file_string(test_dhcp_conf_path, &fdata), 0);
 
-  int cmp = strcmp(fdata, test_dhcp_conf_wifi_if);
-  assert_int_equal(cmp, 0);
+    int cmp = strcmp(fdata, test_dhcp_conf_wifi_if);
+    assert_int_equal(cmp, 0);
 
-  os_free(fdata);
+    os_free(fdata);
+  }
+#endif
 
   const size_t INTERFACE_PREFIX_STR_LEN = ARRAY_SIZE(dconf.interface_prefix);
 
@@ -211,13 +221,19 @@ static void test_generate_dnsmasq_conf(void **state) {
   ret = generate_dnsmasq_conf(&dconf, server_arr);
   assert_true(ret == 0);
 
-  assert_int_equal(read_file_string(test_dhcp_conf_path, &fdata), 0);
+#ifdef WITH_UCI_SERVICE
+  // todo: add some tests for dnsmasq UCI conf
+#else
+  {
+    char *fdata = NULL;
+    assert_int_equal(read_file_string(test_dhcp_conf_path, &fdata), 0);
 
-  printf("%s", fdata);
-  cmp = strcmp(fdata, test_dhcp_conf_prefix_if);
-  assert_int_equal(cmp, 0);
+    int cmp = strcmp(fdata, test_dhcp_conf_prefix_if);
+    assert_int_equal(cmp, 0);
 
-  os_free(fdata);
+    os_free(fdata);
+  }
+#endif
 
   utarray_free(server_arr);
   utarray_free(dconf.config_dhcpinfo_array);
@@ -293,7 +309,11 @@ static void test_clear_dhcp_lease_entry(void **state) {
 static void test_run_dhcp_process(void **state) {
   (void)state;
 
+#ifdef WITH_UCI_SERVICE
+  // todo: add some tests for dnsmasq UCI conf
+#else
   expect_string(__wrap_kill_process, proc_name, "dnsmasq");
+#endif
   expect_string(__wrap_is_proc_running, name, "dnsmasq");
   char *ret = run_dhcp_process("/tmp/sbin/dnsmasq", "/tmp/dnsmasq.conf");
   assert_non_null(ret);
@@ -310,8 +330,11 @@ static void test_kill_dhcp_process(void **state) {
 
 static void test_signal_dhcp_process(void **state) {
   (void)state;
-
+#ifdef WITH_UCI_SERVICE
+  // signal_dhcp_process does nothing in UCI mode
+#else
   expect_string(__wrap_signal_process, proc_name, "dnsmasq");
+#endif
   assert_int_equal(signal_dhcp_process("/tmp/sbin/dnsmasq"), 0);
 }
 

--- a/tests/utils/CMakeLists.txt
+++ b/tests/utils/CMakeLists.txt
@@ -3,7 +3,6 @@ include_directories(
 )
 
 if (USE_UCI_SERVICE)
-  add_compile_definitions(TEST_UCI_CONFIG_DIR="${CMAKE_SOURCE_DIR}/tests/data/uci")
   add_executable(test_uci_wrt test_uci_wrt.c)
   target_link_libraries(test_uci_wrt PRIVATE uci_wrt cmocka::cmocka iface_mapper)
 endif ()

--- a/tests/utils/__wrap_uwrt_init_context.c
+++ b/tests/utils/__wrap_uwrt_init_context.c
@@ -1,0 +1,24 @@
+/**
+ * @file __wrap_uwrt_init_context.c
+ * @author Alois Klink
+ * @date 2022
+ * @copyright
+ * SPDX-FileCopyrightText: © 2022 NQMCyber Ltd and edgesec contributors
+ * SPDX-License-Identifier: LGPL-3.0-or-later
+ * @brief Unit test wrapper function for uwrt_init_context to use
+ * TEST_UCI_CONFIG_DIR Link unit tests with `-Wl,--wrap=uwrt_init_context`
+ */
+#include "utils/uci_wrt.h"
+
+extern struct uctx *__real_uwrt_init_context(const char *path);
+
+struct uctx *__wrap_uwrt_init_context(const char *path) {
+  const char *actual_path = path;
+#ifdef TEST_UCI_CONFIG_DIR
+  if (actual_path == NULL) {
+    log_trace("Opening UCI Config in dir %s", TEST_UCI_CONFIG_DIR);
+    actual_path = TEST_UCI_CONFIG_DIR;
+  }
+#endif
+  return __real_uwrt_init_context(actual_path);
+}


### PR DESCRIPTION
Runs the OpenWRT tests in CI.

I had to slightly play around with some stuff to get OpenWRT tests working again.

Firstly, I had to add `LD_LIBRARY_PATH="${sourceDir}/build/${presetName}/lib/ubox/lib"`, see https://github.com/nqminds/edgesec/commit/ee360ebd6e586790c86fdc0245b54690519eb522 to get OpenWRT tests working properly, since even though we set RPATH on our tests, since the tests link to libuci, libuci is the one that needs RPATH to libubox.

This meant I had to modify the CI to use the presets listed in CMakePresets.json (see [ci: use buildDir from CMake presets](https://github.com/nqminds/edgesec/commit/df4bd607c8e66af522c62ef97321e37c3d4590ed)), then I had to add a preset for `openwrt` that set `LD_LIBRARY_PATH` (see [ci: add test config for openwrt](https://github.com/nqminds/edgesec/commit/ee360ebd6e586790c86fdc0245b54690519eb522))

Then, in order to fix the tests, I needed to:

- [test: add __wrap_uwrt_init_context test lib](https://github.com/nqminds/edgesec/commit/e967f82860ab1a240e3b16da5bc50cb2828fe023)
  The `__wrap_uwrt_init_context` test library can be used to wrap `uwrt_init_context()` so that it loads from the `./test/data/uci` folder.
- [tests(hostapd): fix WITH_HOSTAPD_UCI tests](https://github.com/nqminds/edgesec/commit/94f7930b18c1790c9d8ded726964b2d3a4a75b4f)
  The `run_ap_process()` function doesn't call `kill_process()` when WITH_HOSTAPD_UCI is defined.
  Additionally, no `hostapd_conf_file` is written, instead UCI handles writing the configuration file.
- [test: fix dnsmasq tests when using UCI mode](https://github.com/nqminds/edgesec/commit/451f5e1d92b7fc8f2ae59ad9ac90f32c0a54ffc2)
  When running dnsmasq in UCI mode:
  - The `dnsmasq_conf_path` property is ignored, as UCI decides where to store the configuration
  - `kill_process()` is not run when running `run_dhcp_process()`
  - `signal_dhcp_process()` does nothing

  Additionally, we need to make sure that `dhcp_conf.bridge_prefix` is correctly set, otherwise you'll get a bunch of undefined memory, and your tests will work 95% of the time, and fail 5% of the time. (I think it took me about an hour to debug this)
- [refactor: simplify uwrt_create_interface code](https://github.com/nqminds/edgesec/commit/0d16d12fc18473c7be697fb3bf9bc9819b48e89d)
    Some simple refactoring, just to avoid constantly doing `uwrt_set_property()`.
- [fix: set ifname in uwrt_create_interface()](https://github.com/nqminds/edgesec/commit/2ee2ff6f9f0fd5cd0ef4095c79ee899ab113ee78)
    The ifname field wasn't being set in `uwrt_create_interface`, which was causing the `uci_wrt.c` tests to fail.