### PR TITLE
refactor: change netinit/in.h #include order

### DIFF
--- a/.clang-format
+++ b/.clang-format
@@ -11,4 +11,9 @@ IncludeCategories:
   - Regex: '^<cmocka.h>'
     # <cmocha.h> relies on <std...h> being included first
     SortPriority: 2
+  - Regex: '^<netinet/in.h>'
+    SortPriority: 2
+  - Regex: '^<netinet/'
+    # On FreeBSD, you must include `<netinet/in.h>` before `<netinet/if_ether.h>`
+    SortPriority: 3
 ...

--- a/src/radius/radius_server.h
+++ b/src/radius/radius_server.h
@@ -18,9 +18,10 @@
 #include <stdint.h>
 #include <sys/types.h>
 #include <unistd.h>
+// On FreeBSD, you must include `<netinet/in.h>` before `<netinet/if_ether.h>`
+#include <netinet/in.h>
 #include <netinet/if_ether.h>
 #include <asm/types.h>
-#include <arpa/inet.h>
 #include <stdbool.h>
 
 #include "../utils/os.h"


### PR DESCRIPTION
On FreeBSD, `#include <netinit/in.h>` should come before `#include <netinit/if_ether.h>`, as otherwise `struct in_addr` won't be defined.

I've modified the `.clang-format` rules so that after #116 gets merged, this shouldn't cause any issues.