### PR TITLE
docs: link to cppreference.com in doxygen docs

### DIFF
--- a/docs/doxygen-tag-files.cmake
+++ b/docs/doxygen-tag-files.cmake
@@ -1,0 +1,28 @@
+# Downloads Doxygen tagfiles
+#
+# These are used to auto-link EDGESec docs to external library
+# docs.
+#
+
+include(ExternalProject)
+
+ExternalProject_Add(
+    cppreference_tag_file
+    URL https://upload.cppreference.com/mwiki/images/1/16/html_book_20190607.tar.xz
+    URL_HASH SHA256=8f97b2baa749c748a2e022d785f1a2e95aa851a3075987dfcf38baf65e0e486d
+    CONFIGURE_COMMAND ""
+    INSTALL_COMMAND ""
+    BUILD_COMMAND ""
+    EXCLUDE_FROM_ALL TRUE
+)
+ExternalProject_Get_Property(
+    cppreference_tag_file
+    SOURCE_DIR
+)
+list(
+    APPEND tag_files_list
+    "${SOURCE_DIR}/cppreference-doxygen-web.tag.xml=http://en.cppreference.com/w/"
+)
+list(APPEND tag_file_dependencies cppreference_tag_file)
+
+list(JOIN tag_files_list " " DOXYGEN_TAGFILES)

--- a/docs/doxygen.cmake
+++ b/docs/doxygen.cmake
@@ -14,6 +14,10 @@ if (DOXYGEN_FOUND)
           "dot is not installed, but is highly recommended to create directed graphs"
         )
     endif()
+
+    # Add external library tag files
+    include(./doxygen-tag-files)
+
     # Doxygen parameters
     # currently unused, set if we want to use the `@image` command
     # set(DOXYGEN_IMAGE_PATH "${PROJECT_SOURCE_DIR}/docs")
@@ -43,6 +47,7 @@ if (DOXYGEN_FOUND)
         COMMENT "Generating API documentation with Doxygen"
       )
     endif()
+    add_dependencies(doxydocs ${tag_file_dependencies})
 else ()
   message(WARNING "Doxygen need to be installed to generate the doxygen documentation")
 endif ()


### PR DESCRIPTION
[cppreference.com][1] supplies a Doxygen tag file that can be used to automatically link standard C functions/types to the appropriate cppreference page.

Unfortunately, the tag file is for the C++ stdlib, not the C stdlib, however, the C standard library is mostly included in the C++ spec.

For example, `va_list` will link to https://en.cppreference.com/w/cpp/utility/variadic/va_list, which the C++ version of https://en.cppreference.com/w/c/variadic/va_list

See [the doxygen TAGFILES option][2].

[1]: https://en.cppreference.com/w/Cppreference:Archives#Doxygen_tag_file
[2]: https://www.doxygen.nl/manual/external.html

This slows down the `doxydocs` build by about 1 second, so the performance impact is minimal.