### PR TITLE
test(packet_queue): fix uninitialised warning

### DIFF
--- a/tests/capture/middlewares/test_packet_queue.c
+++ b/tests/capture/middlewares/test_packet_queue.c
@@ -18,7 +18,7 @@
 
 static void test_push_packet_queue(void **state) {
   (void)state; /* unused */
-  struct tuple_packet tp;
+  struct tuple_packet tp = {0};
   struct packet_queue *queue = init_packet_queue();
 
   assert_non_null(push_packet_queue(queue, tp));


### PR DESCRIPTION
Initialises a variable so we don't get an uninitialised warning.