### PR TITLE
Replace pthread with threads in `test_eloop_threaded`

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -148,6 +148,13 @@ include(uthash)
 set(THREADS_PREFER_PTHREAD_FLAG TRUE)
 find_package(Threads REQUIRED)
 
+# Most C11 implementation support threads.h, but it's technically optional and not yet supported on MSVC
+include(CheckIncludeFile)
+check_include_file(threads.h C11_STD_THREADS)
+if (NOT C11_STD_THREADS)
+  message(FATAL_ERROR "Your C11 stdlib does not support #include <threads.h>, see https://en.cppreference.com/w/c/thread")
+endif()
+
 # configure a header file to pass some of the CMake settings
 # to the source code
 configure_file(


### PR DESCRIPTION
pthreads.h is non-standard C11.

The C11 `threads.h` library is supported in almost every modern C11 compiler. However, since it's technically optional, we should explicitly check if it's supported, so that we can print a nicer error message.

Technically, the way you are supposed to do this is by checking for `__STDC_NO_THREADS__`, but that's not easy to do in CMake.

On Linux, you must still link with -lpthreads.

However CMake's `find_package(Threads)` means that we can just link to `Threads::Threads` and CMake will auto-link the correct threading library.

The API for `threads.h` and for `pthreads.h` is pretty similar, but:
  - pthread.h behaviours slightly different on Linux from baseline POSIX.
  - [cppreference](https://en.cppreference.com/w/c/thread) is much nicer than looking at Linux man pages
  -  `threads.h` has a bunch of extra helper features (like atomics for thread safe variables)

**Currently this only a partial proof-of-concept replacement in a single-file**