### PR TITLE
Error on all C/C++ compiler warnings in `src/` and `tests/`

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -1,3 +1,6 @@
+# Error on all C/C++ warnings in the src/ directory if making a Debug build
+add_compile_options($<$<CONFIG:Debug>:-Werror>)
+
 add_subdirectory(utils)
 add_subdirectory(supervisor)
 add_subdirectory(ap)

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -1,3 +1,6 @@
+# Error on all C/C++ warnings in the tests/ directory if making a Debug build
+add_compile_options($<$<CONFIG:Debug>:-Werror>)
+
 include_directories (
   "${PROJECT_SOURCE_DIR}/src"
 )

--- a/tests/utils/test_os.c
+++ b/tests/utils/test_os.c
@@ -107,15 +107,20 @@ static void test_run_command(void **state) {
   status = run_command(argv2, NULL, NULL, NULL);
   assert_int_not_equal(status, 0);
 
-  expect_string(command_out_fn, ctx, "Context");
-  expect_string(command_out_fn, null_terminated_str, "Hello World!\n");
-  expect_value(command_out_fn, count,
-               sizeof("Hello World!\n") - 1); // -1 due to no null terminator
+  { // test process_callback_fn
+    expect_string(command_out_fn, ctx, "Context");
+    expect_string(command_out_fn, null_terminated_str, "Hello World!\n");
+    expect_value(command_out_fn, count,
+                 sizeof("Hello World!\n") - 1); // -1 due to no null terminator
 
-  const char *hello_world_argv[] = {"/usr/bin/env", "echo", "Hello World!",
-                                    NULL};
-  status = run_command(hello_world_argv, NULL, command_out_fn, "Context");
-  assert_int_equal(status, 0);
+    const char *hello_world_argv[] = {"/usr/bin/env", "echo", "Hello World!",
+                                      NULL};
+    char **hello_world_argv_copy = copy_argv(hello_world_argv);
+    status =
+        run_command(hello_world_argv_copy, NULL, command_out_fn, "Context");
+    assert_int_equal(status, 0);
+    free(hello_world_argv_copy);
+  }
 
   free(argv_copy);
 }


### PR DESCRIPTION
Enables the GCC/Clang `-Werror` flag on everything in the src/ and tests/ folder.

It's only enabled if `-DCMAKE_BUILD_TYPE=Debug`. This is so that any 3rd parties using edgesec (for example https://github.com/nqminds/manysecured-openwrt-packages or even the `.deb` build) should still be able to compile edgesec, even if they have a newer version of GCC/Clang that adds new warnings.

These warnings are usually pretty useful, so we probably want to fix them all. If we ever want to disable this, we can do:

```cmake
add_compile_options(-Wno-error=foo) # too many -Wfoo warnings
```

Or better yet, we can use [`target_compile_options`](https://cmake.org/cmake/help/latest/command/target_compile_options.html) to disable them just in one file:

```cmake
target_compile_options(my_library_with_warnings
  PUBLIC -Wno-error=foo # error is also disabled for all dependencies of this lib (e.g. error is in header file)
  PRIVATE -Wno-error=foo # error is not disable for dependencies of this lib (e.g. error is only in .c source file
)
```

There was only one minor warning left to fix in our code, see [test(os): fix const correctness argv warning](https://github.com/nqminds/edgesec/commit/c7e3239f93c589e639f47633083c15f6d784a28e).

(OpenSSL, `lib/libnetlink`, `sqlite3` and `libpcap` print a lot of warnings, but since they're not in `src/` and `tests/`, they won't be converted to errors.