### PR TITLE
ci: fix intermittent disk I/O error

### DIFF
--- a/.github/workflows/create-debs.yml
+++ b/.github/workflows/create-debs.yml
@@ -63,6 +63,8 @@ jobs:
         # code coverage only works if ctest works
         if: steps.test.outputs.tested == 'true'
         run: |
+          # Should prevent `Failed to execute statement: disk I/O error` errors
+          sleep 5
           cmake --build --preset "${{ matrix.cmake-preset }}" --parallel "$(($(nproc) + 1))" --target coverage
           mv "build/${{ matrix.cmake-preset }}/coverage.info" "build/${{ matrix.cmake-preset }}/coverage-${{ matrix.cmake-preset }}.info"
         env:


### PR DESCRIPTION
GitHub Actions CI tests are failing intermittently due to an SQLite `Failed to execute statement: disk I/O error`.

I'm pretty sure this is due to some sort of race condition, either with:
  - a) our thread code
  - b) GitHub Actions file-system

This commit adds a `sleep 5` between the CI tests and the coverage tests in an attempt to prevent this error.

Fixes https://github.com/nqminds/edgesec/issues/252 (hopefully at least!)