### PR TITLE
Make `hmap_str_keychar_get()` params const

### DIFF
--- a/src/firewall/firewall_service.c
+++ b/src/firewall/firewall_service.c
@@ -153,7 +153,7 @@ struct fwctx *fw_init_context(hmap_if_conn *if_mapper,
     return NULL;
   }
 #else
-  char *iptables_path = hmap_str_keychar_get(&hmap_bin_paths, "iptables");
+  const char *iptables_path = hmap_str_keychar_get(hmap_bin_paths, "iptables");
   if (iptables_path == NULL) {
     log_error("Couldn't find iptables binary");
     fw_free_context(fw_ctx);

--- a/src/runctl.c
+++ b/src/runctl.c
@@ -266,7 +266,7 @@ int init_context(struct app_config *app_config,
     return -1;
   }
 
-  char *ipcmd_path = hmap_str_keychar_get(&ctx->hmap_bin_paths, "ip");
+  const char *ipcmd_path = hmap_str_keychar_get(ctx->hmap_bin_paths, "ip");
   if (ipcmd_path == NULL) {
     log_error("Couldn't find ip command");
     return -1;

--- a/src/utils/hashmap.c
+++ b/src/utils/hashmap.c
@@ -26,15 +26,15 @@
 #include "log.h"
 #include "hashmap.h"
 
-char *hmap_str_keychar_get(hmap_str_keychar **hmap, char *keyptr) {
-  hmap_str_keychar *s;
-
+const char *hmap_str_keychar_get(const hmap_str_keychar *hmap,
+                                 const char *keyptr) {
   if (keyptr == NULL) {
     log_trace("keyptr is NULL");
     return NULL;
   }
 
-  HASH_FIND_STR(*hmap, keyptr, s);
+  const hmap_str_keychar *s;
+  HASH_FIND_STR(hmap, keyptr, s);
 
   if (s != NULL)
     return s->value;

--- a/src/utils/hashmap.h
+++ b/src/utils/hashmap.h
@@ -39,16 +39,18 @@ typedef struct hashmap_str_keyptr {
 /**
  * @brief Retrieves a string from string hashmap for a given key
  *
- * @param hmap The string hashmap object
- * @param keyptr The hashmap key
- * @return char* Returned string, NULL if not found
+ * @param hmap The string hashmap object.
+ * @param keyptr The hashmap key.
+ * @return Returned string, NULL if not found. Valid until the hashmap entry is
+ * deleted.
  */
-char *hmap_str_keychar_get(hmap_str_keychar **hmap, char *keyptr);
+const char *hmap_str_keychar_get(const hmap_str_keychar *hmap,
+                                 const char *keyptr);
 
 /**
  * @brief Inserts a string into a string hashmap for a given key
  *
- * @param hmap The string hashmap object
+ * @param[in, out] hmap Pointer to the string hashmap object.
  * @param keyptr The hashmap key
  * @param value The hashmap string value
  * @return true on succes, false if there's an insertion error

--- a/src/utils/iptables.c
+++ b/src/utils/iptables.c
@@ -239,7 +239,7 @@ void iptables_free(struct iptables_context *ctx) {
   }
 }
 
-struct iptables_context *iptables_init(char *path, UT_array *ifinfo_array,
+struct iptables_context *iptables_init(const char *path, UT_array *ifinfo_array,
                                        bool exec_iptables) {
   struct iptables_context *ctx = NULL;
 

--- a/src/utils/iptables.h
+++ b/src/utils/iptables.h
@@ -37,7 +37,7 @@ struct iptables_context {
  * @return struct iptables_context*, pointer to newly created iptables context,
  * NULL on failure
  */
-struct iptables_context *iptables_init(char *path, UT_array *ifinfo_array,
+struct iptables_context *iptables_init(const char *path, UT_array *ifinfo_array,
                                        bool exec_iptables);
 
 /**

--- a/tests/system/test_system_checks.c
+++ b/tests/system/test_system_checks.c
@@ -32,7 +32,7 @@ static void test_check_systems_commands(void **state) {
 
   assert_non_null(hmap);
 
-  char *value = hmap_str_keychar_get(&hmap, "ls");
+  const char *value = hmap_str_keychar_get(hmap, "ls");
 
   assert_string_equal(value, "/bin/ls");
 

--- a/tests/test_runctl.c
+++ b/tests/test_runctl.c
@@ -45,11 +45,12 @@ int __wrap_get_commands_paths(char *commands[], UT_array *bin_path_arr,
   return (int)mock();
 }
 
-char *__wrap_hmap_str_keychar_get(hmap_str_keychar **hmap, char *keyptr) {
+const char *__wrap_hmap_str_keychar_get(const hmap_str_keychar *hmap,
+                                        char *keyptr) {
   (void)hmap;
   (void)keyptr;
 
-  return (char *)mock();
+  return mock_ptr_type(const char *);
 }
 
 #ifdef WITH_CRYPTO_SERVICE

--- a/tests/utils/test_hashmap.c
+++ b/tests/utils/test_hashmap.c
@@ -23,37 +23,37 @@ static void test_hashmap_str_keychar(void **state) {
 
   /* Inserting value value1 for key key1 */
   hmap_str_keychar_put(&hmap, "key1", "value1");
-  char *value = hmap_str_keychar_get(&hmap, "key1");
+  const char *value = hmap_str_keychar_get(hmap, "key1");
   assert_string_equal(value, "value1");
 
   /* Inserting value value2 for key NULL */
   hmap_str_keychar_put(&hmap, NULL, "value2");
-  value = hmap_str_keychar_get(&hmap, NULL);
+  value = hmap_str_keychar_get(hmap, NULL);
   assert_null(value);
 
   /* Inserting value value3 for key \"\" */
   hmap_str_keychar_put(&hmap, "", "value3");
-  value = hmap_str_keychar_get(&hmap, "");
+  value = hmap_str_keychar_get(hmap, "");
   assert_string_equal(value, "value3");
 
   /* Inserting value value4 for key \"\" */
   hmap_str_keychar_put(&hmap, "", "value4");
-  value = hmap_str_keychar_get(&hmap, "");
+  value = hmap_str_keychar_get(hmap, "");
   assert_string_equal(value, "value4");
 
   /* Inserting value NULL for key key3 */
   hmap_str_keychar_put(&hmap, "key3", NULL);
-  value = hmap_str_keychar_get(&hmap, "key3");
+  value = hmap_str_keychar_get(hmap, "key3");
   assert_null(value);
 
   /* Inserting value value3 for key 1234567890qwerty */
   hmap_str_keychar_put(&hmap, "1234567890qwerty", "value3");
-  value = hmap_str_keychar_get(&hmap, "1234567890qwerty");
+  value = hmap_str_keychar_get(hmap, "1234567890qwerty");
   assert_string_equal(value, "value3");
 
   /* Inserting value value3 for key 1234567890qwerty123456789 */
   hmap_str_keychar_put(&hmap, "1234567890qwerty123456789", "value3");
-  value = hmap_str_keychar_get(&hmap, "1234567890qwerty123456789");
+  value = hmap_str_keychar_get(hmap, "1234567890qwerty123456789");
   assert_null(value);
 
   hmap_str_keychar_free(&hmap);


### PR DESCRIPTION
Set the params and return value of `hmap_str_keychar_get()` to `const`.

Also, there's no point in making the `hmap` param a pointer-to-a-pointer if we never modify the pointer, we might as well just pass a pointer and get a performance boost, simplify code, and make it more obvious that we're not changing anything.

Benefits:
  - Reduces the risk of modifying string literals (undefined behaviour by the C compiler)
  - Makes it unlikely for us to accidentally modify hash_maps using the get function.
  - Improves usage documentation
  - Performance increase, since we're moving from a `**` to a `*` (pointer to pointer to just a pointer) (the compiler might have optimized this with Link-time-optimization)