### PR TITLE
Add fallback for unsupported abstract sockets

### DIFF
--- a/src/ap/ap_service.c
+++ b/src/ap/ap_service.c
@@ -291,7 +291,7 @@ int run_ap(struct supervisor_context *context, bool exec_ap, bool generate_ssid,
 
 bool close_ap(struct supervisor_context *context) {
   if (context->ap_sock != -1) {
-    close(context->ap_sock);
+    close_domain_socket(context->ap_sock);
     context->ap_sock = -1;
   }
 

--- a/src/dns/mdns_service.c
+++ b/src/dns/mdns_service.c
@@ -469,7 +469,7 @@ int close_mdns(struct mdns_context *context) {
     free_command_mapper(&context->command_mapper);
     context->command_mapper = NULL;
 
-    close(context->sfd);
+    close_domain_socket(context->sfd);
     context->sfd = 0;
   }
 

--- a/src/utils/CMakeLists.txt
+++ b/src/utils/CMakeLists.txt
@@ -64,3 +64,8 @@ target_link_libraries(sqliteu PUBLIC SQLite::SQLite3 PRIVATE log os)
 
 add_library(sockctl sockctl.c)
 target_link_libraries(sockctl PRIVATE net log os)
+if(${CMAKE_SYSTEM_NAME} STREQUAL "Linux")
+  # Abstract Unix domain sockets are only supported on Linux, but save a bit of writing
+  # to the disk
+  target_compile_definitions(sockctl PRIVATE USE_ABSTRACT_UNIX_DOMAIN_SOCKETS)
+endif()

--- a/src/utils/sockctl.c
+++ b/src/utils/sockctl.c
@@ -88,6 +88,10 @@ static int cleanup_tmp_domain_socket_path(const char *socket_path) {
 
   char *socket_dir = dirname(path);
 
+  log_debug("Deleting folder %s, as it looks like it was created by "
+            "create_tmp_domain_socket_path()",
+            socket_dir);
+  // only deletes empty directories, not empty dirs set errno to ENOTEMPTY
   if (rmdir(socket_dir)) {
     log_errno("Failed to rmdir() tmp unix socket folder %s", socket_dir);
     return -1;

--- a/src/utils/sockctl.c
+++ b/src/utils/sockctl.c
@@ -60,7 +60,7 @@ char *generate_socket_name(void) {
   return buf;
 }
 
-int create_domain_client(char *addr) {
+int create_domain_client(char *path) {
   struct sockaddr_un claddr;
   int sock;
   char *client_addr = NULL;
@@ -75,7 +75,7 @@ int create_domain_client(char *addr) {
     return -1;
   }
 
-  if (addr == NULL) {
+  if (path == NULL) {
     if ((client_addr = generate_socket_name()) == NULL) {
       log_error("generate_socket_name fail");
       close(sock);
@@ -86,7 +86,7 @@ int create_domain_client(char *addr) {
     addrlen = sizeof(sa_family_t) + strlen(client_addr) + 1;
     os_free(client_addr);
   } else {
-    os_strlcpy(claddr.sun_path, addr, sizeof(claddr.sun_path));
+    os_strlcpy(claddr.sun_path, path, sizeof(claddr.sun_path));
     addrlen = sizeof(struct sockaddr_un);
   }
 

--- a/src/utils/sockctl.c
+++ b/src/utils/sockctl.c
@@ -26,7 +26,7 @@
 
 #define DOMAIN_REPLY_TIMEOUT 10
 
-void init_domain_addr(struct sockaddr_un *unaddr, char *addr) {
+void init_domain_addr(struct sockaddr_un *unaddr, const char *addr) {
   os_memset(unaddr, 0, sizeof(struct sockaddr_un));
   unaddr->sun_family = AF_UNIX;
   os_strlcpy(unaddr->sun_path, addr, sizeof(unaddr->sun_path));
@@ -60,7 +60,7 @@ char *generate_socket_name(void) {
   return buf;
 }
 
-int create_domain_client(char *path) {
+int create_domain_client(const char *path) {
   struct sockaddr_un claddr;
   int sock;
   char *client_addr = NULL;
@@ -99,7 +99,7 @@ int create_domain_client(char *path) {
   return sock;
 }
 
-int create_domain_server(char *server_path) {
+int create_domain_server(const char *server_path) {
   struct sockaddr_un svaddr;
   int sfd;
 

--- a/src/utils/sockctl.c
+++ b/src/utils/sockctl.c
@@ -32,6 +32,21 @@ void init_domain_addr(struct sockaddr_un *unaddr, char *addr) {
   os_strlcpy(unaddr->sun_path, addr, sizeof(unaddr->sun_path));
 }
 
+/**
+ * @brief Generate _abstract_ socket name
+ *
+ * Generates a pseudo-random abstract socket name, **WITHOUT** the leading NULL
+ * character.
+ * Unlike _pathname_ sockets, abstract sockets are not bound to a filesystem
+ * pathname.
+ * This means there is no need to run unlink() to cleanup the socket after use.
+ * However, _abstract_ UNIX sockets are Linux only.
+ *
+ * @see https://man7.org/linux/man-pages/man7/unix.7.html
+ * @return A pseudo-random _abstract_ UNIX socket name **WITHOUT**
+ * the leading NULL char, or `NULL` on error.
+ * @post Please `free()` the returned string when finished.
+ */
 char *generate_socket_name(void) {
   unsigned char crypto_rand[4];
   char *buf = NULL;

--- a/src/utils/sockctl.c
+++ b/src/utils/sockctl.c
@@ -106,6 +106,9 @@ int create_domain_client(const char *path) {
 
   if (path == NULL) {
 #ifdef USE_ABSTRACT_UNIX_DOMAIN_SOCKETS
+    (void)&create_tmp_domain_socket_path; // not used if
+                                          // USE_ABSTRACT_UNIX_DOMAIN_SOCKETS is
+                                          // set
     // Setting addrlen to `sizeof(sa_family_t)` will autobind
     // the Unix domain socket to a random 5-hex character long
     // abstract address (2^20 autobind addresses)
@@ -173,7 +176,8 @@ int create_domain_server(const char *server_path) {
 int close_domain_socket(int unix_domain_socket_fd) {
   struct sockaddr_un sockaddr = {0};
   socklen_t address_len = sizeof(sockaddr);
-  if (getsockname(unix_domain_socket_fd, &sockaddr, &address_len)) {
+  if (getsockname(unix_domain_socket_fd, (struct sockaddr *)&sockaddr,
+                  &address_len)) {
     log_errno("Failed to getsockname for unix domain socket %d",
               unix_domain_socket_fd);
     return -1;

--- a/src/utils/sockctl.h
+++ b/src/utils/sockctl.h
@@ -35,12 +35,15 @@ struct client_address {
 };
 
 /**
- * @brief Create a domain client object
+ * @brief Create a unix domain client socket
  *
- * @param addr The socket addr, if NULL is auto genereated and hidden
- * @return int Client socket
+ * @param path The UNIX domain socket path.
+ * If this is NULL, a randomly generated _abstract_ Unix domain socket
+ * will be used instead.
+ * @return File-descriptor for the client socket.
+ * @retval -1 On error.
  */
-int create_domain_client(char *addr);
+int create_domain_client(char *path);
 
 /**
  * @brief Create a domain server object

--- a/src/utils/sockctl.h
+++ b/src/utils/sockctl.h
@@ -54,6 +54,20 @@ int create_domain_client(const char *path);
 int create_domain_server(const char *server_path);
 
 /**
+ * @brief Closes and cleans up a unix domain socket.
+ *
+ * Closes the given unix domain socket.
+ * If the given unix domain socket is a _pathname_ socket,
+ * this function also calls unlink() on the _pathname_.
+ *
+ * @param unix_domain_socket_fd The file descriptor of the unix domain socket to
+ * close.
+ * @retval  0 on success.
+ * @retval -1 on error (see `errno` for error details).
+ */
+int close_domain_socket(int unix_domain_socket_fd);
+
+/**
  * @brief Create a udp server object
  *
  * @param port Server port

--- a/src/utils/sockctl.h
+++ b/src/utils/sockctl.h
@@ -38,8 +38,12 @@ struct client_address {
  * @brief Create a unix domain client socket
  *
  * @param path The UNIX domain socket path.
- * If this is NULL, a randomly generated _abstract_ Unix domain socket
- * will be used instead.
+ * If this is NULL:
+ * - On Linux, a randomly generated _abstract_ Unix domain socket
+ *   will be used instead.
+ * - On other Unix platforms, a randomly generated _pathname_ Unix domain
+ *   socket will be used. Please call close_domain_socket() to unlink()
+ *   the `pathname` (and tmp folder) when finished.
  * @return File-descriptor for the client socket.
  * @retval -1 On error.
  */

--- a/src/utils/sockctl.h
+++ b/src/utils/sockctl.h
@@ -43,7 +43,7 @@ struct client_address {
  * @return File-descriptor for the client socket.
  * @retval -1 On error.
  */
-int create_domain_client(char *path);
+int create_domain_client(const char *path);
 
 /**
  * @brief Create a domain server object
@@ -51,7 +51,7 @@ int create_domain_client(char *path);
  * @param server_path Server UNIX domain socket path
  * @return int Domain server socket
  */
-int create_domain_server(char *server_path);
+int create_domain_server(const char *server_path);
 
 /**
  * @brief Create a udp server object

--- a/tests/supervisor/CMakeLists.txt
+++ b/tests/supervisor/CMakeLists.txt
@@ -7,6 +7,11 @@ target_link_libraries(test_bridge_list PRIVATE bridge_list net log cmocka::cmock
 
 add_executable(test_sockctl_server test_sockctl_server.c)
 target_link_libraries(test_sockctl_server PRIVATE sockctl os log cmocka::cmocka)
+if(${CMAKE_SYSTEM_NAME} STREQUAL "Linux")
+  # Abstract Unix domain sockets are only supported on Linux, but save a bit of writing
+  # to the disk
+  target_compile_definitions(test_sockctl_server PRIVATE USE_ABSTRACT_UNIX_DOMAIN_SOCKETS)
+endif()
 
 add_executable(test_cmd_processor test_cmd_processor.c)
 target_link_libraries(test_cmd_processor PRIVATE cmd_processor iptables log cmocka::cmocka)

--- a/tests/supervisor/test_sockctl_server.c
+++ b/tests/supervisor/test_sockctl_server.c
@@ -319,7 +319,7 @@ static void test_close_domain_socket(void **state) {
 
     struct sockaddr_un sockaddr = {0};
     socklen_t address_len = sizeof(sockaddr);
-    getsockname(sock, &sockaddr, &address_len);
+    getsockname(sock, (struct sockaddr *)&sockaddr, &address_len);
 
 #ifdef USE_ABSTRACT_UNIX_DOMAIN_SOCKETS
     assert_int_equal(sockaddr.sun_path[0], '\0');

--- a/tests/supervisor/test_sockctl_server.c
+++ b/tests/supervisor/test_sockctl_server.c
@@ -285,6 +285,71 @@ static void test_write_socket_data(void **state) {
   close(cfd);
 }
 
+static void test_close_domain_socket(void **state) {
+  struct test_state *test_state = *state;
+
+  // close_domain_socket() should unlink the pathname in a pathname unix socket
+  {
+    int sock = create_domain_client(test_state->client_file_path);
+    assert_return_code(sock, errno);
+
+    assert_return_code(check_file_exists(test_state->client_file_path, NULL),
+                       errno);
+
+    assert_return_code(close_domain_socket(sock), errno);
+    // should close the file descriptor
+    assert_true(fcntl(sock, F_GETFD) == -1 && errno == EBADF);
+    assert_int_equal(check_file_exists(test_state->client_file_path, NULL), -1);
+  }
+
+  // should handle _unnamed_ unix sockets
+  {
+    int sock = socket(AF_UNIX, SOCK_DGRAM, 0);
+    assert_return_code(sock, errno);
+
+    assert_return_code(close_domain_socket(sock), errno);
+    // should close the file descriptor
+    assert_true(fcntl(sock, F_GETFD) == -1 && errno == EBADF);
+  }
+
+  // should handle _abstract_ unix sockets
+  {
+    int sock = create_domain_client(NULL);
+    assert_return_code(sock, errno);
+    assert_return_code(close_domain_socket(sock), errno);
+    // should close the file descriptor
+    assert_true(fcntl(sock, F_GETFD) == -1 && errno == EBADF);
+  }
+
+  // should report an error if the input file descriptor is not valid
+  assert_int_equal(close_domain_socket(-1), -1);
+
+  // should report an error if the given file descriptor is not an UNIX domain
+  // socket
+  {
+    int sock = create_udp_server(0);
+    assert_return_code(sock, errno);
+
+    assert_int_equal(close_domain_socket(sock), -1);
+    // cleanup
+    assert_return_code(close(sock), errno);
+  }
+
+  // should throw an error if the unlink() command fails
+  {
+    int sock = create_domain_client(test_state->client_file_path);
+    assert_return_code(sock, errno);
+
+    assert_return_code(check_file_exists(test_state->client_file_path, NULL),
+                       errno);
+    assert_return_code(unlink(test_state->client_file_path), errno);
+
+    // should fail, since unix domain socket path is already unlink()-ed
+    assert_int_equal(close_domain_socket(sock), -1);
+    assert_return_code(close(sock), errno);
+  }
+}
+
 int main(int argc, char *argv[]) {
   (void)argc;
   (void)argv;
@@ -295,6 +360,8 @@ int main(int argc, char *argv[]) {
       cmocka_unit_test_setup_teardown(test_create_domain_server, setup,
                                       teardown),
       cmocka_unit_test_setup_teardown(test_create_domain_client, setup,
+                                      teardown),
+      cmocka_unit_test_setup_teardown(test_close_domain_socket, setup,
                                       teardown),
       cmocka_unit_test_setup_teardown(test_read_domain_data_s, setup, teardown),
       cmocka_unit_test_setup_teardown(test_write_domain_data_s, setup,


### PR DESCRIPTION
Currently, [`create_domain_client(NULL)`](https://nqminds.github.io/edgesec/sockctl_8c.html#ab74693481cda01c302ed453c910a4096) creates a new temporary _abstract_ Unix domain socket:

> **Abstract sockets**
>
> [...]
> Abstract sockets automatically disappear when  all  open  references  to  the  socket  are closed.
>
> The abstract socket namespace is a nonportable Linux extension.

(from https://manpages.ubuntu.com/manpages/jammy/en/man7/unix.7.html)

Since abstract sockets are "a notportable Linux extension", they are not supported by FreeBSD.

Because of this, I've instead replaced this code with creating a new _pathname_ Unix domain socket, where the socket is located in `/tmp/edgesec.XXXXXX/client-socket.sock`, where `/tmp/edgesec.XXXXXX` is made with `mkdtemp`.

**By default, this code is only used on non-Linux platforms, like FreeBSD**.

I then added a new function called `close_domain_socket()` that:
- closes Unix domain sockets, and
- `unlink()` the `pathname` (only for `_pathname_` Unix domain sockets), and
- `rmdir()` the `/tmp/edgesec.XXXXXX` (only if the socket was created by `create_domain_client(NULL)` (I'm using a `uthash` map to confirm this)).

