### PR TITLE
refactor(radius_client): fix ptr to enum cast

### DIFF
--- a/tests/radius/radius_client.c
+++ b/tests/radius/radius_client.c
@@ -776,7 +776,7 @@ int radius_client_send(struct radius_client_data *radius,
 static void radius_client_receive(int sock, void *eloop_ctx, void *sock_ctx) {
   struct radius_client_data *radius = eloop_ctx;
   struct hostapd_radius_servers *conf = radius->conf;
-  RadiusType msg_type = (RadiusType)sock_ctx;
+  RadiusType msg_type = (RadiusType)(uintptr_t)sock_ctx;
   int len, roundtrip;
   unsigned char buf[3000];
   struct radius_msg *msg;


### PR DESCRIPTION
Casting a pointer to an int is not well defined.
However, casting a pointer to a `uintptr_t` is perfectly legal. Then, casting a `uintptr_t` to a smaller `int`/`enum` is also perfectly legal (although it may result in a loss of data).

The only issues is that `uintptr_t` might not exist on every platform, but it probably exists on all the big platforms.