### PR TITLE
build(debian): link to sqlite3/libpcap shared libs

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -148,6 +148,10 @@ include(zymkey4)
 include(uci)
 include(uthash)
 
+# On Linux, creates a Threads::Threads target that points to pthread
+set(THREADS_PREFER_PTHREAD_FLAG TRUE)
+find_package(Threads REQUIRED)
+
 # configure a header file to pass some of the CMake settings
 # to the source code
 configure_file(

--- a/debian/control
+++ b/debian/control
@@ -12,6 +12,7 @@ Build-Depends: debhelper-compat (= 12),
     libssl-dev,
     libcmocka-dev (>=1.1.5),
     libsqlite3-dev (>=3.31.1),
+    libpcap0.8-dev (>=1.9.1),
     libmnl-dev (>= 1.0.4)
 Standards-Version: 4.5.0
 Homepage: https://github.com/nqminds/EDGESec

--- a/debian/control
+++ b/debian/control
@@ -11,6 +11,7 @@ Build-Depends: debhelper-compat (= 12),
     libjson-c-dev,
     libssl-dev,
     libcmocka-dev (>=1.1.5),
+    libsqlite3-dev (>=3.31.1),
     libmnl-dev (>= 1.0.4)
 Standards-Version: 4.5.0
 Homepage: https://github.com/nqminds/EDGESec

--- a/debian/rules
+++ b/debian/rules
@@ -19,6 +19,7 @@ override_dh_auto_configure:
 		 -DUSE_NETLINK_SERVICE=ON\
 		 -DUSE_UCI_SERVICE=OFF\
 		 -DUSE_HEADER_MIDDLEWARE=ON\
+		 -DBUILD_SQLITE_LIB=OFF\
 		 -DBUILD_HOSTAPD=ON
 
 # make sure to always install into `debian/tmp` and use

--- a/debian/rules
+++ b/debian/rules
@@ -20,6 +20,7 @@ override_dh_auto_configure:
 		 -DUSE_UCI_SERVICE=OFF\
 		 -DUSE_HEADER_MIDDLEWARE=ON\
 		 -DBUILD_SQLITE_LIB=OFF\
+		 -DBUILD_PCAP_LIB=OFF\
 		 -DBUILD_HOSTAPD=ON
 
 # make sure to always install into `debian/tmp` and use

--- a/lib/pcap.cmake
+++ b/lib/pcap.cmake
@@ -8,6 +8,7 @@ elseif(NOT BUILD_PCAP_LIB)
 else()
   FetchContent_Declare(
     libpcap
+    # warning, libpcap 1.9.1 is the latest on OpenWRT 19.07 and Ubuntu 20.04
     URL https://github.com/the-tcpdump-group/libpcap/archive/refs/tags/libpcap-1.10.1.tar.gz
     URL_HASH SHA3_256=9aedcbec09b7b3b01c78cc80822c505846d73928a72ae96eb907b1f467eee649
   )

--- a/lib/sqlite.cmake
+++ b/lib/sqlite.cmake
@@ -22,7 +22,7 @@ else()
   message("Downloading and compiling our own libsqlite library")
   ExternalProject_Add(
     libsqlite
-    # v3.31.01 is the version supported by OpenWRT 19.07
+    # v3.31.01 is the version supported by OpenWRT 19.07 and Ubuntu 20.04
     # see https://github.com/openwrt/packages/blob/5a399f144891d6774611c9903f12059270b09ca8/libs/sqlite3/Makefile#L10-L11
     URL https://www.sqlite.org/2020/sqlite-autoconf-3310100.tar.gz
     URL_HASH SHA256=62284efebc05a76f909c580ffa5c008a7d22a1287285d68b7825a2b6b51949ae

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -31,7 +31,12 @@ if (USE_MDNS_SERVICE)
   target_compile_definitions(runctl PUBLIC WITH_MDNS_SERVICE)
   target_link_libraries(runctl PRIVATE mdns_service)
 endif ()
-target_link_libraries(runctl PRIVATE LibUTHash::LibUTHash capture_service net log iface_mapper os sqlite_macconn_writer firewall_service eloop supervisor network_commands mac_mapper ap_service firewall_service dhcp_service)
+target_link_libraries(runctl PRIVATE
+  LibUTHash::LibUTHash capture_service net log iface_mapper os
+  sqlite_macconn_writer firewall_service eloop supervisor
+  network_commands mac_mapper ap_service firewall_service dhcp_service
+  Threads::Threads
+)
 
 add_library(config config.c)
 target_link_libraries(config PUBLIC supervisor_config LibUTHash::LibUTHash PRIVATE minIni os log)
@@ -42,6 +47,6 @@ if (USE_CRYPTO_SERVICE)
 else ()
   target_include_directories(edgesec PRIVATE ${PROJECT_BINARY_DIR})
 endif ()
-target_link_libraries(edgesec PRIVATE eloop config runctl minIni os hashmap)
+target_link_libraries(edgesec PRIVATE eloop config runctl minIni os hashmap Threads::Threads)
 # link time optimization
 set_target_properties(edgesec PROPERTIES INTERPROCEDURAL_OPTIMIZATION TRUE)

--- a/src/capture/CMakeLists.txt
+++ b/src/capture/CMakeLists.txt
@@ -73,7 +73,9 @@ if (USE_CAPTURE_SERVICE)
   target_link_libraries(
     capture_service
     PUBLIC PCAP::pcap middlewares_list
-    PRIVATE dns_decoder pcap_service pcap_queue packet_queue packet_decoder squeue eloop iface log os hashmap SQLite::SQLite3)
+    PRIVATE
+      dns_decoder pcap_service pcap_queue packet_queue packet_decoder squeue
+      eloop iface log os hashmap SQLite::SQLite3 Threads::Threads)
 
   set(CAPTURE_MIDDLEWARES "")
 

--- a/src/capture/capture_service.c
+++ b/src/capture/capture_service.c
@@ -21,6 +21,7 @@
 #include <errno.h>
 #include <linux/if.h>
 #include <libgen.h>
+#include <pthread.h>
 
 #include "capture_config.h"
 #include "capture_service.h"

--- a/src/capture/capture_service.c
+++ b/src/capture/capture_service.c
@@ -21,8 +21,6 @@
 #include <errno.h>
 #include <linux/if.h>
 #include <libgen.h>
-#include <pcap.h>
-#include <pthread.h>
 
 #include "capture_config.h"
 #include "capture_service.h"

--- a/src/config.c
+++ b/src/config.c
@@ -14,7 +14,6 @@
 #include <fcntl.h>
 #include <ctype.h>
 #include <unistd.h>
-#include <pthread.h>
 #include <stdbool.h>
 #include <errno.h>
 

--- a/src/dns/CMakeLists.txt
+++ b/src/dns/CMakeLists.txt
@@ -28,4 +28,5 @@ target_link_libraries(mdns_service
   PRIVATE
     ifaceu net log eloop sockctl squeue hashmap iface_mapper mdns_decoder
     pcap_service packet_queue supervisor_config cmd_processor mcast
+    Threads::Threads
 )

--- a/src/edgesec.c
+++ b/src/edgesec.c
@@ -22,7 +22,6 @@
 #include <sys/socket.h>
 #include <linux/if.h>
 #include <libgen.h>
-#include <pthread.h>
 
 #include "version.h"
 #include "utils/log.h"

--- a/tests/capture/middlewares/CMakeLists.txt
+++ b/tests/capture/middlewares/CMakeLists.txt
@@ -6,7 +6,7 @@ set_target_properties(test_header_middleware
 )
 
 add_executable(test_sqlite_header test_sqlite_header.c)
-target_link_libraries(test_sqlite_header PUBLIC SQLite::SQLite3 PRIVATE sqlite_header os log cmocka::cmocka)
+target_link_libraries(test_sqlite_header PRIVATE sqlite_header os log Threads::Threads cmocka::cmocka)
 
 add_executable(test_packet_queue test_packet_queue.c)
 target_link_libraries(test_packet_queue PUBLIC PCAP::pcap SQLite::SQLite3 PRIVATE packet_queue os log cmocka::cmocka)
@@ -15,7 +15,7 @@ add_executable(test_pcap_queue test_pcap_queue.c)
 target_link_libraries(test_pcap_queue PRIVATE pcap_queue os log cmocka::cmocka)
 
 add_executable(test_sqlite_pcap test_sqlite_pcap.c)
-target_link_libraries(test_sqlite_pcap PUBLIC SQLite::SQLite3 PRIVATE sqlite_pcap sqliteu os log cmocka::cmocka)
+target_link_libraries(test_sqlite_pcap PRIVATE sqlite_pcap sqliteu os log Threads::Threads cmocka::cmocka)
 
 add_test(NAME test_header_middleware COMMAND test_header_middleware)
 set_tests_properties(test_header_middleware

--- a/tests/dhcp/test_dhcp_service.c
+++ b/tests/dhcp/test_dhcp_service.c
@@ -6,7 +6,6 @@
 #include <fcntl.h>
 #include <ctype.h>
 #include <unistd.h>
-#include <pthread.h>
 #include <stdbool.h>
 #include <errno.h>
 #include <net/if.h>

--- a/tests/dhcp/test_dnsmasq.c
+++ b/tests/dhcp/test_dnsmasq.c
@@ -6,7 +6,6 @@
 #include <fcntl.h>
 #include <ctype.h>
 #include <unistd.h>
-#include <pthread.h>
 #include <stdbool.h>
 #include <errno.h>
 #include <net/if.h>

--- a/tests/dns/test_command_mapper.c
+++ b/tests/dns/test_command_mapper.c
@@ -6,7 +6,6 @@
 #include <fcntl.h>
 #include <ctype.h>
 #include <unistd.h>
-#include <pthread.h>
 #include <stdbool.h>
 #include <errno.h>
 #include <net/if.h>

--- a/tests/dns/test_mdns_list.c
+++ b/tests/dns/test_mdns_list.c
@@ -6,7 +6,6 @@
 #include <fcntl.h>
 #include <ctype.h>
 #include <unistd.h>
-#include <pthread.h>
 #include <stdbool.h>
 #include <errno.h>
 #include <net/if.h>

--- a/tests/dns/test_mdns_mapper.c
+++ b/tests/dns/test_mdns_mapper.c
@@ -6,7 +6,6 @@
 #include <fcntl.h>
 #include <ctype.h>
 #include <unistd.h>
-#include <pthread.h>
 #include <stdbool.h>
 #include <errno.h>
 #include <net/if.h>

--- a/tests/dns/test_mdns_service.c
+++ b/tests/dns/test_mdns_service.c
@@ -6,7 +6,6 @@
 #include <fcntl.h>
 #include <ctype.h>
 #include <unistd.h>
-#include <pthread.h>
 #include <stdbool.h>
 #include <errno.h>
 #include <net/if.h>

--- a/tests/dns/test_reflection_list.c
+++ b/tests/dns/test_reflection_list.c
@@ -6,7 +6,6 @@
 #include <fcntl.h>
 #include <ctype.h>
 #include <unistd.h>
-#include <pthread.h>
 #include <stdbool.h>
 #include <errno.h>
 #include <net/if.h>

--- a/tests/utils/CMakeLists.txt
+++ b/tests/utils/CMakeLists.txt
@@ -36,7 +36,7 @@ add_executable(test_squeue test_squeue.c)
 target_link_libraries(test_squeue PRIVATE squeue os cmocka::cmocka)
 
 add_executable(test_log_thread_safe test_log_thread_safe.c)
-target_link_libraries(test_log_thread_safe log pthread)
+target_link_libraries(test_log_thread_safe log Threads::Threads)
 
 add_executable(test_log_level test_log_level.c)
 target_link_libraries(test_log_level PRIVATE log)


### PR DESCRIPTION
Currently, libsqlite3 and libpcap are statically linked to edgesec, even when building a `.deb`.

Dynamic linking speeds up compilation, makes our package smaller (both on disk and in memory), and means sqlite3/libpcap can be updated to fix bugs without our package being updated.

The dynamically linked version of libsqlite3 is exactly the same as the statically linked version.

**However, the current statically linked version of libpcap is 1.10.1, which is newer than the dynamically linked libpcap 1.9.1** It seems to compile and run tests fine, though, so it probably means we aren't using any new libpcap features.