### PR TITLE
Prevent modifying string literals in `runctl`

### DIFF
--- a/src/runctl.c
+++ b/src/runctl.c
@@ -243,7 +243,7 @@ int construct_ap_ctrlif(char *ctrl_interface, char *interface,
 
 int init_context(struct app_config *app_config,
                  struct supervisor_context *ctx) {
-  char *commands[] = {"ip", "iw", "iptables", "sysctl", NULL};
+  const char *commands[] = {"ip", "iw", "iptables", "sysctl", NULL};
 
   ctx->config_ifinfo_array = NULL;
   ctx->hmap_bin_paths = NULL;
@@ -355,30 +355,36 @@ int init_context(struct app_config *app_config,
   return 0;
 }
 
-int run_mdns_forwarder(char *mdns_bin_path, char *config_ini_path) {
-  int ret;
+int run_mdns_forwarder(const char *mdns_bin_path, const char *config_ini_path) {
+  int ret = -1;
+  const char *process_argv[5] = {mdns_bin_path, MDNS_OPT_CONFIG,
+                                 config_ini_path, NULL};
+  char *proc_name = NULL;
+  char **process_argv_copy = copy_argv(process_argv);
+  if (process_argv_copy == NULL) {
+    log_errno("Failed to copy_argv for %s", mdns_bin_path);
+    goto cleanup;
+  }
+
   pid_t child_pid;
-  char *proc_name;
-  char *process_argv[5] = {NULL, NULL, NULL, NULL};
-  process_argv[0] = mdns_bin_path;
-  process_argv[1] = MDNS_OPT_CONFIG;
-  process_argv[2] = config_ini_path;
+  int run_process_return_code = run_process(process_argv_copy, &child_pid);
 
-  ret = run_process(process_argv, &child_pid);
-
-  if ((proc_name = os_strdup(basename(process_argv[0]))) == NULL) {
+  if ((proc_name = os_strdup(basename(process_argv_copy[0]))) == NULL) {
     log_errno("os_strdup");
-    return -1;
+    goto cleanup;
   }
 
   if (is_proc_running(proc_name) <= 0) {
     log_error("is_proc_running fail (%s)", proc_name);
-    os_free(proc_name);
-    return -1;
+    goto cleanup;
   }
 
   log_debug("Found mdns process running with pid=%d (%s)", child_pid,
             proc_name);
+  ret = run_process_return_code;
+
+cleanup:
+  free(process_argv_copy);
   os_free(proc_name);
 
   return ret;

--- a/src/utils/hashmap.c
+++ b/src/utils/hashmap.c
@@ -42,7 +42,8 @@ const char *hmap_str_keychar_get(const hmap_str_keychar *hmap,
   return NULL;
 }
 
-bool hmap_str_keychar_put(hmap_str_keychar **hmap, char *keyptr, char *value) {
+bool hmap_str_keychar_put(hmap_str_keychar **hmap, const char *keyptr,
+                          const char *value) {
   if (keyptr == NULL) {
     log_trace("keyptr is NULL");
     return false;

--- a/src/utils/hashmap.h
+++ b/src/utils/hashmap.h
@@ -55,7 +55,8 @@ const char *hmap_str_keychar_get(const hmap_str_keychar *hmap,
  * @param value The hashmap string value
  * @return true on succes, false if there's an insertion error
  */
-bool hmap_str_keychar_put(hmap_str_keychar **hmap, char *keyptr, char *value);
+bool hmap_str_keychar_put(hmap_str_keychar **hmap, const char *keyptr,
+                          const char *value);
 
 /**
  * @brief Deletes the string hashmap object

--- a/src/utils/os.c
+++ b/src/utils/os.c
@@ -697,7 +697,8 @@ char *construct_path(const char *path_left, const char *path_right) {
   return path;
 }
 
-char *get_secure_path(UT_array *bin_path_arr, char *filename, bool real) {
+char *get_secure_path(const UT_array *bin_path_arr, const char *filename,
+                      bool real) {
   char **p = NULL;
 
   if (bin_path_arr == NULL) {
@@ -1410,7 +1411,7 @@ int read_file_string(char *path, char **out) {
   return 0;
 }
 
-int get_commands_paths(char *commands[], UT_array *bin_path_arr,
+int get_commands_paths(const char *commands[], const UT_array *bin_path_arr,
                        hmap_str_keychar **hmap_bin_paths) {
   if (bin_path_arr == NULL) {
     log_error("bin_path_arr param NULL");

--- a/src/utils/os.h
+++ b/src/utils/os.h
@@ -396,9 +396,10 @@ char *construct_path(const char *path_left, const char *path_right);
  * @param bin_path_arr The path string of binary
  * @param filename The binary name
  * @param real true to return the real link
- * @return char* the secure path
+ * @return The secure path, or NULL on error. Must be freed with os_free().
  */
-char *get_secure_path(UT_array *bin_path_arr, char *filename, bool real);
+char *get_secure_path(const UT_array *bin_path_arr, const char *filename,
+                      bool real);
 
 typedef bool (*list_dir_fn)(char *, void *args);
 
@@ -617,7 +618,7 @@ int read_file_string(char *path, char **out);
  * @param[out] hmap_bin_paths The created map of system binary to absolute path.
  * @return int 0 on success, -1 on failure
  */
-int get_commands_paths(char *commands[], UT_array *bin_path_arr,
+int get_commands_paths(const char *commands[], const UT_array *bin_path_arr,
                        hmap_str_keychar **hmap_bin_paths);
 
 /**


### PR DESCRIPTION
Prevents modifying string literals in `runctl`, by making sure that all functions that use string literals are const (e.g. following `-Wwrite-strings`).

Additionally, I had to make a copy of string literals whenever we pass them to a function that might modify them (e.g. run_process() or basename()).

After this PR (and the other open ones), I managed to fully compile the `--preset openwrt` when `-Wwrite-strings` without any errors! This means we shouldn't have any undefined behaviour due to modifying strings in OpenWRT.