### PR TITLE
Fix ifaceu test on FreeBSD

### DIFF
--- a/tests/utils/test_ifaceu.c
+++ b/tests/utils/test_ifaceu.c
@@ -9,11 +9,18 @@
 #include "utils/log.h"
 #include "utils/ifaceu.h"
 
+#ifdef __FreeBSD__
+static const char LOCALHOST_INTERFACE[] = "lo0";
+#else
+static const char LOCALHOST_INTERFACE[] = "lo";
+#endif
+
 static void test_iface_exists(void **state) {
   (void)state; /* unused */
 
   /* Testing iface_exists for lo */
-  bool ret = iface_exists("lo");
+  log_debug("Checking whether interface %s exists", LOCALHOST_INTERFACE);
+  bool ret = iface_exists(LOCALHOST_INTERFACE);
   assert_true(ret);
 
   /* Testing iface_exists for chuppa123 */

--- a/tests/utils/test_ifaceu.c
+++ b/tests/utils/test_ifaceu.c
@@ -1,15 +1,7 @@
-#define _GNU_SOURCE
-
-#include <sys/types.h>
-#include <sys/stat.h>
-#include <fcntl.h>
-#include <stdio.h>
-#include <stdlib.h>
-#include <stdarg.h>
-#include <string.h>
-#include <inttypes.h>
-#include <unistd.h>
 #include <stdbool.h>
+
+#include <stdarg.h>
+#include <stddef.h>
 #include <setjmp.h>
 #include <stdint.h>
 #include <cmocka.h>


### PR DESCRIPTION
On FreeBSD, the loopback interface is not called `lo`.
Instead, it is called `lo0`.

I've also removed a bunch of [unnecessary includes](https://github.com/nqminds/edgesec/commit/80bb8d9acec7ef0601840ba8c015e3193ada8973)