### PR TITLE
Test the IP_GENERIC_SERVICE using GitHub Actions

### DIFF
--- a/.github/workflows/create-debs.yml
+++ b/.github/workflows/create-debs.yml
@@ -24,6 +24,7 @@ jobs:
           - clang
           - openwrt-with-header
           - openwrt-21.02.1/bcm27xx/bcm2710 # Raspberry Pi 3 for OpenWRT 21.02.1
+          - recap # Uses the generic IP service
     permissions:
       contents: read
     runs-on: ubuntu-latest

--- a/CMakePresets.json
+++ b/CMakePresets.json
@@ -271,6 +271,10 @@
       "configurePreset": "linux-with-tap"
     },
     {
+      "name": "recap",
+      "configurePreset": "recap"
+    },
+    {
       "name": "linux-with-crypt",
       "configurePreset": "linux-with-crypt"
     },

--- a/src/utils/ipgen.c
+++ b/src/utils/ipgen.c
@@ -50,35 +50,38 @@ void ipgen_free_context(struct ipgenctx *context) {
   }
 }
 
-int run_ip(char *path, char *const argv[]) {
+int run_ip(const char *path, const char *const argv[]) {
   return run_argv_command(path, argv, NULL, NULL);
 }
 
-int ipgen_new_interface(char *path, char *ifname, char *type) {
-  char *argv[7] = {"link", "add", "name", ifname, "type", type, NULL};
+int ipgen_new_interface(const char *path, const char *ifname,
+                        const char *type) {
+  const char *argv[7] = {"link", "add", "name", ifname, "type", type, NULL};
   return run_ip(path, argv);
 }
 
-int ipgen_set_interface_ip(struct ipgenctx *context, char *ifname,
-                           const char *ip_addr, char *brd_addr,
-                           char *subnet_mask) {
+int ipgen_set_interface_ip(const struct ipgenctx *context, const char *ifname,
+                           const char *ip_addr, const char *brd_addr,
+                           const char *subnet_mask) {
   char longip[OS_INET_ADDRSTRLEN];
 
   snprintf(longip, OS_INET_ADDRSTRLEN, "%s/%d", ip_addr,
            (int)get_short_subnet(subnet_mask));
 
-  char *argv[8] = {"addr", "add", longip, "brd", brd_addr, "dev", ifname, NULL};
+  const char *argv[8] = {"addr",   "add", longip, "brd",
+                         brd_addr, "dev", ifname, NULL};
   return run_ip(context->ipcmd_path, argv);
 }
 
-int ipgen_set_interface_state(char *path, char *ifname, bool state) {
-  char *argv[5] = {"link", "set", ifname, NULL, NULL};
-  argv[3] = (state) ? "up" : "down";
+int ipgen_set_interface_state(const char *path, const char *ifname,
+                              bool state) {
+  const char *argv[5] = {"link", "set", ifname, (state) ? "up" : "down", NULL};
   return run_ip(path, argv);
 }
 
-int ipgen_create_interface(struct ipgenctx *context, char *ifname, char *type,
-                           char *ip_addr, char *brd_addr, char *subnet_mask) {
+int ipgen_create_interface(const struct ipgenctx *context, const char *ifname,
+                           const char *type, const char *ip_addr,
+                           const char *brd_addr, const char *subnet_mask) {
   if (ifname == NULL) {
     log_trace("ifname param is NULL");
     return -1;
@@ -123,7 +126,7 @@ int ipgen_create_interface(struct ipgenctx *context, char *ifname, char *type,
   return 0;
 }
 
-int ipgen_reset_interface(struct ipgenctx *context, char *ifname) {
+int ipgen_reset_interface(const struct ipgenctx *context, const char *ifname) {
   if (ipgen_set_interface_state(context->ipcmd_path, ifname, false) < 0) {
     log_trace("ipgen_set_interface_state fail");
     return -1;

--- a/src/utils/ipgen.h
+++ b/src/utils/ipgen.h
@@ -27,14 +27,15 @@ struct ipgenctx {
  * @brief Initialises the ipgen context
  *
  * @param path The path string to the ip command
- * @return struct ipgenctx* The ip generic context
+ * @return The ip generic context or NULL on failure.
+ * Must be cleaned-up with ipgen_free_context().
  */
 struct ipgenctx *ipgen_init_context(char *path);
 
 /**
  * @brief Frees the ipgen context
  *
- * @param context The ipgen context
+ * @param context The ipgen context created by ipgen_init_context()
  */
 void ipgen_free_context(struct ipgenctx *context);
 
@@ -49,8 +50,9 @@ void ipgen_free_context(struct ipgenctx *context);
  * @param subnet_mask The interface IP4 subnet mask
  * @return int 0 on success, -1 on failure
  */
-int ipgen_create_interface(struct ipgenctx *context, char *ifname, char *type,
-                           char *ip_addr, char *brd_addr, char *subnet_mask);
+int ipgen_create_interface(const struct ipgenctx *context, const char *ifname,
+                           const char *type, const char *ip_addr,
+                           const char *brd_addr, const char *subnet_mask);
 
 /**
  * @brief Set the IP address for an interface
@@ -62,9 +64,9 @@ int ipgen_create_interface(struct ipgenctx *context, char *ifname, char *type,
  * @param subnet_mask The interface IP4 subnet mask
  * @return int 0 on success, -1 on failure
  */
-int ipgen_set_interface_ip(struct ipgenctx *context, char *ifname,
-                           const char *ip_addr, char *brd_addr,
-                           char *subnet_mask);
+int ipgen_set_interface_ip(const struct ipgenctx *context, const char *ifname,
+                           const char *ip_addr, const char *brd_addr,
+                           const char *subnet_mask);
 
 /**
  * @brief Resets the interface
@@ -73,5 +75,5 @@ int ipgen_set_interface_ip(struct ipgenctx *context, char *ifname,
  * @param ifname The interface name
  * @return int 0 on success, -1 on failure
  */
-int ipgen_reset_interface(struct ipgenctx *context, char *ifname);
+int ipgen_reset_interface(const struct ipgenctx *context, const char *ifname);
 #endif


### PR DESCRIPTION
Test the `IP_GENERIC_SERVICE` using GitHub Actions.

Currently, the only CMake preset that uses the `IP_GENERIC_SERVICE` is `recap`, so I've added a CTest preset for it too, so that we can run `IP_GENERIC_SERVICE` tests and to get coverage results.

Additionally, I've fixed the `const` errors in `ipgen` that were preventing `recap` from compiling.