### PR TITLE
refactor(eloop): remove `eloop_wait_for_read_sock`

### DIFF
--- a/src/utils/eloop.c
+++ b/src/utils/eloop.c
@@ -640,19 +640,3 @@ int eloop_terminated(struct eloop_data *eloop) {
 
   return eloop->terminate;
 }
-
-void eloop_wait_for_read_sock(int sock) {
-  /*
-   * We can use epoll() here. But epoll() requres 4 system calls.
-   * epoll_create1(), epoll_ctl() for ADD, epoll_wait, and close() for
-   * epoll fd. So select() is better for performance here.
-   */
-  fd_set rfds;
-
-  if (sock < 0)
-    return;
-
-  FD_ZERO(&rfds);
-  FD_SET(sock, &rfds);
-  select(sock + 1, &rfds, NULL, NULL, NULL);
-}

--- a/src/utils/eloop.h
+++ b/src/utils/eloop.h
@@ -328,13 +328,4 @@ void eloop_terminate(struct eloop_data *eloop);
  */
 int eloop_terminated(struct eloop_data *eloop);
 
-/**
- * eloop_wait_for_read_sock - Wait for a single reader
- *
- * @sock: File descriptor number for the socket
- *
- * Do a blocking wait for a single read socket.
- */
-void eloop_wait_for_read_sock(int sock);
-
 #endif /* ELOOP_H */


### PR DESCRIPTION
This function is not used anywhere, so we might as well delete it.