### PR TITLE
refactor(wpabuf): simplify byte swaps

### DIFF
--- a/src/radius/wpabuf.h
+++ b/src/radius/wpabuf.h
@@ -1,15 +1,12 @@
-/*
- * Dynamic data buffer
- * Copyright (c) 2007-2012, Jouni Malinen <j@w1.fi>
- *
- * This software may be distributed under the terms of the BSD license.
- * See README for more details.
- */
-
 /**
+ * @brief Dynamic data buffer.
  * @file wpabuf.h
  * @author Jouni Malinen
- * @brief Dynamic data buffer.
+ * @author Alois Klink
+ * @copyright
+ * SPDX-FileCopyrightText: Copyright (c) 2007-2012, Jouni Malinen <j@w1.fi>
+ * SPDX-FileCopyrightText: © 2022 NQMCyber Ltd and edgesec contributors
+ * SPDX-License-Identifier: BSD-3-clause
  */
 
 #ifndef WPABUF_H

--- a/src/radius/wpabuf.h
+++ b/src/radius/wpabuf.h
@@ -38,18 +38,6 @@
 
 #ifndef WPA_BYTE_SWAP_DEFINED
 
-#ifndef __BYTE_ORDER
-#ifndef __LITTLE_ENDIAN
-#ifndef __BIG_ENDIAN
-#define __LITTLE_ENDIAN 1234
-#define __BIG_ENDIAN 4321
-#if defined(sparc)
-#define __BYTE_ORDER __BIG_ENDIAN
-#endif
-#endif /* __BIG_ENDIAN */
-#endif /* __LITTLE_ENDIAN */
-#endif /* __BYTE_ORDER */
-
 #define le_to_host16(n) le16toh(n)
 #define host_to_le16(n) htole16(n)
 #define be_to_host16(n) be16toh(n)

--- a/src/radius/wpabuf.h
+++ b/src/radius/wpabuf.h
@@ -22,20 +22,6 @@
 #include "utils/allocs.h"
 #include "utils/os.h"
 
-/*
- * Definitions for sparse validation
- * (http://kernel.org/pub/linux/kernel/people/josh/sparse/)
- */
-#ifdef __CHECKER__
-#define __force __attribute__((force))
-#undef __bitwise
-#define __bitwise __attribute__((bitwise))
-#else
-#define __force
-#undef __bitwise
-#define __bitwise
-#endif
-
 #ifndef WPA_BYTE_SWAP_DEFINED
 
 #define le_to_host16(n) le16toh(n)

--- a/src/radius/wpabuf.h
+++ b/src/radius/wpabuf.h
@@ -50,38 +50,18 @@
 #endif /* __LITTLE_ENDIAN */
 #endif /* __BYTE_ORDER */
 
-#if __BYTE_ORDER == __LITTLE_ENDIAN
-#define le_to_host16(n) ((__force u16)(le16)(n))
-#define host_to_le16(n) ((__force le16)(uint16_t)(n))
-#define be_to_host16(n) bswap_16((__force uint16_t)(uint16_t)(n))
-#define host_to_be16(n) ((__force uint16_t)bswap_16((n)))
-#define le_to_host32(n) ((__force u32)(le32)(n))
-#define host_to_le32(n) ((__force le32)(uint32_t)(n))
-#define be_to_host32(n) bswap_32((__force uint32_t)(be32)(n))
-#define host_to_be32(n) ((__force be32)bswap_32((n)))
-#define le_to_host64(n) ((__force u64)(le64)(n))
-#define host_to_le64(n) ((__force le64)(uint64_t)(n))
-#define be_to_host64(n) bswap_64((__force uint64_t)(be64)(n))
-#define host_to_be64(n) ((__force be64)bswap_64((n)))
-#elif __BYTE_ORDER == __BIG_ENDIAN
-#define le_to_host16(n) bswap_16(n)
-#define host_to_le16(n) bswap_16(n)
-#define be_to_host16(n) (n)
-#define host_to_be16(n) (n)
-#define le_to_host32(n) bswap_32(n)
-#define host_to_le32(n) bswap_32(n)
-#define be_to_host32(n) (n)
-#define host_to_be32(n) (n)
-#define le_to_host64(n) bswap_64(n)
-#define host_to_le64(n) bswap_64(n)
-#define be_to_host64(n) (n)
-#define host_to_be64(n) (n)
-#ifndef WORDS_BIGENDIAN
-#define WORDS_BIGENDIAN
-#endif
-#else
-#error Could not determine CPU byte order
-#endif
+#define le_to_host16(n) le16toh(n)
+#define host_to_le16(n) htole16(n)
+#define be_to_host16(n) be16toh(n)
+#define host_to_be16(n) htobe16(n)
+#define le_to_host32(n) le32toh(n)
+#define host_to_le32(n) htole32(n)
+#define be_to_host32(n) be32toh(n)
+#define host_to_be32(n) htobe32(n)
+#define le_to_host64(n) le64toh(n)
+#define host_to_le64(n) htole64(n)
+#define be_to_host64(n) be64toh(n)
+#define host_to_be64(n) htobe64(n)
 
 #define WPA_BYTE_SWAP_DEFINED
 #endif /* !WPA_BYTE_SWAP_DEFINED */


### PR DESCRIPTION
Cleans up the `wpabuf.h` file to improve support for non Linux OSes like FreeBSD.

As of glibc 2.19, the following macros are defined in `endian.h`:
  ```
  htobe16(), htole16(), be16toh(), le16toh(), htobe32(), htole32(),
  be32toh(), le32toh(), htobe64(), htole64(), be64toh(), le64toh()
  ```

These macros are also defined in FreeBSD, however they are located in the `<sys/endian.h>` file.

