### PR TITLE
test(sqlite_header): improve sqlite_header tests

### DIFF
--- a/tests/capture/middlewares/CMakeLists.txt
+++ b/tests/capture/middlewares/CMakeLists.txt
@@ -6,7 +6,7 @@ target_link_options(test_header_middleware
 )
 
 add_executable(test_sqlite_header test_sqlite_header.c)
-target_link_libraries(test_sqlite_header PRIVATE sqlite_header os log Threads::Threads cmocka::cmocka)
+target_link_libraries(test_sqlite_header PRIVATE sqlite_header os log Threads::Threads cmocka::cmocka SQLite::SQLite3)
 
 add_executable(test_packet_queue test_packet_queue.c)
 target_link_libraries(test_packet_queue PUBLIC PCAP::pcap SQLite::SQLite3 PRIVATE packet_queue os log cmocka::cmocka)
@@ -25,7 +25,9 @@ set_tests_properties(test_header_middleware
 add_test(NAME test_sqlite_header COMMAND test_sqlite_header)
 set_tests_properties(test_sqlite_header
   PROPERTIES
-  WILL_FAIL FALSE)
+  WILL_FAIL FALSE
+  ENVIRONMENT CMOCKA_TEST_ABORT='1' # these tests uses threading
+)
 
 add_test(NAME test_packet_queue COMMAND test_packet_queue)
 set_tests_properties(test_packet_queue


### PR DESCRIPTION
The `test_sqlite_header` test is intermittently failing in GitHub Actions.

I'm not 100% sure why this the test is failing.
One thing I did notice is that CMocka performs really poorly in multi-threaded applications.

As recommended in the CMocka docs, I've added the `CMOCKA_TEST_ABORT=1` environment variable so that CMocka automatically `aborts()` if a test fails, see https://api.cmocka.org/#main-threads

I've also removed all of the `assert_*()` macros from the non-main threads, since CMocka doesn't properly handle these. Instead, we pass an error_message string to the main thread, and the main thread then calls `asssert_string_equal()` on it.

This might fix https://github.com/nqminds/edgesec/issues/252, but even if it doesn't, hopefully this will improve the logs and make it easier to debug in the future.