### PR TITLE
ci(coverage): use codecov token from CODECOV_TOKEN

### DIFF
--- a/.github/workflows/create-debs.yml
+++ b/.github/workflows/create-debs.yml
@@ -132,6 +132,8 @@ jobs:
         uses: codecov/codecov-action@v3
         with:
           files: coverage.info
+          # not officially needed for public repos, but we're getting a bunch of API issues
+          token: ${{ secrets.CODECOV_TOKEN }}
           fail_ci_if_error: true
   build-recap:
     name: Building Recap


### PR DESCRIPTION
The GitHub codecov upload action keeps on failing, and recommends setting a CODECOV_TOKEN.

Technically, we shouldn't need one, since we're using a public repository, but it might be that we're encountering some sort of usage limit, so setting an explicit `CODECOV_TOKEN` might help.

### TODO

- [x] ~@mereacre, can you use your codecov admin powers and go to https://codecov.io/github/nqminds/edgesec/settings, look for a repository upload token, then add it to https://github.com/nqminds/edgesec/settings/secrets/actions under `CODECOV_TOKEN`?~ token added!

