### PR TITLE
test(uci_wrt): use temporary test data files

### DIFF
--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -6,7 +6,10 @@ include_directories (
 )
 
 if (USE_UCI_SERVICE)
-  add_compile_definitions(TEST_UCI_CONFIG_DIR="${CMAKE_SOURCE_DIR}/tests/data/uci")
+  # tests may modify these files, so we only run on a copy
+  file(COPY "${CMAKE_SOURCE_DIR}/tests/data/uci" DESTINATION "${CMAKE_BINARY_DIR}/tests/data")
+  set(TEST_UCI_CONFIG_DIR "${CMAKE_BINARY_DIR}/tests/data/uci")
+  add_compile_definitions(TEST_UCI_CONFIG_DIR="${TEST_UCI_CONFIG_DIR}")
   add_library(
     __wrap_uwrt_init_context OBJECT ./utils/__wrap_uwrt_init_context.c
   )


### PR DESCRIPTION
The uci_wrt tests sometimes modify the `./tests/data/uci` files. This causes issues with `git switch`/`git rebase`.

This commit means we instead test on a copy of the test data in the build directory.