### PR TITLE
Better CMocka asserts

### DIFF
--- a/tests/supervisor/test_bridge_list.c
+++ b/tests/supervisor/test_bridge_list.c
@@ -203,11 +203,11 @@ static void test_get_all_bridge_edges(void **state) {
   count = get_all_bridge_edges(bridge_list, &tuple_list_arr);
   assert_int_equal(count, 2);
   p = (struct bridge_mac_tuple *)utarray_next(tuple_list_arr, NULL);
-  assert_int_equal(memcmp(p->src_addr, mac_addr_2, ETHER_ADDR_LEN), 0);
-  assert_int_equal(memcmp(p->dst_addr, mac_addr_1, ETHER_ADDR_LEN), 0);
+  assert_memory_equal(p->src_addr, mac_addr_2, ETHER_ADDR_LEN);
+  assert_memory_equal(p->dst_addr, mac_addr_1, ETHER_ADDR_LEN);
   p = (struct bridge_mac_tuple *)utarray_next(tuple_list_arr, p);
-  assert_int_equal(memcmp(p->src_addr, mac_addr_1, ETHER_ADDR_LEN), 0);
-  assert_int_equal(memcmp(p->dst_addr, mac_addr_2, ETHER_ADDR_LEN), 0);
+  assert_memory_equal(p->src_addr, mac_addr_1, ETHER_ADDR_LEN);
+  assert_memory_equal(p->dst_addr, mac_addr_2, ETHER_ADDR_LEN);
   utarray_free(tuple_list_arr);
 
   add_bridge_mac(bridge_list, mac_addr_2, mac_addr_3);
@@ -216,23 +216,23 @@ static void test_get_all_bridge_edges(void **state) {
   assert_int_equal(count, 6);
   assert_int_equal(utarray_len(tuple_list_arr), 6);
   p = (struct bridge_mac_tuple *)utarray_next(tuple_list_arr, NULL);
-  assert_int_equal(memcmp(p->src_addr, mac_addr_4, ETHER_ADDR_LEN), 0);
-  assert_int_equal(memcmp(p->dst_addr, mac_addr_3, ETHER_ADDR_LEN), 0);
+  assert_memory_equal(p->src_addr, mac_addr_4, ETHER_ADDR_LEN);
+  assert_memory_equal(p->dst_addr, mac_addr_3, ETHER_ADDR_LEN);
   p = (struct bridge_mac_tuple *)utarray_next(tuple_list_arr, p);
-  assert_int_equal(memcmp(p->src_addr, mac_addr_3, ETHER_ADDR_LEN), 0);
-  assert_int_equal(memcmp(p->dst_addr, mac_addr_4, ETHER_ADDR_LEN), 0);
+  assert_memory_equal(p->src_addr, mac_addr_3, ETHER_ADDR_LEN);
+  assert_memory_equal(p->dst_addr, mac_addr_4, ETHER_ADDR_LEN);
   p = (struct bridge_mac_tuple *)utarray_next(tuple_list_arr, p);
-  assert_int_equal(memcmp(p->src_addr, mac_addr_3, ETHER_ADDR_LEN), 0);
-  assert_int_equal(memcmp(p->dst_addr, mac_addr_2, ETHER_ADDR_LEN), 0);
+  assert_memory_equal(p->src_addr, mac_addr_3, ETHER_ADDR_LEN);
+  assert_memory_equal(p->dst_addr, mac_addr_2, ETHER_ADDR_LEN);
   p = (struct bridge_mac_tuple *)utarray_next(tuple_list_arr, p);
-  assert_int_equal(memcmp(p->src_addr, mac_addr_2, ETHER_ADDR_LEN), 0);
-  assert_int_equal(memcmp(p->dst_addr, mac_addr_3, ETHER_ADDR_LEN), 0);
+  assert_memory_equal(p->src_addr, mac_addr_2, ETHER_ADDR_LEN);
+  assert_memory_equal(p->dst_addr, mac_addr_3, ETHER_ADDR_LEN);
   p = (struct bridge_mac_tuple *)utarray_next(tuple_list_arr, p);
-  assert_int_equal(memcmp(p->src_addr, mac_addr_2, ETHER_ADDR_LEN), 0);
-  assert_int_equal(memcmp(p->dst_addr, mac_addr_1, ETHER_ADDR_LEN), 0);
+  assert_memory_equal(p->src_addr, mac_addr_2, ETHER_ADDR_LEN);
+  assert_memory_equal(p->dst_addr, mac_addr_1, ETHER_ADDR_LEN);
   p = (struct bridge_mac_tuple *)utarray_next(tuple_list_arr, p);
-  assert_int_equal(memcmp(p->src_addr, mac_addr_1, ETHER_ADDR_LEN), 0);
-  assert_int_equal(memcmp(p->dst_addr, mac_addr_2, ETHER_ADDR_LEN), 0);
+  assert_memory_equal(p->src_addr, mac_addr_1, ETHER_ADDR_LEN);
+  assert_memory_equal(p->dst_addr, mac_addr_2, ETHER_ADDR_LEN);
 
   utarray_free(tuple_list_arr);
   free_bridge_list(bridge_list);
@@ -268,7 +268,7 @@ static void test_get_src_mac_list(void **state) {
   assert_int_equal(count, 1);
 
   p = (uint8_t *)utarray_next(mac_list_arr, NULL);
-  assert_int_equal(memcmp(p, mac_addr_2, ETHER_ADDR_LEN), 0);
+  assert_memory_equal(p, mac_addr_2, ETHER_ADDR_LEN);
   utarray_free(mac_list_arr);
 
   add_bridge_mac(bridge_list, mac_addr_1, mac_addr_3);
@@ -276,29 +276,29 @@ static void test_get_src_mac_list(void **state) {
   count = get_src_mac_list(bridge_list, mac_addr_1, &mac_list_arr);
   assert_int_equal(count, 3);
   p = (uint8_t *)utarray_next(mac_list_arr, NULL);
-  assert_int_equal(memcmp(p, mac_addr_4, ETHER_ADDR_LEN), 0);
+  assert_memory_equal(p, mac_addr_4, ETHER_ADDR_LEN);
   p = (uint8_t *)utarray_next(mac_list_arr, p);
-  assert_int_equal(memcmp(p, mac_addr_3, ETHER_ADDR_LEN), 0);
+  assert_memory_equal(p, mac_addr_3, ETHER_ADDR_LEN);
   p = (uint8_t *)utarray_next(mac_list_arr, p);
-  assert_int_equal(memcmp(p, mac_addr_2, ETHER_ADDR_LEN), 0);
+  assert_memory_equal(p, mac_addr_2, ETHER_ADDR_LEN);
   utarray_free(mac_list_arr);
 
   count = get_src_mac_list(bridge_list, mac_addr_3, &mac_list_arr);
   assert_int_equal(count, 3);
   p = (uint8_t *)utarray_next(mac_list_arr, NULL);
-  assert_int_equal(memcmp(p, mac_addr_1, ETHER_ADDR_LEN), 0);
+  assert_memory_equal(p, mac_addr_1, ETHER_ADDR_LEN);
   p = (uint8_t *)utarray_next(mac_list_arr, p);
-  assert_int_equal(memcmp(p, mac_addr_4, ETHER_ADDR_LEN), 0);
+  assert_memory_equal(p, mac_addr_4, ETHER_ADDR_LEN);
   p = (uint8_t *)utarray_next(mac_list_arr, p);
-  assert_int_equal(memcmp(p, mac_addr_2, ETHER_ADDR_LEN), 0);
+  assert_memory_equal(p, mac_addr_2, ETHER_ADDR_LEN);
   utarray_free(mac_list_arr);
 
   count = get_src_mac_list(bridge_list, mac_addr_2, &mac_list_arr);
   assert_int_equal(count, 2);
   p = (uint8_t *)utarray_next(mac_list_arr, NULL);
-  assert_int_equal(memcmp(p, mac_addr_3, ETHER_ADDR_LEN), 0);
+  assert_memory_equal(p, mac_addr_3, ETHER_ADDR_LEN);
   p = (uint8_t *)utarray_next(mac_list_arr, p);
-  assert_int_equal(memcmp(p, mac_addr_1, ETHER_ADDR_LEN), 0);
+  assert_memory_equal(p, mac_addr_1, ETHER_ADDR_LEN);
   utarray_free(mac_list_arr);
 
   int ret = remove_bridge_mac(bridge_list, mac_addr_1, mac_addr_4);

--- a/tests/utils/test_iface_mapper.c
+++ b/tests/utils/test_iface_mapper.c
@@ -31,7 +31,7 @@ static void test_get_if_mapper(void **state) {
   bool ret = get_if_mapper(&hmap, 0x0A000100, ifname);
   assert_true(ret);
 
-  assert_int_equal(strcmp(ifname, "br2"), 0);
+  assert_string_equal(ifname, "br2");
 
   ret = get_if_mapper(&hmap, 0x0A000101, ifname);
   assert_false(ret);
@@ -50,7 +50,7 @@ static void test_put_if_mapper(void **state) {
   ret = get_if_mapper(&hmap, 0x0A000100, ifname);
   assert_true(ret);
 
-  assert_int_equal(strcmp(ifname, "br2"), 0);
+  assert_string_equal(ifname, "br2");
   free_if_mapper(&hmap);
 }
 


### PR DESCRIPTION
Replaces all usages of:
- `assert_int_equal(memcmp` with [`assert_memory_equal()`](https://api.cmocka.org/group__cmocka__asserts.html#gac933d8b75ebd55e88ca85963721c05d9)
- `assert_int_equal(strcmp` with [`assert_string_equal()`](https://api.cmocka.org/group__cmocka__asserts.html#ga3db7885581668648088fc4eb4cee6d4f)