### PR TITLE
refactor: add #include <stdint.h> before cmocka

### DIFF
--- a/tests/ap/test_ap_service.c
+++ b/tests/ap/test_ap_service.c
@@ -8,11 +8,11 @@
 #include <stdlib.h>
 #include <stdarg.h>
 #include <stddef.h>
-#include <stdint.h>
 #include <string.h>
 #include <inttypes.h>
 #include <unistd.h>
 #include <setjmp.h>
+#include <stdint.h>
 #include <cmocka.h>
 
 #include "supervisor/supervisor_config.h"

--- a/tests/ap/test_hostapd.c
+++ b/tests/ap/test_hostapd.c
@@ -7,11 +7,11 @@
 #include <stdlib.h>
 #include <stdarg.h>
 #include <stddef.h>
-#include <stdint.h>
 #include <string.h>
 #include <inttypes.h>
 #include <unistd.h>
 #include <setjmp.h>
+#include <stdint.h>
 #include <cmocka.h>
 
 #include "utils/log.h"

--- a/tests/capture/middlewares/test_header_middleware.c
+++ b/tests/capture/middlewares/test_header_middleware.c
@@ -10,6 +10,7 @@
 #include <inttypes.h>
 #include <unistd.h>
 #include <setjmp.h>
+#include <stdint.h>
 #include <cmocka.h>
 
 #include "utils/log.h"

--- a/tests/capture/middlewares/test_packet_queue.c
+++ b/tests/capture/middlewares/test_packet_queue.c
@@ -10,6 +10,7 @@
 #include <inttypes.h>
 #include <unistd.h>
 #include <setjmp.h>
+#include <stdint.h>
 #include <cmocka.h>
 
 #include "utils/log.h"

--- a/tests/capture/middlewares/test_pcap_queue.c
+++ b/tests/capture/middlewares/test_pcap_queue.c
@@ -10,6 +10,7 @@
 #include <inttypes.h>
 #include <unistd.h>
 #include <setjmp.h>
+#include <stdint.h>
 #include <cmocka.h>
 
 #include "utils/allocs.h"

--- a/tests/capture/middlewares/test_sqlite_header.c
+++ b/tests/capture/middlewares/test_sqlite_header.c
@@ -10,6 +10,7 @@
 #include <inttypes.h>
 #include <unistd.h>
 #include <setjmp.h>
+#include <stdint.h>
 #include <cmocka.h>
 #include <pthread.h>
 

--- a/tests/capture/middlewares/test_sqlite_pcap.c
+++ b/tests/capture/middlewares/test_sqlite_pcap.c
@@ -10,6 +10,7 @@
 #include <inttypes.h>
 #include <unistd.h>
 #include <setjmp.h>
+#include <stdint.h>
 #include <cmocka.h>
 #include <pthread.h>
 

--- a/tests/capture/test_capture_service.c
+++ b/tests/capture/test_capture_service.c
@@ -10,6 +10,7 @@
 #include <inttypes.h>
 #include <unistd.h>
 #include <setjmp.h>
+#include <stdint.h>
 #include <cmocka.h>
 
 #include "utils/log.h"

--- a/tests/crypt/test_crypt_service.c
+++ b/tests/crypt/test_crypt_service.c
@@ -10,6 +10,7 @@
 #include <inttypes.h>
 #include <unistd.h>
 #include <setjmp.h>
+#include <stdint.h>
 #include <cmocka.h>
 
 #include "utils/log.h"

--- a/tests/crypt/test_sqlite_crypt_writer.c
+++ b/tests/crypt/test_sqlite_crypt_writer.c
@@ -10,6 +10,7 @@
 #include <inttypes.h>
 #include <unistd.h>
 #include <setjmp.h>
+#include <stdint.h>
 #include <cmocka.h>
 
 #include "utils/log.h"

--- a/tests/dhcp/test_dhcp_service.c
+++ b/tests/dhcp/test_dhcp_service.c
@@ -10,6 +10,7 @@
 #include <errno.h>
 #include <libgen.h>
 #include <setjmp.h>
+#include <stdint.h>
 #include <cmocka.h>
 
 #include "utils/log.h"

--- a/tests/dhcp/test_dnsmasq.c
+++ b/tests/dhcp/test_dnsmasq.c
@@ -10,6 +10,7 @@
 #include <errno.h>
 #include <libgen.h>
 #include <setjmp.h>
+#include <stdint.h>
 #include <cmocka.h>
 
 #include "utils/log.h"

--- a/tests/dns/test_command_mapper.c
+++ b/tests/dns/test_command_mapper.c
@@ -10,6 +10,7 @@
 #include <errno.h>
 #include <libgen.h>
 #include <setjmp.h>
+#include <stdint.h>
 #include <cmocka.h>
 
 #include "utils/log.h"

--- a/tests/dns/test_mdns_list.c
+++ b/tests/dns/test_mdns_list.c
@@ -10,6 +10,7 @@
 #include <errno.h>
 #include <libgen.h>
 #include <setjmp.h>
+#include <stdint.h>
 #include <cmocka.h>
 
 #include "utils/log.h"

--- a/tests/dns/test_mdns_mapper.c
+++ b/tests/dns/test_mdns_mapper.c
@@ -10,6 +10,7 @@
 #include <errno.h>
 #include <libgen.h>
 #include <setjmp.h>
+#include <stdint.h>
 #include <cmocka.h>
 
 #include "utils/log.h"

--- a/tests/dns/test_mdns_service.c
+++ b/tests/dns/test_mdns_service.c
@@ -10,6 +10,7 @@
 #include <errno.h>
 #include <libgen.h>
 #include <setjmp.h>
+#include <stdint.h>
 #include <cmocka.h>
 
 #include "utils/log.h"

--- a/tests/dns/test_reflection_list.c
+++ b/tests/dns/test_reflection_list.c
@@ -10,6 +10,7 @@
 #include <errno.h>
 #include <libgen.h>
 #include <setjmp.h>
+#include <stdint.h>
 #include <cmocka.h>
 #include <sys/socket.h>
 

--- a/tests/radius/test_radius_server.c
+++ b/tests/radius/test_radius_server.c
@@ -5,7 +5,6 @@
  * This software may be distributed under the terms of the BSD license.
  * See README for more details.
  */
-#include <stdint.h>
 #include <sys/types.h>
 #include <unistd.h>
 #include <arpa/inet.h>
@@ -19,8 +18,8 @@
 #include <string.h>
 #include <inttypes.h>
 #include <unistd.h>
-
 #include <setjmp.h>
+#include <stdint.h>
 #include <cmocka.h>
 
 #include "utils/eloop.h"

--- a/tests/supervisor/test_bridge_list.c
+++ b/tests/supervisor/test_bridge_list.c
@@ -10,6 +10,7 @@
 #include <inttypes.h>
 #include <unistd.h>
 #include <setjmp.h>
+#include <stdint.h>
 #include <cmocka.h>
 
 #include "supervisor/bridge_list.h"

--- a/tests/supervisor/test_cmd_processor.c
+++ b/tests/supervisor/test_cmd_processor.c
@@ -10,6 +10,7 @@
 #include <inttypes.h>
 #include <unistd.h>
 #include <setjmp.h>
+#include <stdint.h>
 #include <cmocka.h>
 
 #include "supervisor/cmd_processor.h"

--- a/tests/supervisor/test_mac_mapper.c
+++ b/tests/supervisor/test_mac_mapper.c
@@ -10,6 +10,7 @@
 #include <inttypes.h>
 #include <unistd.h>
 #include <setjmp.h>
+#include <stdint.h>
 #include <cmocka.h>
 
 #include "utils/log.h"

--- a/tests/supervisor/test_sockctl_server.c
+++ b/tests/supervisor/test_sockctl_server.c
@@ -10,6 +10,7 @@
 #include <inttypes.h>
 #include <unistd.h>
 #include <setjmp.h>
+#include <stdint.h>
 #include <cmocka.h>
 #include <sys/un.h>
 #include <sys/socket.h>

--- a/tests/supervisor/test_sqlite_macconn_writer.c
+++ b/tests/supervisor/test_sqlite_macconn_writer.c
@@ -10,6 +10,7 @@
 #include <inttypes.h>
 #include <unistd.h>
 #include <setjmp.h>
+#include <stdint.h>
 #include <cmocka.h>
 
 #include "utils/log.h"

--- a/tests/system/test_system_checks.c
+++ b/tests/system/test_system_checks.c
@@ -10,6 +10,7 @@
 #include <inttypes.h>
 #include <unistd.h>
 #include <setjmp.h>
+#include <stdint.h>
 #include <cmocka.h>
 
 #include "system_checks.h"

--- a/tests/test_runctl.c
+++ b/tests/test_runctl.c
@@ -10,6 +10,7 @@
 #include <inttypes.h>
 #include <unistd.h>
 #include <setjmp.h>
+#include <stdint.h>
 #include <cmocka.h>
 
 #include "supervisor/sqlite_macconn_writer.h"

--- a/tests/utils/test_hashmap.c
+++ b/tests/utils/test_hashmap.c
@@ -10,6 +10,7 @@
 #include <inttypes.h>
 #include <unistd.h>
 #include <setjmp.h>
+#include <stdint.h>
 #include <cmocka.h>
 
 #include "utils/log.h"

--- a/tests/utils/test_iface_mapper.c
+++ b/tests/utils/test_iface_mapper.c
@@ -11,6 +11,7 @@
 #include <unistd.h>
 #include <stdbool.h>
 #include <setjmp.h>
+#include <stdint.h>
 #include <cmocka.h>
 
 #include "utils/log.h"

--- a/tests/utils/test_ifaceu.c
+++ b/tests/utils/test_ifaceu.c
@@ -11,6 +11,7 @@
 #include <unistd.h>
 #include <stdbool.h>
 #include <setjmp.h>
+#include <stdint.h>
 #include <cmocka.h>
 
 #include "utils/log.h"

--- a/tests/utils/test_minIni.c
+++ b/tests/utils/test_minIni.c
@@ -10,6 +10,7 @@
 #include <inttypes.h>
 #include <unistd.h>
 #include <setjmp.h>
+#include <stdint.h>
 #include <cmocka.h>
 
 #include "utils/log.h"

--- a/tests/utils/test_net.c
+++ b/tests/utils/test_net.c
@@ -11,6 +11,7 @@
 #include <unistd.h>
 #include <stdbool.h>
 #include <setjmp.h>
+#include <stdint.h>
 #include <cmocka.h>
 
 #include "utils/log.h"

--- a/tests/utils/test_nl.c
+++ b/tests/utils/test_nl.c
@@ -1,6 +1,7 @@
 #include <stdarg.h>
 #include <stddef.h>
 #include <setjmp.h>
+#include <stdint.h>
 #include <cmocka.h>
 
 #include "utils/nl.h"

--- a/tests/utils/test_os.c
+++ b/tests/utils/test_os.c
@@ -11,6 +11,7 @@
 #include <inttypes.h>
 #include <unistd.h>
 #include <setjmp.h>
+#include <stdint.h>
 #include <cmocka.h>
 // used to delete directory recursively
 #include <ftw.h>

--- a/tests/utils/test_sqliteu.c
+++ b/tests/utils/test_sqliteu.c
@@ -1,6 +1,7 @@
 #include <stdarg.h>
 #include <stddef.h>
 #include <setjmp.h>
+#include <stdint.h>
 #include <cmocka.h>
 
 #include "utils/sqliteu.h"

--- a/tests/utils/test_squeue.c
+++ b/tests/utils/test_squeue.c
@@ -11,6 +11,7 @@
 #include <unistd.h>
 #include <stdbool.h>
 #include <setjmp.h>
+#include <stdint.h>
 #include <cmocka.h>
 
 #include "utils/allocs.h"

--- a/tests/utils/test_uci_wrt.c
+++ b/tests/utils/test_uci_wrt.c
@@ -11,6 +11,7 @@
 #include <unistd.h>
 #include <stdbool.h>
 #include <setjmp.h>
+#include <stdint.h>
 #include <cmocka.h>
 
 #include "utils/log.h"

--- a/tests/utils/test_utarray.c
+++ b/tests/utils/test_utarray.c
@@ -3,6 +3,7 @@
 #include <stdarg.h>
 #include <stddef.h>
 #include <setjmp.h>
+#include <stdint.h>
 #include <cmocka.h>
 
 #include <utarray.h>

--- a/tests/utils/test_wrap_log_error.c
+++ b/tests/utils/test_wrap_log_error.c
@@ -1,6 +1,7 @@
 #include <stdarg.h>
 #include <stddef.h>
 #include <setjmp.h>
+#include <stdint.h>
 #include <cmocka.h>
 
 #include "./wrap_log_error.h"

--- a/tests/utils/wrap_log_error.c
+++ b/tests/utils/wrap_log_error.c
@@ -1,6 +1,7 @@
 #include <stdarg.h>
 #include <stddef.h>
 #include <setjmp.h>
+#include <stdint.h>
 #include <cmocka.h>
 
 #include "./wrap_log_error.h"


### PR DESCRIPTION
CMocka requires `#include <stdint.h>` to be included before every `#include <cmocka.h>`. On Linux, some of the other headers include `#include <stdint.h>` for us, but on FreeBSD, we need to manually include it.