### PR TITLE
Refactor `iface` functions so that they are `const`

### DIFF
--- a/src/utils/iface.c
+++ b/src/utils/iface.c
@@ -98,7 +98,7 @@ struct iface_context *iface_init_context(void *params) {
   return ctx;
 }
 
-UT_array *iface_get(char *ifname) {
+UT_array *iface_get(const char *ifname) {
   struct ifaddrs *ifaddr;
   int ret;
   char ipaddr[NI_MAXHOST];
@@ -154,7 +154,8 @@ UT_array *iface_get(char *ifname) {
   return interfaces;
 }
 
-UT_array *iface_get_ip4(struct iface_context *ctx, char *brname, char *ifname) {
+UT_array *iface_get_ip4(const struct iface_context *ctx, const char *brname,
+                        const char *ifname) {
   (void)ctx;
 
   UT_array *ip4s = NULL;
@@ -194,18 +195,18 @@ UT_array *iface_get_ip4(struct iface_context *ctx, char *brname, char *ifname) {
   return ip4s;
 }
 
-char *iface_get_vlan(char *buf) {
+char *iface_get_vlan(char if_buf[static IF_NAMESIZE]) {
 #ifdef WITH_NETLINK_SERVICE
-  return nl_get_valid_iw(buf);
+  return nl_get_valid_iw(if_buf);
 #else
-  (void)buf;
+  (void)if_buf;
 
   log_trace("iface_get_vlan not implemented");
   return NULL;
 #endif
 }
 
-int reset_interface(struct iface_context *ctx, char *ifname) {
+int reset_interface(const struct iface_context *ctx, const char *ifname) {
   log_trace("Reseting interface state for if_name=%s", ifname);
 #ifdef WITH_NETLINK_SERVICE
   (void)ctx;
@@ -221,8 +222,9 @@ int reset_interface(struct iface_context *ctx, char *ifname) {
 #endif
 }
 
-int iface_create(struct iface_context *ctx, char *brname, char *ifname,
-                 char *type, char *ip_addr, char *brd_addr, char *subnet_mask) {
+int iface_create(const struct iface_context *ctx, const char *brname,
+                 const char *ifname, const char *type, const char *ip_addr,
+                 const char *brd_addr, const char *subnet_mask) {
 #ifdef WITH_NETLINK_SERVICE
   (void)brname;
   return nl_create_interface(ctx->context, ifname, type, ip_addr, brd_addr,
@@ -249,8 +251,9 @@ int iface_create(struct iface_context *ctx, char *brname, char *ifname,
 #endif
 }
 
-int iface_set_ip4(struct iface_context *ctx, char *brname, char *ifname,
-                  char *ip_addr, char *brd_addr, char *subnet_mask) {
+int iface_set_ip4(const struct iface_context *ctx, const char *brname,
+                  const char *ifname, const char *ip_addr, const char *brd_addr,
+                  const char *subnet_mask) {
 
 #ifdef WITH_NETLINK_SERVICE
   (void)brname;
@@ -277,7 +280,7 @@ int iface_set_ip4(struct iface_context *ctx, char *brname, char *ifname,
 #endif
 }
 
-int iface_commit(struct iface_context *ctx) {
+int iface_commit(const struct iface_context *ctx) {
   log_debug("Commiting interface changes");
 #ifdef WITH_NETLINK_SERVICE
   (void)ctx;

--- a/src/utils/iface.h
+++ b/src/utils/iface.h
@@ -15,6 +15,7 @@
 #include <stdbool.h>
 #include <netinet/in.h>
 #include <net/ethernet.h>
+#include <net/if.h>
 
 #include <utarray.h>
 #include <uthash.h>
@@ -43,7 +44,7 @@ struct iface_context {
  * @brief Initialises the interface context
  *
  * @param params The parameters for interface context
- * @return struct iface_context* The interface context
+ * @return The interface context. Must be freed by iface_free_context().
  */
 struct iface_context *iface_init_context(void *params);
 
@@ -57,18 +58,19 @@ void iface_free_context(struct iface_context *context);
 /**
  * @brief Returns an exisiting WiFi interface name that supports VLAN
  *
- * @param if_buf Interface working buffer
- * @return char* WiFi interface name
+ * @param[out] if_buf Interface working buffer of at least size IF_NAMESIZE.
+ * @return WiFi interface name (pointer to @p if_buf param), or NULL on error.
  */
-char *iface_get_vlan(char *if_buf);
+char *iface_get_vlan(char if_buf[static IF_NAMESIZE]);
 
 /**
  * @brief Get the array of @c struct netif_info_t for each available interface
  *
  * @param[in] ifname The interface name, if NULL return all interfaces
- * @return UT_array* The returned array of @c struct netif_info_t
+ * @return UT_array* The returned array of @c struct netif_info_t.
+ * Must be freed with utarray_free() when done.
  */
-UT_array *iface_get(char *ifname);
+UT_array *iface_get(const char *ifname);
 
 /**
  * @brief Get the IP4 addresses for a given interface
@@ -76,10 +78,11 @@ UT_array *iface_get(char *ifname);
  * @param context The interface context
  * @param[in] brname The bridge name
  * @param[in] ifname The interface name
- * @return UT_array* The returned array of IP4 strings
+ * @return UT_array* The returned array of IP4 strings.
+ * Must be freed with utarray_free() when done.
  */
-UT_array *iface_get_ip4(struct iface_context *context, char *brname,
-                        char *ifname);
+UT_array *iface_get_ip4(const struct iface_context *context, const char *brname,
+                        const char *ifname);
 
 /**
  * @brief Creates and interface and assigns an IP
@@ -93,8 +96,9 @@ UT_array *iface_get_ip4(struct iface_context *context, char *brname,
  * @param subnet_mask The interface IP4 subnet mask
  * @return int 0 on success, -1 on failure
  */
-int iface_create(struct iface_context *context, char *brname, char *ifname,
-                 char *type, char *ip_addr, char *brd_addr, char *subnet_mask);
+int iface_create(const struct iface_context *context, const char *brname,
+                 const char *ifname, const char *type, const char *ip_addr,
+                 const char *brd_addr, const char *subnet_mask);
 
 /**
  * @brief Sets the IP4 for a given interface
@@ -107,8 +111,9 @@ int iface_create(struct iface_context *context, char *brname, char *ifname,
  * @param subnet_mask The interface IP4 subnet mask
  * @return int 0 on success, -1 on failure
  */
-int iface_set_ip4(struct iface_context *context, char *brname, char *ifname,
-                  char *ip_addr, char *brd_addr, char *subnet_mask);
+int iface_set_ip4(const struct iface_context *context, const char *brname,
+                  const char *ifname, const char *ip_addr, const char *brd_addr,
+                  const char *subnet_mask);
 
 /**
  * @brief Commits the interface changes
@@ -116,7 +121,7 @@ int iface_set_ip4(struct iface_context *context, char *brname, char *ifname,
  * @param context The interface context
  * @return int 0 on success, -1 on failure
  */
-int iface_commit(struct iface_context *context);
+int iface_commit(const struct iface_context *context);
 
 /**
  * @brief Resets an interface
@@ -125,5 +130,5 @@ int iface_commit(struct iface_context *context);
  * @param ifname The interface name
  * @return int 0 on success, -1 on failure
  */
-int reset_interface(struct iface_context *context, char *ifname);
+int reset_interface(const struct iface_context *context, const char *ifname);
 #endif

--- a/src/utils/nl.c
+++ b/src/utils/nl.c
@@ -1237,7 +1237,7 @@ int nl_is_iw_vlan(const char *ifname) {
   return -1;
 }
 
-char *nl_get_valid_iw(char buf[static IFNAMSIZ]) {
+char *nl_get_valid_iw(char buf[static IF_NAMESIZE]) {
   UT_array *netif_list = get_netiw_info();
 
   if (netif_list == NULL) {

--- a/src/utils/uci_wrt.c
+++ b/src/utils/uci_wrt.c
@@ -460,7 +460,7 @@ void uwrt_free_context(struct uctx *context) {
   }
 }
 
-struct uctx *uwrt_init_context(char *path) {
+struct uctx *uwrt_init_context(const char *path) {
   struct uctx *context = os_zalloc(sizeof(struct uctx));
 
   if (context == NULL) {
@@ -486,7 +486,7 @@ struct uctx *uwrt_init_context(char *path) {
   return context;
 }
 
-UT_array *uwrt_get_interfaces(struct uctx *context, char *ifname) {
+UT_array *uwrt_get_interfaces(const struct uctx *context, const char *ifname) {
   int ret, idx = 0;
   UT_array *kv = NULL;
   UT_array *interfaces = NULL;
@@ -535,8 +535,8 @@ uwrt_get_fail:
   return NULL;
 }
 
-int uwrt_set_interface_ip(struct uctx *context, char *ifname, char *ip_addr,
-                          char *netmask) {
+int uwrt_set_interface_ip(const struct uctx *context, const char *ifname,
+                          const char *ip_addr, const char *netmask) {
   if (context == NULL) {
     log_trace("context param is NULL");
     return -1;
@@ -582,8 +582,9 @@ int uwrt_set_interface_ip(struct uctx *context, char *ifname, char *ip_addr,
   return 0;
 }
 
-int uwrt_create_interface(struct uctx *context, char *ifname, char *type,
-                          char *ip_addr, char *brd_addr, char *netmask) {
+int uwrt_create_interface(const struct uctx *context, const char *ifname,
+                          const char *type, const char *ip_addr,
+                          const char *brd_addr, const char *netmask) {
   if (context == NULL) {
     log_trace("context param is NULL");
     return -1;
@@ -659,7 +660,7 @@ int uwrt_create_interface(struct uctx *context, char *ifname, char *type,
   return 0;
 }
 
-int uwrt_commit_section(struct uctx *context, char *section) {
+int uwrt_commit_section(const struct uctx *context, const char *section) {
   struct uci_ptr ptr;
   char *psection = os_strdup(section);
 
@@ -684,10 +685,10 @@ int uwrt_commit_section(struct uctx *context, char *section) {
   return 0;
 }
 
-int uwrt_gen_dnsmasq_instance(struct uctx *context,
-                              struct string_queue *ifname_queue,
-                              UT_array *server_array, char *leasefile,
-                              char *scriptfile) {
+int uwrt_gen_dnsmasq_instance(const struct uctx *context,
+                              const struct string_queue *ifname_queue,
+                              const UT_array *server_array,
+                              const char *leasefile, const char *scriptfile) {
   char **p = NULL;
   struct string_queue *el = NULL;
 
@@ -779,8 +780,9 @@ int uwrt_gen_dnsmasq_instance(struct uctx *context,
   return 0;
 }
 
-int uwrt_add_dhcp_pool(struct uctx *context, char *ifname, char *ip_addr_low,
-                       char *ip_addr_upp, char *subnet_mask, char *lease_time) {
+int uwrt_add_dhcp_pool(const struct uctx *context, const char *ifname,
+                       const char *ip_addr_low, const char *ip_addr_upp,
+                       const char *subnet_mask, const char *lease_time) {
   uint32_t start, limit;
 
   if (context == NULL) {
@@ -874,8 +876,8 @@ int uwrt_add_dhcp_pool(struct uctx *context, char *ifname, char *ip_addr_low,
   return 0;
 }
 
-int uwrt_gen_hostapd_instance(struct uctx *context,
-                              struct hostapd_params *params) {
+int uwrt_gen_hostapd_instance(const struct uctx *context,
+                              const struct hostapd_params *params) {
   if (context == NULL) {
     log_trace("context param is NULL");
     return -1;
@@ -1034,7 +1036,7 @@ int uwrt_gen_hostapd_instance(struct uctx *context,
   return 0;
 }
 
-int uwrt_gen_firewall_zone(struct uctx *context, char *brname) {
+int uwrt_gen_firewall_zone(const struct uctx *context, const char *brname) {
   if (context == NULL) {
     log_trace("context param is NULL");
     return -1;
@@ -1229,8 +1231,8 @@ int uwrt_gen_firewall_zone(struct uctx *context, char *brname) {
   return 0;
 }
 
-int uwrt_add_firewall_nat(struct uctx *context, char *brname, char *ip_addr,
-                          char *nat_name) {
+int uwrt_add_firewall_nat(const struct uctx *context, const char *brname,
+                          const char *ip_addr, const char *nat_name) {
   uint8_t ip_buf[4];
 
   if (context == NULL) {
@@ -1443,7 +1445,7 @@ int uwrt_add_firewall_nat(struct uctx *context, char *brname, char *ip_addr,
   return 0;
 }
 
-int uwrt_delete_firewall_nat(struct uctx *context, char *ip_addr) {
+int uwrt_delete_firewall_nat(const struct uctx *context, const char *ip_addr) {
   uint8_t ip_buf[4];
 
   if (context == NULL) {
@@ -1492,8 +1494,9 @@ int uwrt_delete_firewall_nat(struct uctx *context, char *ip_addr) {
   return 0;
 }
 
-int uwrt_add_firewall_bridge(struct uctx *context, char *sip, char *sbr,
-                             char *dip, char *dbr) {
+int uwrt_add_firewall_bridge(const struct uctx *context, const char *sip,
+                             const char *sbr, const char *dip,
+                             const char *dbr) {
   uint8_t sip_buf[4], dip_buf[4];
 
   if (context == NULL) {
@@ -1644,7 +1647,8 @@ int uwrt_add_firewall_bridge(struct uctx *context, char *sip, char *sbr,
   return 0;
 }
 
-int uwrt_delete_firewall_bridge(struct uctx *context, char *sip, char *dip) {
+int uwrt_delete_firewall_bridge(const struct uctx *context, const char *sip,
+                                const char *dip) {
   uint8_t sip_buf[4], dip_buf[4];
 
   if (context == NULL) {
@@ -1697,7 +1701,7 @@ int uwrt_delete_firewall_bridge(struct uctx *context, char *sip, char *dip) {
   return 0;
 }
 
-int uwrt_cleanup_firewall(struct uctx *context) {
+int uwrt_cleanup_firewall(const struct uctx *context) {
   int ret;
   char **ptr = NULL, *fo = NULL, *p = NULL;
   UT_array *kv = NULL, *parray = NULL;

--- a/src/utils/uci_wrt.h
+++ b/src/utils/uci_wrt.h
@@ -46,9 +46,10 @@ struct hostapd_params {
  * @brief Initialises the uci context
  *
  * @param path The path string to the config folder
- * @return struct uctx* The uci context
+ * @return The uci context, or `NULL` on error.
+ * This return variable must be cleaned up by uwrt_free_context().
  */
-struct uctx *uwrt_init_context(char *path);
+struct uctx *uwrt_init_context(const char *path);
 
 /**
  * @brief Frees the uci context
@@ -63,8 +64,9 @@ void uwrt_free_context(struct uctx *context);
  * @param context The uci context
  * @param ifname The interface name, if NULL return all interfaces
  * @return UT_array* The returned array of @c struct netif_info_t
+ * This return variable must be cleaned up by utarray_free().
  */
-UT_array *uwrt_get_interfaces(struct uctx *context, char *ifname);
+UT_array *uwrt_get_interfaces(const struct uctx *context, const char *ifname);
 
 /**
  * @brief Assigns an IP to an interface
@@ -75,8 +77,8 @@ UT_array *uwrt_get_interfaces(struct uctx *context, char *ifname);
  * @param netmask The interface IP4 netmask
  * @return int 0 on success, -1 on failure
  */
-int uwrt_set_interface_ip(struct uctx *context, char *ifname, char *ip_addr,
-                          char *netmask);
+int uwrt_set_interface_ip(const struct uctx *context, const char *ifname,
+                          const char *ip_addr, const char *netmask);
 /**
  * @brief Creates and interface and assigns an IP
  *
@@ -88,8 +90,9 @@ int uwrt_set_interface_ip(struct uctx *context, char *ifname, char *ip_addr,
  * @param netmask The interface IP4 netmask
  * @return int 0 on success, -1 on failure
  */
-int uwrt_create_interface(struct uctx *context, char *ifname, char *type,
-                          char *ip_addr, char *brd_addr, char *netmask);
+int uwrt_create_interface(const struct uctx *context, const char *ifname,
+                          const char *type, const char *ip_addr,
+                          const char *brd_addr, const char *netmask);
 
 /**
  * @brief Commit a uci section
@@ -98,7 +101,7 @@ int uwrt_create_interface(struct uctx *context, char *ifname, char *type,
  * @param section The uci section
  * @return int 0 on success, -1 on failure
  */
-int uwrt_commit_section(struct uctx *context, char *section);
+int uwrt_commit_section(const struct uctx *context, const char *section);
 
 /**
  * @brief Generates a dnsmasq uci instance
@@ -110,10 +113,10 @@ int uwrt_commit_section(struct uctx *context, char *section);
  * @param scriptfile The script file path string
  * @return int 0 on success, -1 on failure
  */
-int uwrt_gen_dnsmasq_instance(struct uctx *context,
-                              struct string_queue *ifname_queue,
-                              UT_array *server_array, char *leasefile,
-                              char *scriptfile);
+int uwrt_gen_dnsmasq_instance(const struct uctx *context,
+                              const struct string_queue *ifname_queue,
+                              const UT_array *server_array,
+                              const char *leasefile, const char *scriptfile);
 
 /**
  * @brief Adds a dhcp pool entry
@@ -126,18 +129,19 @@ int uwrt_gen_dnsmasq_instance(struct uctx *context,
  * @param lease_time Interface lease time string
  * @return int 0 on success, -1 on failure
  */
-int uwrt_add_dhcp_pool(struct uctx *context, char *ifname, char *ip_addr_low,
-                       char *ip_addr_upp, char *subnet_mask, char *lease_time);
+int uwrt_add_dhcp_pool(const struct uctx *context, const char *ifname,
+                       const char *ip_addr_low, const char *ip_addr_upp,
+                       const char *subnet_mask, const char *lease_time);
 
 /**
- * @brief Generate the hostapd configf
+ * @brief Generate the hostapd config
  *
  * @param context The uci context
  * @param params The hostapd params
  * @return int 0 on success, -1 on failure
  */
-int uwrt_gen_hostapd_instance(struct uctx *context,
-                              struct hostapd_params *params);
+int uwrt_gen_hostapd_instance(const struct uctx *context,
+                              const struct hostapd_params *params);
 
 /**
  * @brief Generate a firewall zone for a bridge
@@ -146,7 +150,7 @@ int uwrt_gen_hostapd_instance(struct uctx *context,
  * @param brname The bridge name
  * @return int 0 on success, -1 on failure
  */
-int uwrt_gen_firewall_zone(struct uctx *context, char *brname);
+int uwrt_gen_firewall_zone(const struct uctx *context, const char *brname);
 
 /**
  * @brief Adds a firewall rule for an IP address
@@ -157,8 +161,8 @@ int uwrt_gen_firewall_zone(struct uctx *context, char *brname);
  * @param nat_name The NAT bridge name
  * @return int 0 on success, -1 on failure
  */
-int uwrt_add_firewall_nat(struct uctx *context, char *brname, char *ip_addr,
-                          char *nat_name);
+int uwrt_add_firewall_nat(const struct uctx *context, const char *brname,
+                          const char *ip_addr, const char *nat_name);
 
 /**
  * @brief Deletes a firewall rule for an IP address
@@ -167,7 +171,7 @@ int uwrt_add_firewall_nat(struct uctx *context, char *brname, char *ip_addr,
  * @param ip_addr The IP address
  * @return int 0 on success, -1 on failure
  */
-int uwrt_delete_firewall_nat(struct uctx *context, char *ip_addr);
+int uwrt_delete_firewall_nat(const struct uctx *context, const char *ip_addr);
 
 /**
  * @brief Adds a firewall bridge rule for two IP addresses
@@ -179,8 +183,8 @@ int uwrt_delete_firewall_nat(struct uctx *context, char *ip_addr);
  * @param dbr The destination bridge interface name
  * @return int 0 on success, -1 on failure
  */
-int uwrt_add_firewall_bridge(struct uctx *context, char *sip, char *sbr,
-                             char *dip, char *dbr);
+int uwrt_add_firewall_bridge(const struct uctx *context, const char *sip,
+                             const char *sbr, const char *dip, const char *dbr);
 
 /**
  * @brief Deletes a firewall bridge rule for two IP addresses
@@ -190,7 +194,8 @@ int uwrt_add_firewall_bridge(struct uctx *context, char *sip, char *sbr,
  * @param dip The destination IP address
  * @return int 0 on success, -1 on failure
  */
-int uwrt_delete_firewall_bridge(struct uctx *context, char *sip, char *dip);
+int uwrt_delete_firewall_bridge(const struct uctx *context, const char *sip,
+                                const char *dip);
 
 /**
  * @brief Removes all the firewall rules
@@ -198,5 +203,5 @@ int uwrt_delete_firewall_bridge(struct uctx *context, char *sip, char *dip);
  * @param context The uci context
  * @return int 0 on success, -1 on failure
  */
-int uwrt_cleanup_firewall(struct uctx *context);
+int uwrt_cleanup_firewall(const struct uctx *context);
 #endif


### PR DESCRIPTION
**Draft until #315 and #316 are merged**

This is because it relies on the new `list.h` function, as well as the new const `ipgen_` functions.

--

Makes the `iface_*` functions `const`, by making the following functions `const` too:
  - `ipgen_*` Will be added by PR #316 
  - `net_*` Added by PR #325
  - `uci_wrt_*`

Fixes quite a few `-Wwrite-string` error in `recap.c` file.