### PR TITLE
refactor(middlewares): fix const stype difference

### DIFF
--- a/src/capture/middlewares/cleaner_middleware/cleaner_middleware.c
+++ b/src/capture/middlewares/cleaner_middleware/cleaner_middleware.c
@@ -231,9 +231,9 @@ struct middleware_context *init_cleaner_middleware(sqlite3 *db, char *db_path,
   return context;
 }
 
-int process_cleaner_middleware(struct middleware_context *context, char *ltype,
-                               struct pcap_pkthdr *header, uint8_t *packet,
-                               char *ifname) {
+int process_cleaner_middleware(struct middleware_context *context,
+                               const char *ltype, struct pcap_pkthdr *header,
+                               uint8_t *packet, char *ifname) {
   (void)context;
   (void)ltype;
   (void)header;

--- a/src/capture/middlewares/pcap_middleware/pcap_middleware.c
+++ b/src/capture/middlewares/pcap_middleware/pcap_middleware.c
@@ -229,9 +229,9 @@ struct middleware_context *init_pcap_middleware(sqlite3 *db, char *db_path,
   return context;
 }
 
-int process_pcap_middleware(struct middleware_context *context, char *ltype,
-                            struct pcap_pkthdr *header, uint8_t *packet,
-                            char *ifname) {
+int process_pcap_middleware(struct middleware_context *context,
+                            const char *ltype, struct pcap_pkthdr *header,
+                            uint8_t *packet, char *ifname) {
   (void)ltype;
   (void)ifname;
 


### PR DESCRIPTION
`ltype` was made const in commit 669377818af88075f604e71224a703820e30704b but some middlewares missed the change.

Fixes: 669377818af88075f604e71224a703820e30704b