### PR TITLE
ci: limit `create-debs.yml` permissions

### DIFF
--- a/.github/workflows/create-debs.yml
+++ b/.github/workflows/create-debs.yml
@@ -20,6 +20,8 @@ jobs:
           - linux-with-example-middlewares # tests whether example capture middlewares work
           - openwrt-with-header
           - openwrt-21.02.1/bcm27xx/bcm2710 # Raspberry Pi 3 for OpenWRT 21.02.1
+    permissions:
+      contents: read
     runs-on: ubuntu-latest
     steps:
       - name: Checkout code
@@ -80,6 +82,9 @@ jobs:
   coverage:
     name: Code Coverage
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      actions: read # to download artifact
     needs:
       - build
     steps:
@@ -120,6 +125,8 @@ jobs:
           # focal and jammy are incompatible due to ABI incompatible libssl versions
           - focal # uses libssl1.1
           - jammy # uses libssl3
+    permissions:
+      contents: write # needed for publishing release artifact
     env:
       OTHER_MIRROR:
         deb [arch=arm64] http://ports.ubuntu.com/ubuntu-ports ${{ matrix.distribution }} main universe | deb [arch=amd64] http://archive.ubuntu.com/ubuntu ${{ matrix.distribution }} main universe


### PR DESCRIPTION
Limit the `create_debs.yml` action to the bare minimum permissions it needs to runs the actions.

This is considered to be more secure, as it lowers the risk of supply-side attacks getting access to our GitHub repo.