### PR TITLE
Refactor non-`const` string literals in `iptables`

### DIFF
--- a/src/utils/iptables.c
+++ b/src/utils/iptables.c
@@ -299,8 +299,8 @@ int get_nat_rules(struct iptables_context *ctx) {
   return utarray_len(ctx->rule_list) ? 0 : -1;
 }
 
-long find_rule(UT_array *rlist, char *sip, char *sif, char *dip, char *dif,
-               char *target) {
+long find_rule(UT_array *rlist, const char *sip, const char *sif,
+               const char *dip, const char *dif, const char *target) {
   struct iptables_columns *el = NULL;
   while ((el = (struct iptables_columns *)utarray_next(rlist, el)) != NULL) {
     if (!strcmp(el->in, sif) && !strcmp(el->out, dif) &&
@@ -312,8 +312,8 @@ long find_rule(UT_array *rlist, char *sip, char *sif, char *dip, char *dif,
   return 0;
 }
 
-int delete_bridge_rule(struct iptables_context *ctx, char *sip, char *sif,
-                       char *dip, char *dif) {
+int delete_bridge_rule(struct iptables_context *ctx, const char *sip,
+                       const char *sif, const char *dip, const char *dif) {
   char num_buf[10];
 
   const char *bridge_rule[16] = {"-D", "FORWARD", NULL, "-t", "filter", NULL};
@@ -341,8 +341,8 @@ int delete_bridge_rule(struct iptables_context *ctx, char *sip, char *sif,
   return 0;
 }
 
-int iptables_delete_bridge(struct iptables_context *ctx, char *sip, char *sif,
-                           char *dip, char *dif) {
+int iptables_delete_bridge(struct iptables_context *ctx, const char *sip,
+                           const char *sif, const char *dip, const char *dif) {
   if (delete_bridge_rule(ctx, sip, sif, dip, dif) < 0) {
     log_error("delete_bridge_rule fail");
     return -1;
@@ -356,7 +356,7 @@ int iptables_delete_bridge(struct iptables_context *ctx, char *sip, char *sif,
   return 0;
 }
 
-long find_baseif_rulenum(UT_array *rlist, char *ifname) {
+long find_baseif_rulenum(UT_array *rlist, const char *ifname) {
   struct iptables_columns *el = NULL;
   while ((el = (struct iptables_columns *)utarray_next(rlist, el)) != NULL) {
     if (!strcmp(el->in, ifname) && !strcmp(el->out, "*") &&
@@ -367,8 +367,8 @@ long find_baseif_rulenum(UT_array *rlist, char *ifname) {
   return 0;
 }
 
-int add_bridge_rule(struct iptables_context *ctx, char *sip, char *sif,
-                    char *dip, char *dif) {
+int add_bridge_rule(struct iptables_context *ctx, const char *sip,
+                    const char *sif, const char *dip, const char *dif) {
   char num_buf[10];
 
   const char *bridge_rule[16] = {

--- a/src/utils/iptables.h
+++ b/src/utils/iptables.h
@@ -70,8 +70,8 @@ int iptables_add_bridge(struct iptables_context *ctx, char *sip, char *sif,
  * @param dif Destination interface name string
  * @return 0 on success, -1 on error
  */
-int iptables_delete_bridge(struct iptables_context *ctx, char *sip, char *sif,
-                           char *dip, char *dif);
+int iptables_delete_bridge(struct iptables_context *ctx, const char *sip,
+                           const char *sif, const char *dip, const char *dif);
 
 /**
  * @brief Add a NAT rule

--- a/src/utils/net.c
+++ b/src/utils/net.c
@@ -18,7 +18,7 @@
 #include "os.h"
 #include "net.h"
 
-bool validate_ipv4_string(char *ip) {
+bool validate_ipv4_string(const char *ip) {
   struct sockaddr_in sa;
   char proc_ip[OS_INET_ADDRSTRLEN];
   char *netmask_sep = strchr(ip, '/');

--- a/src/utils/net.h
+++ b/src/utils/net.h
@@ -56,7 +56,7 @@
  * @param ip The IP in fromat x.y.z.q
  * @return true if the string is an IP, false otherwise
  */
-bool validate_ipv4_string(char *ip);
+bool validate_ipv4_string(const char *ip);
 
 /**
  * @brief IP string to @c struct in_addr_t converter


### PR DESCRIPTION
Modifying string literals is undefined behaviour in the C spec, and can cause all sorts of trouble (especially at higher optimisation levels).

A good way to prevent modifying string literals is to label them as `const`. This is the default behaviour in C++, but unfortunately, back in the early days of C, `const` didn't yet exist, and so we need to add an optional `-Wwrite-strings` compiler flag to enable making them `const` by default.

While waiting for OpenWRT to super slowly compile, I went through the `iptables` source files and made sure that we had no `-Wwrite-strings` warnings.