### PR TITLE
docs: add a "code-style LLVM" badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,6 +9,7 @@
 [![GitHub Pages](https://github.com/nqminds/edgesec/actions/workflows/pages.yml/badge.svg)](https://github.com/nqminds/edgesec/actions/workflows/pages.yml)
 ![CMake](https://img.shields.io/badge/CMake-%23008FBA.svg?logo=cmake&logoColor=white)
 ![C11](https://img.shields.io/badge/C11-informational.svg?logo=c)
+[![code style: llvm](https://img.shields.io/badge/code%20style-LLVM-green?logo=llvm&color=2b617a)](https://llvm.org/docs/CodingStandards.html)
 [![OpenWRT package feed](https://img.shields.io/badge/OpenWRT%20Package%20Feed-%23002B49.svg?logo=OpenWrt&logoColor=white)](https://github.com/nqminds/manysecured-openwrt-packages)
 
 edgesec defines a new architecture and toolset for edge based routers addressing


### PR DESCRIPTION
Adds the following badge to the README.md to show that we follow the LLVM code style: [![code style: llvm](https://img.shields.io/badge/code%20style-LLVM-green?logo=llvm&color=2b617a)](https://llvm.org/docs/CodingStandards.html)