### PR TITLE
Fully test `make_dirs_to_path()`

### DIFF
--- a/tests/utils/test_os.c
+++ b/tests/utils/test_os.c
@@ -558,6 +558,23 @@ static void test_make_dirs_to_path(void **state) {
   // should return no error code
   assert_int_equal(ret, 0);
 
+  // should return an error on invalid input string
+  ret = make_dirs_to_path(NULL, 0755);
+  assert_int_equal(ret, -1);
+
+  // create a file in the directory
+  FILE *fp = fopen(path, "w");
+  assert_non_null(fp);
+  assert_int_not_equal(fputs("test file, should be deleted", fp), EOF);
+  assert_int_not_equal(fclose(fp), EOF);
+
+  // should throw a ENOTDIR (NOT A DIRECTORY) error when trying to create
+  // folder in `not_a_dir.txt`
+  const *enotdir_path = construct_path(directories_to_build,
+                                       "not_a_dir.txt/new_folder/new_file.txt");
+  assert_int_equal(make_dirs_to_path(enotdir_path, 0755), -1);
+  free(enotdir_path);
+
   free(directories_to_build);
   free(path);
 }

--- a/tests/utils/test_os.c
+++ b/tests/utils/test_os.c
@@ -557,6 +557,9 @@ static void test_make_dirs_to_path(void **state) {
   ret = make_dirs_to_path(path, 0755);
   // should return no error code
   assert_int_equal(ret, 0);
+
+  free(directories_to_build);
+  free(path);
 }
 
 static void test_string_append_char(void **state) {


### PR DESCRIPTION
Adds tests to add full code-coverage to the function `make_dirs_to_path`.

Function docs are here, if you want to know what this function is supposed to do https://nqminds.github.io/edgesec/os_8c.html#ab45d38138784ebb93e2eafbc4b20fbf0

@AshleySetter, no pressure if you don't want to review this :) It's not anything urgent, it's just I wanted to add full test coverage for this function since I was the one that added the function.
