### PR TITLE
refactor: remove unnecessary middlewares includes

### DIFF
--- a/src/capture/middlewares/header_middleware/dns_decoder.c
+++ b/src/capture/middlewares/header_middleware/dns_decoder.c
@@ -9,15 +9,8 @@
  * utilities.
  */
 
-#include <netinet/in.h>
-#include <netinet/ip.h>
-#include <netinet/if_ether.h>
-#include <netinet/ip6.h>
-#include <netinet/icmp6.h>
-#include <netinet/ip_icmp.h>
 #include <netinet/tcp.h>
 #include <netinet/udp.h>
-#include <arpa/inet.h>
 #include <utarray.h>
 
 #include "../../../utils/allocs.h"

--- a/src/capture/middlewares/header_middleware/mdns_decoder.c
+++ b/src/capture/middlewares/header_middleware/mdns_decoder.c
@@ -9,15 +9,7 @@
  * utilities.
  */
 
-#include <netinet/in.h>
-#include <netinet/ip.h>
-#include <netinet/if_ether.h>
-#include <netinet/ip6.h>
-#include <netinet/icmp6.h>
-#include <netinet/ip_icmp.h>
-#include <netinet/tcp.h>
 #include <netinet/udp.h>
-#include <arpa/inet.h>
 
 #include "../../../utils/allocs.h"
 #include "../../../utils/os.h"

--- a/src/capture/middlewares/header_middleware/packet_decoder.c
+++ b/src/capture/middlewares/header_middleware/packet_decoder.c
@@ -14,16 +14,15 @@
 #include <stdlib.h>
 #include <string.h>
 
+#include <sys/socket.h>
 #include <netinet/in.h>
 #include <netinet/ip.h>
-#include <net/if_arp.h>
 #include <netinet/if_ether.h>
 #include <netinet/ip6.h>
 #include <netinet/icmp6.h>
+#include <netinet/ip_icmp.h>
 #include <netinet/tcp.h>
 #include <netinet/udp.h>
-#include <arpa/inet.h>
-
 #include <pcap.h>
 
 #include "../../../utils/log.h"

--- a/src/capture/middlewares/header_middleware/packet_decoder.h
+++ b/src/capture/middlewares/header_middleware/packet_decoder.h
@@ -11,18 +11,7 @@
 #ifndef PACKET_DECODER_H
 #define PACKET_DECODER_H
 
-#include <netinet/in.h>
-#include <netinet/ip.h>
-#include <sys/types.h>
-#include <sys/socket.h>
 #include <net/if.h>
-#include <netinet/if_ether.h>
-#include <netinet/ip6.h>
-#include <netinet/icmp6.h>
-#include <netinet/ip_icmp.h>
-#include <netinet/tcp.h>
-#include <netinet/udp.h>
-#include <arpa/inet.h>
 #include <pcap.h>
 
 #include <utarray.h>


### PR DESCRIPTION
Including `<netinet/ip.h>` is causing issues on FreeBSD.

These includes aren't actually needed, so we might as well get rid of them and speed up compilation slightly.