### PR TITLE
refactor: use POSIX standard udphdr/tcphdr

### DIFF
--- a/src/capture/middlewares/header_middleware/packet_decoder.c
+++ b/src/capture/middlewares/header_middleware/packet_decoder.c
@@ -86,10 +86,10 @@ bool decode_udp_packet(struct capture_packet *cpac) {
 
   strcpy(cpac->udps.id, cpac->id);
 
-  cpac->udps.source = ntohs(cpac->udph->source);
-  cpac->udps.dest = ntohs(cpac->udph->dest);
-  cpac->udps.len = ntohs(cpac->udph->len);
-  cpac->udps.check_p = ntohs(cpac->udph->check);
+  cpac->udps.source = ntohs(cpac->udph->uh_sport);
+  cpac->udps.dest = ntohs(cpac->udph->uh_dport);
+  cpac->udps.len = ntohs(cpac->udph->uh_ulen);
+  cpac->udps.check_p = ntohs(cpac->udph->uh_sum);
 
   // log_trace("UDP source=%d dest=%d", cpac->udps.source, cpac->udps.dest);
 
@@ -106,21 +106,21 @@ bool decode_tcp_packet(struct capture_packet *cpac) {
 
   strcpy(cpac->tcps.id, cpac->id);
 
-  cpac->tcps.source = ntohs(cpac->tcph->source);
-  cpac->tcps.dest = ntohs(cpac->tcph->dest);
-  cpac->tcps.seq = ntohl(cpac->tcph->seq);
-  cpac->tcps.ack_seq = ntohl(cpac->tcph->ack_seq);
-  cpac->tcps.res1 = ntohs(cpac->tcph->res1);
-  cpac->tcps.doff = ntohs(cpac->tcph->doff);
-  cpac->tcps.fin = ntohs(cpac->tcph->fin);
-  cpac->tcps.syn = ntohs(cpac->tcph->syn);
-  cpac->tcps.rst = ntohs(cpac->tcph->rst);
-  cpac->tcps.psh = ntohs(cpac->tcph->psh);
-  cpac->tcps.ack = ntohs(cpac->tcph->ack);
-  cpac->tcps.urg = ntohs(cpac->tcph->urg);
-  cpac->tcps.window = ntohs(cpac->tcph->window);
-  cpac->tcps.check_p = ntohs(cpac->tcph->check);
-  cpac->tcps.urg_ptr = ntohs(cpac->tcph->urg_ptr);
+  cpac->tcps.source = ntohs(cpac->tcph->th_sport);
+  cpac->tcps.dest = ntohs(cpac->tcph->th_dport);
+  cpac->tcps.seq = ntohl(cpac->tcph->th_seq);
+  cpac->tcps.ack_seq = ntohl(cpac->tcph->th_ack);
+  cpac->tcps.res1 = ntohs(cpac->tcph->th_x2);
+  cpac->tcps.doff = ntohs(cpac->tcph->th_off);
+  cpac->tcps.fin = (cpac->tcph->th_flags & TH_FIN) != 0;
+  cpac->tcps.syn = (cpac->tcph->th_flags & TH_SYN) != 0;
+  cpac->tcps.rst = (cpac->tcph->th_flags & TH_RST) != 0;
+  cpac->tcps.psh = (cpac->tcph->th_flags & TH_PUSH) != 0;
+  cpac->tcps.ack = (cpac->tcph->th_flags & TH_ACK) != 0;
+  cpac->tcps.urg = (cpac->tcph->th_flags & TH_URG) != 0;
+  cpac->tcps.window = ntohs(cpac->tcph->th_win);
+  cpac->tcps.check_p = ntohs(cpac->tcph->th_sum);
+  cpac->tcps.urg_ptr = ntohs(cpac->tcph->th_urp);
 
   // log_trace("TCP source=%d dest=%d", cpac->tcps.source, cpac->tcps.dest);
   return true;


### PR DESCRIPTION
Refactors the `packet_decoder` so that the POSIX standard values for the `udphdr` and `tcphdr` struct are used.

On Linux, these structs are defined as a union, so that the POSIX standard can also be used. However, other platforms like FreeBSD only have the POSIX standard.