### PR TITLE
fix(nl): fix missing curly brackets

### DIFF
--- a/src/utils/nl.c
+++ b/src/utils/nl.c
@@ -1016,18 +1016,14 @@ out_handle_destroy:
 }
 
 static int process_phy_handler(struct nl_msg *msg, void *arg) {
+  bool *isvalid = (bool *)arg;
+
   struct nlattr *tb_msg[NL80211_ATTR_MAX + 1];
   struct genlmsghdr *gnlh = nlmsg_data(nlmsg_hdr(msg));
-
-  struct nlattr *nl_mode;
-  int rem_mode;
-  bool *isvalid = (bool *)arg;
-  char *capability;
-  char *wiphy = NULL;
-
   nla_parse(tb_msg, NL80211_ATTR_MAX, genlmsg_attrdata(gnlh, 0),
             genlmsg_attrlen(gnlh, 0), NULL);
 
+  char *wiphy = NULL;
   if (tb_msg[NL80211_ATTR_WIPHY_NAME]) {
     wiphy = nla_get_string(tb_msg[NL80211_ATTR_WIPHY_NAME]);
     log_trace("Using Wiphy %s", wiphy);
@@ -1035,9 +1031,11 @@ static int process_phy_handler(struct nl_msg *msg, void *arg) {
 
   if (tb_msg[NL80211_ATTR_SUPPORTED_IFTYPES]) {
     char modebuf[100];
+    struct nlattr *nl_mode;
+    int rem_mode;
     nla_for_each_nested(nl_mode, tb_msg[NL80211_ATTR_SUPPORTED_IFTYPES],
                         rem_mode) {
-      capability = (char *)iftype_name(nla_type(nl_mode), modebuf);
+      const char *capability = (char *)iftype_name(nla_type(nl_mode), modebuf);
       log_trace("%s -> %s", wiphy, capability);
       if (!strcmp(capability, "AP/VLAN")) {
         *isvalid = true;

--- a/src/utils/nl.c
+++ b/src/utils/nl.c
@@ -1023,7 +1023,7 @@ static int process_phy_handler(struct nl_msg *msg, void *arg) {
   int rem_mode;
   bool *isvalid = (bool *)arg;
   char *capability;
-  char *wiphy;
+  char *wiphy = NULL;
 
   nla_parse(tb_msg, NL80211_ATTR_MAX, genlmsg_attrdata(gnlh, 0),
             genlmsg_attrlen(gnlh, 0), NULL);

--- a/src/utils/nl.c
+++ b/src/utils/nl.c
@@ -1028,9 +1028,10 @@ static int process_phy_handler(struct nl_msg *msg, void *arg) {
   nla_parse(tb_msg, NL80211_ATTR_MAX, genlmsg_attrdata(gnlh, 0),
             genlmsg_attrlen(gnlh, 0), NULL);
 
-  if (tb_msg[NL80211_ATTR_WIPHY_NAME])
+  if (tb_msg[NL80211_ATTR_WIPHY_NAME]) {
     wiphy = nla_get_string(tb_msg[NL80211_ATTR_WIPHY_NAME]);
-  log_trace("Using Wiphy %s", wiphy);
+    log_trace("Using Wiphy %s", wiphy);
+  }
 
   if (tb_msg[NL80211_ATTR_SUPPORTED_IFTYPES]) {
     char modebuf[100];


### PR DESCRIPTION
According to the indentation, this was supposed to be part of the if-block, but because there were no curly braces, the auto-formatter reformatted it.

See https://github.com/nqminds/edgesec/blob/8cd691957f4b727f81d08a0e452caf22102de317/src/utils/nl.c#L1058-L1060

Fixes: 3c1e6da64d9e0d2dad383dbff737d0353f44321e