### PR TITLE
refactor: replace non-standard icmphdr with icmp

### DIFF
--- a/src/capture/middlewares/header_middleware/packet_decoder.c
+++ b/src/capture/middlewares/header_middleware/packet_decoder.c
@@ -127,14 +127,15 @@ bool decode_tcp_packet(struct capture_packet *cpac) {
 }
 
 bool decode_icmp4_packet(struct capture_packet *cpac) {
-  cpac->icmp4h = (struct icmphdr *)((void *)cpac->ip4h + sizeof(struct ip));
+  // don't use icmphdr, it's non-standard and not supported on FreeBSD
+  cpac->icmp4h = (struct icmp *)((void *)cpac->ip4h + sizeof(struct ip));
 
   strcpy(cpac->icmp4s.id, cpac->id);
 
-  cpac->icmp4s.type = cpac->icmp4h->type;
-  cpac->icmp4s.code = cpac->icmp4h->code;
-  cpac->icmp4s.checksum = ntohs(cpac->icmp4h->checksum);
-  cpac->icmp4s.gateway = ntohl(cpac->icmp4h->un.gateway);
+  cpac->icmp4s.type = cpac->icmp4h->icmp_type;
+  cpac->icmp4s.code = cpac->icmp4h->icmp_code;
+  cpac->icmp4s.checksum = ntohs(cpac->icmp4h->icmp_cksum);
+  cpac->icmp4s.gateway = ntohl(cpac->icmp4h->icmp_hun.ih_gwaddr.s_addr);
 
   // log_trace("ICMP4 type=%d code=%d", cpac->icmp4s.type, cpac->icmp4s.code);
 

--- a/src/capture/middlewares/header_middleware/packet_decoder.h
+++ b/src/capture/middlewares/header_middleware/packet_decoder.h
@@ -309,7 +309,7 @@ struct capture_packet {
   struct ip6_hdr *ip6h;
   struct tcphdr *tcph;
   struct udphdr *udph;
-  struct icmphdr *icmp4h;
+  struct icmp *icmp4h;
   struct icmp6_hdr *icmp6h;
   struct dns_header *dnsh;
   struct mdns_header *mdnsh;


### PR DESCRIPTION
The `struct icmphdr` in `#include <netinit/ip_icmp.h>` is non-standard, and contains different properties on FreeBSD.

Because it's only a pointer (there's no memory allocation), we might as well use the standard `struct icmp`, which is a both Linux and FreeBSD compatible superset of `struct icmphdr`.