### PR TITLE
build: convert LINK_FLAGS to target_link_options

### DIFF
--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -23,22 +23,28 @@ endif ()
 
 add_executable(test_runctl test_runctl.c)
 target_link_libraries(test_runctl PUBLIC SQLite::SQLite3 LibUTHash::LibUTHash PRIVATE runctl log os supervisor_config mac_mapper cmocka::cmocka)
-set(TEST_RUNCTL_PROPS "-Wl,--wrap=get_vlan_mapper -Wl,--wrap=eloop_run -Wl,--wrap=get_commands_paths -Wl,--wrap=hmap_str_keychar_get")
-set(TEST_RUNCTL_PROPS "${TEST_RUNCTL_PROPS} -Wl,--wrap=fw_init_context -Wl,--wrap=fw_set_ip_forward")
+
+target_link_options(test_runctl PRIVATE
+  "LINKER:--wrap=get_vlan_mapper,--wrap=eloop_run,--wrap=get_commands_paths,--wrap=hmap_str_keychar_get"
+  "LINKER:--wrap=fw_init_context,--wrap=fw_set_ip_forward"
+)
+
 if (USE_CRYPTO_SERVICE)
   target_link_libraries(test_runctl PRIVATE crypt_service)
-  set(TEST_RUNCTL_PROPS "${TEST_RUNCTL_PROPS} -Wl,--wrap=load_crypt_service")
+  target_link_options(test_runctl PRIVATE "LINKER:--wrap=load_crypt_service")
 endif ()
-set(TEST_RUNCTL_PROPS "${TEST_RUNCTL_PROPS} -Wl,--wrap=iface_get_vlan -Wl,--wrap=run_supervisor")
-set(TEST_RUNCTL_PROPS "${TEST_RUNCTL_PROPS} -Wl,--wrap=run_ap -Wl,--wrap=run_dhcp")
+
+target_link_options(test_runctl PRIVATE
+  "LINKER:--wrap=iface_get_vlan,--wrap=run_supervisor"
+  "LINKER:--wrap=run_ap,--wrap=run_dhcp"
+)
+
 if (USE_RADIUS_SERVICE)
-  set(TEST_RUNCTL_PROPS "${TEST_RUNCTL_PROPS} -Wl,--wrap=run_radius")
+  target_link_options(test_runctl PRIVATE "LINKER:--wrap=run_radius")
 endif()
 if (USE_MDNS_SERVICE)
-  set(TEST_RUNCTL_PROPS "${TEST_RUNCTL_PROPS} -Wl,--wrap=run_mdns_thread")
+  target_link_options(test_runctl PRIVATE "LINKER:--wrap=run_mdns_thread")
 endif()
-
-set_target_properties(test_runctl PROPERTIES LINK_FLAGS ${TEST_RUNCTL_PROPS})
 
 add_test(NAME test_runctl COMMAND test_runctl)
 set_tests_properties(test_runctl

--- a/tests/ap/CMakeLists.txt
+++ b/tests/ap/CMakeLists.txt
@@ -4,17 +4,17 @@ include_directories(
 
 add_executable(test_hostapd test_hostapd.c)
 target_link_libraries(test_hostapd PRIVATE hostapd iface os log cmocka::cmocka)
-set_target_properties(test_hostapd
-  PROPERTIES
-  LINK_FLAGS  "-Wl,--wrap=kill_process -Wl,--wrap=signal_process -Wl,--wrap=reset_interface -Wl,--wrap=run_process -Wl,--wrap=list_dir -Wl,--wrap=check_sock_file_exists"
+target_link_options(test_hostapd
+  PRIVATE
+  "LINKER:--wrap=kill_process,--wrap=signal_process,--wrap=reset_interface,--wrap=run_process,--wrap=list_dir,--wrap=check_sock_file_exists"
 )
 
 add_executable(test_ap_service test_ap_service.c)
 target_link_libraries(test_ap_service PRIVATE ap_service hostapd iface os log cmocka::cmocka)
 # sqlite3.h required by src/supervisor/supervisor_config.h
-set_target_properties(test_ap_service
-  PROPERTIES
-  LINK_FLAGS  "-Wl,--wrap=close -Wl,--wrap=generate_vlan_conf -Wl,--wrap=run_ap_process -Wl,--wrap=generate_hostapd_conf -Wl,--wrap=signal_ap_process -Wl,--wrap=create_domain_client -Wl,--wrap=eloop_register_read_sock -Wl,--wrap=write_domain_data_s -Wl,--wrap=writeread_domain_data_str"
+target_link_options(test_ap_service
+  PRIVATE
+  "LINKER:--wrap=close,--wrap=generate_vlan_conf,--wrap=run_ap_process,--wrap=generate_hostapd_conf,--wrap=signal_ap_process,--wrap=create_domain_client,--wrap=eloop_register_read_sock,--wrap=write_domain_data_s,--wrap=writeread_domain_data_str"
 )
 
 add_test(NAME test_hostapd COMMAND test_hostapd)

--- a/tests/capture/CMakeLists.txt
+++ b/tests/capture/CMakeLists.txt
@@ -6,9 +6,9 @@ include_directories (
 
 add_executable(test_capture_service test_capture_service.c)
 target_link_libraries(test_capture_service PUBLIC PCAP::pcap SQLite::SQLite3 PRIVATE capture_service packet_decoder os log cmocka::cmocka)
-set_target_properties(test_capture_service
-  PROPERTIES
-  LINK_FLAGS  "-Wl,--wrap=open_sqlite_header_db -Wl,--wrap=open_sqlite_pcap_db -Wl,--wrap=free_sqlite_header_db -Wl,--wrap=free_sqlite_pcap_db -Wl,--wrap=run_pcap -Wl,--wrap=close_pcap -Wl,--wrap=eloop_init -Wl,--wrap=eloop_register_read_sock -Wl,--wrap=eloop_register_timeout -Wl,--wrap=eloop_run -Wl,--wrap=eloop_free -Wl,--wrap=run_register_db -Wl,--wrap=extract_packets -Wl,--wrap=push_packet_queue -Wl,--wrap=push_pcap_queue"
+target_link_options(test_capture_service
+  PRIVATE
+  "LINKER:--wrap=open_sqlite_header_db,--wrap=open_sqlite_pcap_db,--wrap=free_sqlite_header_db,--wrap=free_sqlite_pcap_db,--wrap=run_pcap,--wrap=close_pcap,--wrap=eloop_init,--wrap=eloop_register_read_sock,--wrap=eloop_register_timeout,--wrap=eloop_run,--wrap=eloop_free,--wrap=run_register_db,--wrap=extract_packets,--wrap=push_packet_queue,--wrap=push_pcap_queue"
 )
 
 add_test(NAME test_capture_service COMMAND test_capture_service)

--- a/tests/capture/middlewares/CMakeLists.txt
+++ b/tests/capture/middlewares/CMakeLists.txt
@@ -1,8 +1,8 @@
 add_executable(test_header_middleware test_header_middleware.c)
 target_link_libraries(test_header_middleware PUBLIC PCAP::pcap SQLite::SQLite3 PRIVATE header_middleware sqliteu os log cmocka::cmocka)
-set_target_properties(test_header_middleware
-  PROPERTIES
-  LINK_FLAGS  "-Wl,--wrap=sqlite3_open"
+target_link_options(test_header_middleware
+  PRIVATE
+  "LINKER:--wrap=sqlite3_open"
 )
 
 add_executable(test_sqlite_header test_sqlite_header.c)

--- a/tests/crypt/CMakeLists.txt
+++ b/tests/crypt/CMakeLists.txt
@@ -4,16 +4,16 @@ include_directories (
 
 add_executable(test_sqlite_crypt_writer test_sqlite_crypt_writer.c)
 target_link_libraries(test_sqlite_crypt_writer PRIVATE sqlite_crypt_writer sqliteu os log SQLite::SQLite3 cmocka::cmocka)
-set_target_properties(test_sqlite_crypt_writer
-  PROPERTIES
-  LINK_FLAGS  "-Wl,--wrap=sqlite3_open"
+target_link_options(test_sqlite_crypt_writer
+  PRIVATE
+  "LINKER:--wrap=sqlite3_open"
 )
 
 add_executable(test_crypt_service test_crypt_service.c)
 target_link_libraries(test_crypt_service PRIVATE crypt_service sqlite_crypt_writer sqliteu os log cmocka::cmocka)
-set_target_properties(test_crypt_service
-  PROPERTIES
-  LINK_FLAGS  "-Wl,--wrap=crypto_decrypt -Wl,--wrap=init_hsm"
+target_link_options(test_crypt_service
+  PRIVATE
+  "LINKER:--wrap=crypto_decrypt,--wrap=init_hsm"
 )
 
 add_test(NAME test_sqlite_crypt_writer COMMAND test_sqlite_crypt_writer)

--- a/tests/dhcp/CMakeLists.txt
+++ b/tests/dhcp/CMakeLists.txt
@@ -4,16 +4,16 @@ include_directories(
 
 add_executable(test_dnsmasq test_dnsmasq.c)
 target_link_libraries(test_dnsmasq PRIVATE dnsmasq log cmocka::cmocka)
-set_target_properties(test_dnsmasq
-  PROPERTIES
-  LINK_FLAGS  "-Wl,--wrap=kill_process -Wl,--wrap=run_process -Wl,--wrap=is_proc_running -Wl,--wrap=signal_process"
+target_link_options(test_dnsmasq
+  PRIVATE
+  "LINKER:--wrap=kill_process,--wrap=run_process,--wrap=is_proc_running,--wrap=signal_process"
 )
 
 add_executable(test_dhcp_service test_dhcp_service.c)
 target_link_libraries(test_dhcp_service PRIVATE dhcp_service dnsmasq log cmocka::cmocka)
-set_target_properties(test_dhcp_service
-  PROPERTIES
-  LINK_FLAGS  "-Wl,--wrap=generate_dnsmasq_conf -Wl,--wrap=generate_dnsmasq_script -Wl,--wrap=run_dhcp_process -Wl,--wrap=kill_dhcp_process -Wl,--wrap=clear_dhcp_lease_entry"
+target_link_options(test_dhcp_service
+  PRIVATE
+  "LINKER:--wrap=generate_dnsmasq_conf,--wrap=generate_dnsmasq_script,--wrap=run_dhcp_process,--wrap=kill_dhcp_process,--wrap=clear_dhcp_lease_entry"
 )
 
 add_test(NAME test_dnsmasq COMMAND test_dnsmasq)

--- a/tests/dns/CMakeLists.txt
+++ b/tests/dns/CMakeLists.txt
@@ -17,9 +17,9 @@ target_link_libraries(test_reflection_list PRIVATE os reflection_list log cmocka
 if (USE_MDNS_SERVICE AND USE_CAPTURE_SERVICE)
   add_executable(test_mdns_service test_mdns_service.c)
   target_link_libraries(test_mdns_service PRIVATE mdns_service pcap_service log cmocka::cmocka)
-  set_target_properties(test_mdns_service
-    PROPERTIES
-    LINK_FLAGS  "-Wl,--wrap=run_pcap -Wl,--wrap=eloop_register_read_sock -Wl,--wrap=eloop_init -Wl,--wrap=eloop_run -Wl,--wrap=eloop_free"
+  target_link_options(test_mdns_service
+    PRIVATE
+    "LINKER:--wrap=run_pcap,--wrap=eloop_register_read_sock,--wrap=eloop_init,--wrap=eloop_run,--wrap=eloop_free"
   )
 endif ()
 

--- a/tests/supervisor/CMakeLists.txt
+++ b/tests/supervisor/CMakeLists.txt
@@ -10,31 +10,32 @@ target_link_libraries(test_sockctl_server PRIVATE sockctl os log cmocka::cmocka)
 
 add_executable(test_cmd_processor test_cmd_processor.c)
 target_link_libraries(test_cmd_processor PRIVATE cmd_processor iptables log cmocka::cmocka)
-
-set(TEST_CMD_PROPS "-Wl,--wrap=write_socket_data -Wl,--wrap=accept_mac_cmd -Wl,--wrap=deny_mac_cmd")
-set(TEST_CMD_PROPS "${TEST_CMD_PROPS} -Wl,--wrap=write_socket_data -Wl,--wrap=accept_mac_cmd -Wl,--wrap=deny_mac_cmd")
-set(TEST_CMD_PROPS "${TEST_CMD_PROPS} -Wl,--wrap=add_nat_cmd -Wl,--wrap=remove_nat_cmd -Wl,--wrap=assign_psk_cmd")
-set(TEST_CMD_PROPS "${TEST_CMD_PROPS} -Wl,--wrap=set_ip_cmd -Wl,--wrap=add_bridge_mac_cmd -Wl,--wrap=add_bridge_ip_cmd")
-set(TEST_CMD_PROPS "${TEST_CMD_PROPS} -Wl,--wrap=set_fingerprint_cmd -Wl,--wrap=query_fingerprint_cmd")
-set(TEST_CMD_PROPS "${TEST_CMD_PROPS} -Wl,--wrap=clear_psk_cmd -Wl,--wrap=get_mac_mapper -Wl,--wrap=remove_bridge_cmd")
-set(TEST_CMD_PROPS "${TEST_CMD_PROPS} -Wl,--wrap=clear_bridges_cmd -Wl,--wrap=subscribe_events_cmd -Wl,--wrap=register_ticket_cmd")
+target_link_options(test_cmd_processor PRIVATE
+  "LINKER:--wrap=write_socket_data,--wrap=accept_mac_cmd,--wrap=deny_mac_cmd"
+  "LINKER:--wrap=write_socket_data,--wrap=accept_mac_cmd,--wrap=deny_mac_cmd"
+  "LINKER:--wrap=add_nat_cmd,--wrap=remove_nat_cmd,--wrap=assign_psk_cmd"
+  "LINKER:--wrap=set_ip_cmd,--wrap=add_bridge_mac_cmd,--wrap=add_bridge_ip_cmd"
+  "LINKER:--wrap=set_fingerprint_cmd,--wrap=query_fingerprint_cmd"
+  "LINKER:--wrap=clear_psk_cmd,--wrap=get_mac_mapper,--wrap=remove_bridge_cmd"
+  "LINKER:--wrap=clear_bridges_cmd,--wrap=subscribe_events_cmd,--wrap=register_ticket_cmd"
+)
 
 if (USE_CRYPTO_SERVICE)
-  set(TEST_CMD_PROPS "${TEST_CMD_PROPS} -Wl,--wrap=gen_randkey_cmd -Wl,--wrap=gen_privkey_cmd -Wl,--wrap=gen_pubkey_cmd")
-  set(TEST_CMD_PROPS "${TEST_CMD_PROPS} -Wl,--wrap=gen_cert_cmd -Wl,--wrap=put_crypt_cmd -Wl,--wrap=get_crypt_cmd")
-  set(TEST_CMD_PROPS "${TEST_CMD_PROPS} -Wl,--wrap=encrypt_blob_cmd -Wl,--wrap=decrypt_blob_cmd -Wl,--wrap=sign_blob_cmd")
+  target_link_options(test_cmd_processor PRIVATE
+    "LINKER:--wrap=gen_randkey_cmd,--wrap=gen_privkey_cmd,--wrap=gen_pubkey_cmd"
+    "LINKER:--wrap=gen_cert_cmd,--wrap=put_crypt_cmd,--wrap=get_crypt_cmd"
+    "LINKER:--wrap=encrypt_blob_cmd,--wrap=decrypt_blob_cmd,--wrap=sign_blob_cmd"
+  )
 endif ()
-
-set_target_properties(test_cmd_processor PROPERTIES LINK_FLAGS ${TEST_CMD_PROPS})
 
 add_executable(test_mac_mapper test_mac_mapper.c)
 target_link_libraries(test_mac_mapper PRIVATE log os mac_mapper cmocka::cmocka)
 
 add_executable(test_sqlite_macconn_writer test_sqlite_macconn_writer.c)
 target_link_libraries(test_sqlite_macconn_writer PRIVATE sqlite_macconn_writer sqliteu os log cmocka::cmocka)
-set_target_properties(test_sqlite_macconn_writer
-  PROPERTIES
-  LINK_FLAGS  "-Wl,--wrap=sqlite3_open"
+target_link_options(test_sqlite_macconn_writer
+  PRIVATE
+  "LINKER:--wrap=sqlite3_open"
 )
 
 add_test(NAME test_bridge_list COMMAND test_bridge_list)

--- a/tests/supervisor/CMakeLists.txt
+++ b/tests/supervisor/CMakeLists.txt
@@ -12,7 +12,6 @@ add_executable(test_cmd_processor test_cmd_processor.c)
 target_link_libraries(test_cmd_processor PRIVATE cmd_processor iptables log cmocka::cmocka)
 target_link_options(test_cmd_processor PRIVATE
   "LINKER:--wrap=write_socket_data,--wrap=accept_mac_cmd,--wrap=deny_mac_cmd"
-  "LINKER:--wrap=write_socket_data,--wrap=accept_mac_cmd,--wrap=deny_mac_cmd"
   "LINKER:--wrap=add_nat_cmd,--wrap=remove_nat_cmd,--wrap=assign_psk_cmd"
   "LINKER:--wrap=set_ip_cmd,--wrap=add_bridge_mac_cmd,--wrap=add_bridge_ip_cmd"
   "LINKER:--wrap=set_fingerprint_cmd,--wrap=query_fingerprint_cmd"


### PR DESCRIPTION
Instead of manually setting LINK_FLAGS for each target, we can use CMake's [target_link_options][1].

This has a few benefits:
- args can be scoped to be `INTERFACE|PUBLIC|PRIVATE`
- args are automatically deduplicated
- linker flags are portable for all compilers
  (e.g. these options will work both for Clang and GCC)

Downsides:
- Minimum CMake support is v3.13, which is fine, since our project minimum is currently v3.14

[1]: https://cmake.org/cmake/help/latest/command/target_link_options.html