### PR TITLE
Adds basic tests for `config.ini` parsing

### DIFF
--- a/deployment/rpi-config/config.ini
+++ b/deployment/rpi-config/config.ini
@@ -72,11 +72,13 @@ firewallBinPath = ""
 
 [dns]
 servers="8.8.4.4,8.8.8.8"
+mdnsFilter = "src net 10.0 and dst net 10.0"
 
 [dhcp]
 dhcpBinPath = "/usr/sbin/dnsmasq"
 dhcpConfigPath = "/tmp/dnsmasq.conf"
 dhcpScriptPath = "/tmp/dnsmasq_exec.sh"
+dhcpLeasefilePath = "/tmp/dnsmasq.leases"
 dhcpRange0 = "0,10.0.0.2,10.0.0.254,255.255.255.0,24h"
 dhcpRange1 = "1,10.0.1.2,10.0.1.254,255.255.255.0,24h"
 dhcpRange2 = "2,10.0.2.2,10.0.2.254,255.255.255.0,24h"

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -33,6 +33,9 @@ if (USE_MDNS_SERVICE)
   add_subdirectory(dns)
 endif ()
 
+add_executable(test_config test_config.c)
+target_link_libraries(test_config PRIVATE cmocka::cmocka log config)
+
 add_executable(test_runctl test_runctl.c)
 target_link_libraries(test_runctl PUBLIC SQLite::SQLite3 LibUTHash::LibUTHash PRIVATE runctl log os supervisor_config mac_mapper cmocka::cmocka)
 
@@ -60,6 +63,11 @@ endif()
 if (USE_UCI_SERVICE)
   target_link_libraries(test_runctl PUBLIC __wrap_uwrt_init_context)
 endif()
+
+add_test(NAME test_config COMMAND test_config)
+set_tests_properties(test_config
+  PROPERTIES
+  WILL_FAIL FALSE)
 
 add_test(NAME test_runctl COMMAND test_runctl)
 set_tests_properties(test_runctl

--- a/tests/test_config.c
+++ b/tests/test_config.c
@@ -1,0 +1,58 @@
+#include <stdarg.h>
+#include <stddef.h>
+#include <setjmp.h>
+#include <stdint.h>
+#include <cmocka.h>
+
+#include "./utils/log.h"
+
+#include "./config.h"
+#include <libgen.h>
+#include <limits.h>
+
+static void get_edgesec_root_dir(char buffer[static PATH_MAX]) {
+  char this_file[] = __FILE__;
+  const char *edgesec_root_dir = dirname(dirname(this_file));
+  strncpy(buffer, edgesec_root_dir, PATH_MAX - 1);
+  buffer[PATH_MAX - 1] = '\0';
+}
+
+static void test_load_config(const char *path_to_config_from_root_dir) {
+  struct app_config config = {0};
+
+  char edgesec_root_dir[PATH_MAX];
+  get_edgesec_root_dir(edgesec_root_dir);
+
+  // need to make copy since construct_path() uses non-const char*
+  char path_to_config[PATH_MAX] = {0};
+  strncpy(path_to_config, path_to_config_from_root_dir, PATH_MAX - 1);
+
+  char *full_config_path = construct_path(edgesec_root_dir, path_to_config);
+  log_debug("Loading app config from %s", full_config_path);
+  bool ret = load_app_config(full_config_path, &config);
+  assert_true(ret);
+
+  free(full_config_path);
+  free_app_config(&config);
+}
+
+static void test_load_configs(void **state) {
+  (void)state; /* unused */
+  test_load_config("dev-config.ini");
+  test_load_config("deployment/owrt-config/config-dev.ini");
+  test_load_config("deployment/owrt-config/config.ini");
+  test_load_config("deployment/rpi-config/config.ini");
+}
+
+int main(int argc, char *argv[]) {
+  (void)argc;
+  (void)argv;
+
+  log_set_quiet(false);
+
+  const struct CMUnitTest tests[] = {
+      cmocka_unit_test(test_load_configs),
+  };
+
+  return cmocka_run_group_tests(tests, NULL, NULL);
+}


### PR DESCRIPTION
Adds a basic tests that tries to parse the following files and sees if an error is thrown:

```c
  test_load_config("dev-config.ini");
  test_load_config("deployment/owrt-config/config-dev.ini");
  test_load_config("deployment/owrt-config/config.ini");
  test_load_config("deployment/rpi-config/config.ini");
```

I found that there were two missing params in `deployment/rpi-config/config.ini`, so these have now been fixed as well.