### PR TITLE
Remove deprecated `tempnam()` from eloop tests

### DIFF
--- a/tests/utils/CMakeLists.txt
+++ b/tests/utils/CMakeLists.txt
@@ -23,7 +23,7 @@ add_executable(test_os test_os.c)
 target_link_libraries(test_os PRIVATE tmpdir os allocs hashmap cmocka::cmocka)
 
 add_executable(test_eloop test_eloop.c)
-target_link_libraries(test_eloop PRIVATE sockctl os allocs eloop cmocka::cmocka)
+target_link_libraries(test_eloop PRIVATE tmpdir sockctl os allocs eloop cmocka::cmocka)
 
 add_executable(test_eloop_threaded test_eloop_threaded.c)
 target_link_libraries(test_eloop_threaded PRIVATE eloop cmocka::cmocka sockctl LibUTHash::LibUTHash Threads::Threads)

--- a/tests/utils/CMakeLists.txt
+++ b/tests/utils/CMakeLists.txt
@@ -2,6 +2,9 @@ include_directories(
   "${PROJECT_SOURCE_DIR}/src"
 )
 
+add_library(tmpdir OBJECT tmpdir.c)
+target_link_libraries(tmpdir PRIVATE log cmocka::cmocka)
+
 if (USE_UCI_SERVICE)
   add_executable(test_uci_wrt test_uci_wrt.c)
   target_link_libraries(test_uci_wrt PRIVATE uci_wrt cmocka::cmocka iface_mapper)
@@ -17,7 +20,7 @@ add_executable(test_net test_net.c)
 target_link_libraries(test_net PRIVATE net cmocka::cmocka)
 
 add_executable(test_os test_os.c)
-target_link_libraries(test_os PRIVATE os allocs hashmap cmocka::cmocka)
+target_link_libraries(test_os PRIVATE tmpdir os allocs hashmap cmocka::cmocka)
 
 add_executable(test_eloop test_eloop.c)
 target_link_libraries(test_eloop PRIVATE sockctl os allocs eloop cmocka::cmocka)

--- a/tests/utils/test_os.c
+++ b/tests/utils/test_os.c
@@ -13,12 +13,14 @@
 #include <setjmp.h>
 #include <stdint.h>
 #include <cmocka.h>
-// used to delete directory recursively
-#include <ftw.h>
+
+#include <limits.h>
 
 #include "utils/log.h"
 #include "utils/os.h"
 #include "utils/allocs.h"
+
+#include "tmpdir.h"
 
 static void test_copy_argv(void **state) {
   (void)state; /* unused */
@@ -550,68 +552,10 @@ static void test_list_dir(void **state) {
   assert_int_equal(list_dir("/bin", failing_dir_fn, &found_ls), -1);
 }
 
-typedef struct {
-  char tmp_dir[256];
-} make_dirs_to_path_t;
-
-static int test_make_dirs_to_path_setup(void **state) {
-  make_dirs_to_path_t *test_state = test_calloc(1, sizeof(make_dirs_to_path_t));
-  *state = test_state;
-
-  // ignore return value if directory creation failed
-  mkdir("/tmp/edgesec_tests", 0755);
-  char template[] = "/tmp/edgesec_tests/os_tests.XXXXXX";
-  char *tmp_dir = mkdtemp(template);
-
-  // check to see if tmp_dir was built correctly
-  assert_non_null(tmp_dir);
-
-  strcpy(test_state->tmp_dir, tmp_dir);
-  return 0;
-}
-
-// recursively delete folder using ftw
-static int rm_file(const char *pathname, const struct stat *sbuf, int type,
-                   struct FTW *ftwb) {
-  (void)sbuf;
-  (void)type;
-  (void)ftwb;
-
-  if (remove(pathname) < 0) {
-    perror("ERROR: remove");
-    return -1;
-  }
-  return 0;
-}
-static int rm_dir_recursive(const char *directory) {
-  int ret_val = nftw(directory, rm_file, 10, FTW_DEPTH | FTW_MOUNT | FTW_PHYS);
-  if (ret_val) {
-    printf("Error when trying to delete '%s'", directory);
-    perror("ERROR: rm_dir_recursive for directory");
-  }
-  return ret_val;
-}
-
-static int test_make_dirs_to_path_teardown(void **state) {
-  make_dirs_to_path_t *test_state = *state;
-  if (test_state == NULL) {
-    return 0;
-  }
-
-  assert_string_not_equal(test_state->tmp_dir, "");
-  int ret_val = rm_dir_recursive(test_state->tmp_dir);
-  assert_int_equal(ret_val, 0);
-  strcpy(test_state->tmp_dir, "");
-
-  test_free(*state);
-  *state = NULL;
-  return 0;
-}
-
 static void test_make_dirs_to_path(void **state) {
-  make_dirs_to_path_t *test_state = *state;
+  struct tmpdir *test_state = *state;
   char *directories_to_build =
-      construct_path(test_state->tmp_dir, "should/create/these/dirs");
+      construct_path(test_state->tmpdir, "should/create/these/dirs");
   char *path = construct_path(directories_to_build, "not_a_dir.txt");
 
   int ret = make_dirs_to_path(path, 0755);
@@ -684,9 +628,8 @@ int main(int argc, char *argv[]) {
       cmocka_unit_test(test_get_secure_path),
       cmocka_unit_test(test_list_dir),
       cmocka_unit_test(test_string_append_char),
-      cmocka_unit_test_setup_teardown(test_make_dirs_to_path,
-                                      test_make_dirs_to_path_setup,
-                                      test_make_dirs_to_path_teardown)};
+      cmocka_unit_test_setup_teardown(test_make_dirs_to_path, setup_tmpdir,
+                                      teardown_tmpdir)};
 
   return cmocka_run_group_tests(tests, NULL, NULL);
 }

--- a/tests/utils/tmpdir.c
+++ b/tests/utils/tmpdir.c
@@ -1,0 +1,67 @@
+#define _XOPEN_SOURCE 700 /* mkdtemp() is part of POSIX 700 spec*/
+#include <stdarg.h>
+#include <stddef.h>
+#include <setjmp.h>
+#include <stdint.h>
+#include <cmocka.h>
+// used to delete directory recursively
+#include <ftw.h>
+
+#include <stdlib.h>
+
+#include "utils/log.h"
+
+#include "tmpdir.h"
+
+// recursively delete folder using ftw
+static int rm_file(const char *pathname, const struct stat *sbuf, int type,
+                   struct FTW *ftwb) {
+  (void)sbuf;
+  (void)type;
+  (void)ftwb;
+
+  if (remove(pathname) < 0) {
+    log_errno("remove %s", pathname);
+    return -1;
+  }
+  return 0;
+}
+static int rm_dir_recursive(const char *directory) {
+  int ret_val = nftw(directory, rm_file, 10, FTW_DEPTH | FTW_MOUNT | FTW_PHYS);
+  if (ret_val) {
+    log_error("Error when trying to delete '%s'", directory);
+  }
+  return ret_val;
+}
+
+int setup_tmpdir(void **test_state) {
+  struct tmpdir *state = test_malloc(sizeof(struct tmpdir));
+  assert_non_null(state);
+
+  // ignore return value if directory creation failed
+  (void)mkdir("/tmp/edgesec_tests", 0755);
+
+  *state = (struct tmpdir){.tmpdir = TMPDIR_MKDTEMP_TEMPLATE};
+  assert_non_null(mkdtemp(state->tmpdir));
+
+  *test_state = state;
+  return 0;
+}
+
+int teardown_tmpdir(void **test_state) {
+  struct tmpdir *state = *test_state;
+
+  if (state == NULL) {
+    return 0;
+  }
+  assert_string_not_equal(state->tmpdir, "");
+
+  log_debug("Deleting directory recursively %s", state->tmpdir);
+  int ret_val = rm_dir_recursive(state->tmpdir);
+  assert_int_equal(ret_val, 0);
+
+  test_free(state);
+
+  *test_state = NULL;
+  return 0;
+}

--- a/tests/utils/tmpdir.h
+++ b/tests/utils/tmpdir.h
@@ -1,0 +1,33 @@
+/**
+ * @brief Contains CMocka setup/teardown functions for creating tmpdirs
+ * @author Alois Klink
+ * @date 2022
+ * @copyright
+ * SPDX-FileCopyrightText: © 2022 NQMCyber Ltd and edgesec contributors
+ * SPDX-License-Identifier: LGPL-3.0-or-later
+ */
+
+#define TMPDIR_MKDTEMP_TEMPLATE "/tmp/edgesec_tests/tmpdir.XXXXXX"
+
+struct tmpdir {
+  char tmpdir[sizeof(TMPDIR_MKDTEMP_TEMPLATE)];
+};
+
+/**
+ * @brief Sets up tmpdir object.
+ *
+ * Contains a temporary directory that will be deleted by cleanup_tmpdir()
+ *
+ * @param[out] test_state Will be set to the pointer to the created struct
+ * tmpdir
+ * @return Return code.
+ */
+int setup_tmpdir(void **test_state);
+
+/**
+ * @brief Deletes tmpdir and all contents
+ *
+ * @param[in, out] test_state Pointer to `struct tmpdir`. Will be set to NULL.
+ * @return Return code.
+ */
+int teardown_tmpdir(void **test_state);


### PR DESCRIPTION
Removes the usage of `tempnam()`, which is deprecated and throws a warning on use.
The first line of the description in the tempnam manpage says:

> _Never use this function_.  Use mkstemp(3) or tmpfile(3) instead.

I've made a new file called `tests/utils/tmpdir.h` that contains the following functions, that can be used as CMocka setup/teardown functions.

- `int setup_tmpdir(void **test_state);`
- `int teardown_tmpdir(void **test_state);`