### PR TITLE
refactor: remove `#include <asm/types.h>`

### DIFF
--- a/src/radius/radius.h
+++ b/src/radius/radius.h
@@ -18,7 +18,6 @@
 #include <stdint.h>
 #include <sys/types.h>
 #include <unistd.h>
-#include <asm/types.h>
 #include <arpa/inet.h>
 
 #include "utils/allocs.h"

--- a/src/radius/radius_server.c
+++ b/src/radius/radius_server.c
@@ -15,7 +15,6 @@
 #include <stdint.h>
 #include <sys/types.h>
 #include <unistd.h>
-#include <asm/types.h>
 #include <arpa/inet.h>
 #include <stdbool.h>
 #include <sys/types.h>

--- a/src/radius/radius_server.h
+++ b/src/radius/radius_server.h
@@ -21,7 +21,6 @@
 // On FreeBSD, you must include `<netinet/in.h>` before `<netinet/if_ether.h>`
 #include <netinet/in.h>
 #include <netinet/if_ether.h>
-#include <asm/types.h>
 #include <stdbool.h>
 
 #include "../utils/os.h"

--- a/tests/radius/ip_addr.h
+++ b/tests/radius/ip_addr.h
@@ -12,7 +12,6 @@
 #include <stdint.h>
 #include <sys/types.h>
 #include <unistd.h>
-#include <asm/types.h>
 #include <arpa/inet.h>
 #include <stdbool.h>
 #include <net/if.h>

--- a/tests/radius/radius_client.c
+++ b/tests/radius/radius_client.c
@@ -9,7 +9,6 @@
 #include <stdint.h>
 #include <sys/types.h>
 #include <unistd.h>
-#include <asm/types.h>
 #include <arpa/inet.h>
 #include <stdbool.h>
 #include <net/if.h>

--- a/tests/radius/radius_client.h
+++ b/tests/radius/radius_client.h
@@ -12,7 +12,6 @@
 #include <stdint.h>
 #include <sys/types.h>
 #include <unistd.h>
-#include <asm/types.h>
 #include <arpa/inet.h>
 #include <stdbool.h>
 #include <net/if.h>

--- a/tests/radius/test_radius_server.c
+++ b/tests/radius/test_radius_server.c
@@ -8,7 +8,6 @@
 #include <stdint.h>
 #include <sys/types.h>
 #include <unistd.h>
-#include <asm/types.h>
 #include <arpa/inet.h>
 #include <stdbool.h>
 #include <net/if.h>


### PR DESCRIPTION
As far as I'm aware, this doesn't do anything, except cause issues on non-Linux platforms like FreeBSD.