### PR TITLE
fix(sockctl): fix cleanup of unix mkdtemp dirs

### DIFF
--- a/src/utils/sockctl.c
+++ b/src/utils/sockctl.c
@@ -75,7 +75,7 @@ static int cleanup_tmp_domain_socket_path(const char *socket_path) {
     return -1;
   }
   if (strncmp(TMP_UNIX_SOCK_FOLDER_PREFIX, socket_path,
-              sizeof(TMP_UNIX_SOCK_FOLDER_PREFIX)) != 0) {
+              sizeof(TMP_UNIX_SOCK_FOLDER_PREFIX) - 1) != 0) {
     // **NOT** created create_tmp_domain_socket_path()
     return 0;
   }


### PR DESCRIPTION
Whoops, I forgot that `sizeof("")` includes a NUL-terminator, even though `strlen("")` does not include a NUL-terminator.