### PR TITLE
refactor: include sys/socket.h then netinet/in.h

### DIFF
--- a/.clang-format
+++ b/.clang-format
@@ -11,6 +11,9 @@ IncludeCategories:
   - Regex: '^<cmocka.h>'
     # <cmocha.h> relies on <std...h> being included first
     SortPriority: 2
+  - Regex: '^<sys/socket.h>'
+    # On FreeBSD, sys/socket.h must be included before `<netinet/in.h>`
+    SortPriority: 1
   - Regex: '^<netinet/in.h>'
     SortPriority: 2
   - Regex: '^<netinet/'

--- a/src/radius/radius_server.h
+++ b/src/radius/radius_server.h
@@ -18,7 +18,9 @@
 #include <stdint.h>
 #include <sys/types.h>
 #include <unistd.h>
-// On FreeBSD, you must include `<netinet/in.h>` before `<netinet/if_ether.h>`
+// On FreeBSD, you must include `<sys/socket.h>` and `<netinet/in.h>` before
+// `<netinet/if_ether.h>`
+#include <sys/socket.h>
 #include <netinet/in.h>
 #include <netinet/if_ether.h>
 #include <stdbool.h>

--- a/tests/radius/radius_client.c
+++ b/tests/radius/radius_client.c
@@ -11,6 +11,8 @@
 #include <unistd.h>
 #include <arpa/inet.h>
 #include <stdbool.h>
+#include <sys/socket.h>
+#include <netinet/in.h>
 #include <netinet/if_ether.h>
 #include <errno.h>
 


### PR DESCRIPTION
On FreeBSD, `#include <sys/socket.h>` must be included before including `#include <netinet/in.h>`.