### PR TITLE
Improve the GitHub Actions cache step

### DIFF
--- a/.github/workflows/create-debs.yml
+++ b/.github/workflows/create-debs.yml
@@ -161,6 +161,9 @@ jobs:
           path: |
             /var/cache/pbuilder/base.tgz
           key: ${{ runner.os }}-${{ matrix.distribution }}-${{ matrix.architecture }}
+        # Sometimes the cache step just freezes forever
+        # so put a limit on it so that we can restart it earlier on failure
+        timeout-minutes: 10
       - name: Install dependencies
         run: |
           sudo apt-get update && sudo apt-get install pbuilder debhelper -y

--- a/.github/workflows/create-debs.yml
+++ b/.github/workflows/create-debs.yml
@@ -150,6 +150,10 @@ jobs:
     steps:
       - name: Checkout code
         uses: actions/checkout@v2
+      - name: Create pbuilder cache dir
+        # The actions/cache action does not have permissions to create the pbuilder
+        # cache folder if it doesn't exist
+        run: sudo mkdir -m777 -p /var/cache/pbuilder/
       - name: Cache pbuilder base
         id: cache-pbuilder-base
         uses: actions/cache@v2

--- a/.github/workflows/create-debs.yml
+++ b/.github/workflows/create-debs.yml
@@ -156,7 +156,7 @@ jobs:
         run: sudo mkdir -m777 -p /var/cache/pbuilder/
       - name: Cache pbuilder base
         id: cache-pbuilder-base
-        uses: actions/cache@v2
+        uses: actions/cache@v3
         with:
           path: |
             /var/cache/pbuilder/base.tgz


### PR DESCRIPTION
The GitHub Actions cache step keeps on freezing and taking 6 hours to crash.

I've made the following commits in an attempt to fix this:
  - [ci(deb): limit cache download step to 10 minutes](https://github.com/nqminds/edgesec/commit/78ec74b84c03083b305be1f6ff1d344c88762592)
  - [ci(deps): bump actions/cache from v2 to v3](https://github.com/nqminds/edgesec/commit/ba2676128158b5ff186f6662d69c3f53e2c44085)

Also, I've noticed that sometimes the cache doesn't work properly due to a permissions error.
Because of that, I've added [ci(deb): fix cache permissions error](https://github.com/nqminds/edgesec/commit/572406ca66a682138eb1bdff5517ecc76b463672) in this PR too.