### PR TITLE
feat(os): add copy_argv() function

### DIFF
--- a/src/utils/os.c
+++ b/src/utils/os.c
@@ -288,6 +288,10 @@ int read_command_output(int fd, process_callback_fn fn, void *ctx) {
 
 char **copy_argv(const char *const argv[]) {
   // calculate the length of argv (without NULL terminator)
+  if (argv == NULL) {
+    log_error("argv param is NULL");
+    return NULL;
+  }
   size_t argc = 0;
   while (argv[argc] != NULL) {
     argc++;

--- a/src/utils/os.h
+++ b/src/utils/os.h
@@ -269,6 +269,27 @@ void *__hide_aliasing_typecast(void *foo);
 typedef void (*process_callback_fn)(void *ctx, void *buf, size_t count);
 
 /**
+ * @brief Makes a copy of argv
+ *
+ * When writing code, we normally define argv using `const char *` string
+ * literals, e.g.: `const char * args[] {"hello", "world", NULL};`
+ *
+ * However, the C functions (e.g. execve()) expect `char * const *`,
+ * aka the strings must be mallable (unsafe with string literals).
+ *
+ * This function makes a copy of argv so that we don't get undefined
+ * behaviour by modifing `const` data.
+ *
+ * The entire argv array (and strings) is allocated as a single malloc()
+ * so that you can use a single free() to release the memory when done.
+ *
+ * @param argv The NULL-terminated array of '\0'-terminated strings to copy.
+ * @return A modifiable copy of argv, or @p NULL if malloc() failed.
+ * @post Use `free()` when finished with the @p argv_copy.
+ */
+char **copy_argv(const char *const argv[]);
+
+/**
  * @brief Executes a command
  *
  * @param argv The command arguments including the process path

--- a/tests/utils/test_os.c
+++ b/tests/utils/test_os.c
@@ -31,30 +31,41 @@ static void command_out_fn(void *ctx, void *buf, size_t count) {
 static void test_run_command(void **state) {
   (void)state; /* unused */
 
-  const char *argv[] = {"/usr/bin/env", "uname", "-s", NULL};
+  const char *const argv[] = {"/usr/bin/env", "uname", "-s", NULL};
+  // we need to make a copy of argv, since run_command might modify the data
+  char **argv_copy = copy_argv(argv);
+  assert_non_null(argv_copy);
 
   /* Testing run_command with /usr/bin/env uname -s */
-  int status = run_command(argv, NULL, NULL, NULL);
+  int status = run_command(argv_copy, NULL, NULL, NULL);
   assert_int_equal(status, 0);
 
-  char *argv1[3] = {"/bin/chuppauname", "-s", NULL};
+  {
+    const char *const argv1[] = {"/bin/chuppauname", "-s", NULL};
+    char **argv1_copy = copy_argv(argv1);
+    assert_non_null(argv1_copy);
 
-  /* Testing run_command with /bin/chuppauname -s */
-  status = run_command(argv1, NULL, NULL, NULL);
-  assert_int_not_equal(status, 0);
+    /* Testing run_command with /bin/chuppauname -s */
+    status = run_command(argv1_copy, NULL, NULL, NULL);
+    assert_int_not_equal(status, 0);
+
+    free(argv1_copy);
+  }
 
   /* Testing run_command with NULL */
   status = run_command(NULL, NULL, NULL, NULL);
   assert_int_not_equal(status, 0);
 
-  char *argv2[1] = {NULL};
+  char *argv2[] = {NULL};
   /* Testing run_command with {NULL} */
   status = run_command(argv2, NULL, NULL, NULL);
   assert_int_not_equal(status, 0);
 
   /* Testing run_command with /usr/bin/env uname -s and callback */
-  status = run_command(argv, NULL, command_out_fn, NULL);
+  status = run_command(argv_copy, NULL, command_out_fn, NULL);
   assert_int_equal(status, 0);
+
+  free(argv_copy);
 }
 
 int fn_split_string(const char *str, size_t len, void *data) {


### PR DESCRIPTION
C programs such as `run_command()` accept argv as an `char *`, not a `const char *`. This is because the `main()` function of programs is explicitly allowed to modify the data in `argv()`.

This can cause issues, since we declare arrays using string literals, (e.g. `char * argv[] = {"hello", "world", NULL};`), and modifying string literals is undefined behaviour.

To get around this, we can just make a mofiiable copy of argv before passing it to run_command().

There is a warning we can enable that will check for this (`-Wwrite-strings`), but it creates 100s of warnings throughout our code-base, so it's something we should slowly fix.