### PR TITLE
fix: fix if_nametoindex implicit declaration

### DIFF
--- a/src/utils/ifaceu.c
+++ b/src/utils/ifaceu.c
@@ -13,6 +13,7 @@
 #include <stdlib.h>
 #include <string.h>
 #include <stdbool.h>
+#include <net/if.h>
 
 #include "log.h"
 


### PR DESCRIPTION
The `#include <net/if.h>` where `if_nametoindex` was defined was not included.

This meant that C implicitly defined the function as `int if_nametoindex(int);`, when the function is actually `int if_nametoindex(char *);`

This doesn't cause any issues in Linux 32-bit, since there the implicit `int` and actual pointer parameter are the same size.

However, on Linux 64-bit, this means that the compiler sees us passing a 64-bit pointer to a 32-bit int, so who knows what will happen.