### PR TITLE
docs: optimize doxygen docs for C code

### DIFF
--- a/docs/doxygen.cmake
+++ b/docs/doxygen.cmake
@@ -23,6 +23,8 @@ if (DOXYGEN_FOUND)
     set(DOXYGEN_DOT_IMAGE_FORMAT svg)
     set(DOXYGEN_EXTRACT_ALL YES) # document even files missing `@file` command
 
+    set(DOXYGEN_OPTIMIZE_OUTPUT_FOR_C YES) # we only have C-code documentation
+
     # allows for more complitated include diagrams
     set(DOXYGEN_DOT_GRAPH_MAX_NODES 128)
     set(doxygen_input_files


### PR DESCRIPTION
Enables the [`OPTIMIZE_OUTPUT_FOR_C`][1] Doxygen option.

It basically just renames the list of classes to a list of "Data Structures", since C does not have classes.

[1]: https://www.doxygen.nl/manual/config.html#cfg_optimize_output_for_c