### PR TITLE
Fix `linux-with-crypt` `-Wwrite-string` warnings

### DIFF
--- a/src/crypt/crypt_service.c
+++ b/src/crypt/crypt_service.c
@@ -28,9 +28,21 @@ void free_crypt_service(struct crypt_context *ctx) {
   }
 }
 
-int generate_user_key(uint8_t *user_secret, int user_secret_size,
+/**
+ * @brief Generates a the key for a user.
+ *
+ * @param user_secret Secret bytes.
+ * @param user_secret_size Size of @p user_secret.
+ * @param[out] user_key Output buffer for the generated key.
+ * @param user_key_size Size of @p user_key
+ * @param user_key_salt Salt bytes.
+ * @param user_key_salt_size Size of @p user_key_salt_size
+ * @retval  0 On success.
+ * @retval -1 On error.
+ */
+int generate_user_key(const uint8_t *user_secret, int user_secret_size,
                       uint8_t *user_key, int user_key_size,
-                      uint8_t *user_key_salt, int user_key_salt_size) {
+                      const uint8_t *user_key_salt, int user_key_salt_size) {
   if (crypto_buf2key(user_secret, user_secret_size, user_key_salt,
                      user_key_salt_size, user_key, user_key_size) < 0) {
     log_trace("crypto_buf2key fail");
@@ -40,9 +52,9 @@ int generate_user_key(uint8_t *user_secret, int user_secret_size,
   return 0;
 }
 
-struct secrets_row *prepare_secret_entry(char *key_id, uint8_t *key,
-                                         int key_size, uint8_t *salt,
-                                         int salt_size, uint8_t *iv,
+struct secrets_row *prepare_secret_entry(const char *key_id, const uint8_t *key,
+                                         int key_size, const uint8_t *salt,
+                                         int salt_size, const uint8_t *iv,
                                          int iv_size) {
   size_t out_len;
   struct secrets_row *row = os_zalloc(sizeof(struct secrets_row));
@@ -71,9 +83,22 @@ struct secrets_row *prepare_secret_entry(char *key_id, uint8_t *key,
   return row;
 }
 
-int extract_secret_entry(struct secrets_row *row, uint8_t *key, int *key_size,
-                         uint8_t *salt, int *salt_size, uint8_t *iv,
-                         int *iv_size) {
+/**
+ * @brief Extracts the secret key, salt, and IV from a secret entry.
+ *
+ * @param row The row to extract the data from.
+ * @param[out] key The output secret key buffer.
+ * @param key_size The size of @p key.
+ * @param[out] salt The output secret salt buffer.
+ * @param salt_size The size of @p salt.
+ * @param[out] iv The output IV buffer.
+ * @param iv_size The size of @p iv.
+ * @retval  0 On success.
+ * @retval -1 On error.
+ */
+int extract_secret_entry(const struct secrets_row *row, uint8_t *key,
+                         int *key_size, uint8_t *salt, int *salt_size,
+                         uint8_t *iv, int *iv_size) {
   size_t out_len;
   char *buf;
 
@@ -171,8 +196,8 @@ int extract_user_crypto_key_entry(struct secrets_row *row_secret,
   return crypto_key_size;
 }
 
-struct secrets_row *generate_user_crypto_key_entry(char *key_id,
-                                                   uint8_t *user_secret,
+struct secrets_row *generate_user_crypto_key_entry(const char *key_id,
+                                                   const uint8_t *user_secret,
                                                    int user_secret_size,
                                                    uint8_t *crypto_key) {
   uint8_t user_key[AES_KEY_SIZE];
@@ -208,7 +233,8 @@ struct secrets_row *generate_user_crypto_key_entry(char *key_id,
                               user_key_salt, SALT_SIZE, iv, IV_SIZE);
 }
 
-struct crypt_context *load_crypt_service(char *crypt_db_path, char *key_id,
+struct crypt_context *load_crypt_service(const char *crypt_db_path,
+                                         const char *key_id,
                                          uint8_t *user_secret,
                                          int user_secret_size) {
   sqlite3 *db = NULL;

--- a/src/crypt/crypt_service.h
+++ b/src/crypt/crypt_service.h
@@ -35,12 +35,15 @@ struct crypt_pair {
  *
  * @param crypt_db_path The crypt db path
  * @param key_id The crypt secrets key id
- * @param user_secret The user secret
+ * @param[in,out] user_secret The user secret.
+ * If creating a new key, the user secret will be loaded from this variable.
+ * If loading an existing key, the existing key will be writen to the buffer.
  * @param user_secret_size The user secret size, if zero use the hardware secure
  * element
  * @return struct crypt_context* The crypt contex, NULL on failure
  */
-struct crypt_context *load_crypt_service(char *crypt_db_path, char *key_id,
+struct crypt_context *load_crypt_service(const char *crypt_db_path,
+                                         const char *key_id,
                                          uint8_t *user_secret,
                                          int user_secret_size);
 

--- a/src/crypt/sqlite_crypt_writer.c
+++ b/src/crypt/sqlite_crypt_writer.c
@@ -19,7 +19,7 @@
 #include "../utils/log.h"
 #include "../utils/sqliteu.h"
 
-int open_sqlite_crypt_db(char *db_path, sqlite3 **sql) {
+int open_sqlite_crypt_db(const char *db_path, sqlite3 **sql) {
   sqlite3 *db = NULL;
   int rc;
 
@@ -270,7 +270,7 @@ void free_sqlite_secrets_row(struct secrets_row *row) {
   }
 }
 
-struct secrets_row *get_sqlite_secrets_row(sqlite3 *db, char *id) {
+struct secrets_row *get_sqlite_secrets_row(sqlite3 *db, const char *id) {
   struct secrets_row *row;
   sqlite3_stmt *res;
   int rc;

--- a/src/crypt/sqlite_crypt_writer.h
+++ b/src/crypt/sqlite_crypt_writer.h
@@ -66,10 +66,10 @@ struct secrets_row {
  * @brief Opens the sqlite crypt db
  *
  * @param db_path The sqlite db path
- * @param sql The returned sqlite db structure pointer
+ * @param[out] sql The returned sqlite db structure pointer
  * @return 0 on success, -1 on failure
  */
-int open_sqlite_crypt_db(char *db_path, sqlite3 **sql);
+int open_sqlite_crypt_db(const char *db_path, sqlite3 **sql);
 
 /**
  * @brief Closes the sqlite db
@@ -119,7 +119,7 @@ void free_sqlite_store_row(struct store_row *row);
  * @param id The secrets column id
  * @return struct secrets_row* row value, NULL on failure
  */
-struct secrets_row *get_sqlite_secrets_row(sqlite3 *db, char *id);
+struct secrets_row *get_sqlite_secrets_row(sqlite3 *db, const char *id);
 
 /**
  * @brief Frees a secrets row entry

--- a/src/utils/cryptou.c
+++ b/src/utils/cryptou.c
@@ -37,8 +37,8 @@ int crypto_genkey(uint8_t *buf, int key_size) {
   return RAND_bytes(buf, key_size);
 }
 
-int crypto_buf2key(uint8_t *buf, int buf_size, uint8_t *salt, int salt_size,
-                   uint8_t *key, int key_size) {
+int crypto_buf2key(const uint8_t *buf, int buf_size, const uint8_t *salt,
+                   int salt_size, uint8_t *key, int key_size) {
   if (PKCS5_PBKDF2_HMAC((char *)buf, buf_size, salt, salt_size,
                         MAX_KEY_ITERATIONS, EVP_sha256(), key_size, key) < 1) {
     log_trace("PKCS5_PBKDF2_HMAC fail wit code=%d", ERR_get_error());
@@ -48,8 +48,8 @@ int crypto_buf2key(uint8_t *buf, int buf_size, uint8_t *salt, int salt_size,
   return 0;
 }
 
-ssize_t crypto_encrypt(uint8_t *in, int in_size, uint8_t *key, uint8_t *iv,
-                       uint8_t *out) {
+ssize_t crypto_encrypt(const uint8_t *in, int in_size, const uint8_t *key,
+                       const uint8_t *iv, uint8_t *out) {
   EVP_CIPHER_CTX *ctx;
   int len;
   ssize_t ciphertext_len;

--- a/src/utils/cryptou.h
+++ b/src/utils/cryptou.h
@@ -64,16 +64,17 @@ int crypto_genkey(uint8_t *buf, int key_size);
 /**
  * @brief Transforms a secret buf into a key
  *
- * @param buf The secret buf
- * @param buf_size The buf size
- * @param salt The salt buf
- * @param salt_size The salt buf size
- * @param key The returned key
- * @param key_size The key size
- * @return int 0 on success, -1 on failure
+ * @param buf The secret buffer
+ * @param buf_size The secret @p buf size
+ * @param salt The salt buffer
+ * @param salt_size The @p salt buffer size
+ * @param[out] key The ouput buffer to store the key.
+ * @param key_size The size of the @p key buffer.
+ * @retval  0 on success
+ * @retval -1 on failure
  */
-int crypto_buf2key(uint8_t *buf, int buf_size, uint8_t *salt, int salt_size,
-                   uint8_t *key, int key_size);
+int crypto_buf2key(const uint8_t *buf, int buf_size, const uint8_t *salt,
+                   int salt_size, uint8_t *key, int key_size);
 
 /**
  * @brief Encrypts a buffer with AES CBC 256
@@ -82,11 +83,11 @@ int crypto_buf2key(uint8_t *buf, int buf_size, uint8_t *salt, int salt_size,
  * @param in_size The input buffer size
  * @param key The 256 bit key
  * @param iv The 128 bit key
- * @param out The output buffer
+ * @param[out] out The output buffer
  * @return The output size, -1 on error
  */
-ssize_t crypto_encrypt(uint8_t *in, int in_size, uint8_t *key, uint8_t *iv,
-                       uint8_t *out);
+ssize_t crypto_encrypt(const uint8_t *in, int in_size, const uint8_t *key,
+                       const uint8_t *iv, uint8_t *out);
 
 /**
  * @brief Decrypts a buffer with AES CBC 256


### PR DESCRIPTION
Fix `-Wwrite-string` warnings when running `cmake --preset linux-with-crypt`.

We don't modify any string constants in the `crypt` code, so all we had to do was to make some params `const`.

This prevents `-Wwrite-string` from raising any warnings.