### PR TITLE
fix(nl): fix potential missing NUL terminator

### DIFF
--- a/src/utils/nl.c
+++ b/src/utils/nl.c
@@ -592,7 +592,8 @@ static int ipaddr_modify(int cmd, int flags, int argc,
       // Get prefix temporarily modifies argv,
       // which may cause problems for multi-threading
       char argv_buf[256];
-      strncpy(argv_buf, *argv, 256);
+      argv_buf[255] = '\0'; // NUL terminate in case strncpy maxes out
+      strncpy(argv_buf, *argv, sizeof(argv_buf) - 1);
       get_prefix(&lcl, argv_buf, req.ifa.ifa_family);
       if (req.ifa.ifa_family == AF_UNSPEC)
         req.ifa.ifa_family = lcl.family;


### PR DESCRIPTION
When compiling with `-DCMAKE_BUILD_TYPE=Release`, we get a `-Wstringop-truncation` warning.

This is because when `strncpy` exits early because the input string is too long, it **DOES NOT** copy a NUL terminator. Instead, we need to manually setup a NUL terminator ourselves.

---

Side-note, I've been trying to use NULL to denote `NULL` (aka ptr type) and NUL/␀ to denote `'\0'` (aka char/byte type). That seems to be the convention for C programmers.