### PR TITLE
refactor(subscribe_events): fix `-Wwrite-strings`

### DIFF
--- a/src/supervisor/subscriber_events.c
+++ b/src/supervisor/subscriber_events.c
@@ -66,7 +66,7 @@ int add_events_subscriber(struct supervisor_context *context,
   return 0;
 }
 
-int send_events(struct supervisor_context *context, char *name,
+int send_events(struct supervisor_context *context, const char *name,
                 const char *format, va_list args) {
   struct client_address *p = NULL;
   char *send_buf = NULL;


### PR DESCRIPTION
Fix `-Wwrite-strings` warnings, where we use a string literal in a non-const location.