### PR TITLE
refactor(hashmap): fix circular dependency

### DIFF
--- a/src/utils/CMakeLists.txt
+++ b/src/utils/CMakeLists.txt
@@ -12,7 +12,7 @@ add_library(base64 base64.c)
 target_link_libraries(base64 PRIVATE os log)
 
 add_library(hashmap hashmap.c)
-target_link_libraries(hashmap PUBLIC LibUTHash::LibUTHash PRIVATE log os)
+target_link_libraries(hashmap PUBLIC LibUTHash::LibUTHash PRIVATE log)
 
 add_library(os os.c)
 set_property(TARGET os PROPERTY POSITION_INDEPENDENT_CODE ON)


### PR DESCRIPTION
We don't need to `#include <os.h>` or `#include <allocs.h>` since these functions are part of the C11 standard lib.

strdup() is also part of the C23 standard, but it's part of the POSIX standard too.

The only annoying thing is that although `strnlen_s` is part of the C11 standard. Everybody hates it, and only MSVC has these functions (although they're meant to be buggy).

Luckily, `strnlen_s` is very easy to define in terms of `strnlen`, which is part of the POSIX standard, and part of GCC/Clang's stdlib (the only difference is that `strnlen_s` returns 0 if the input str is `NULL`)