### PR TITLE
Use `AddCMockaTest.cmake` script to simplify test scripts

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -34,7 +34,7 @@ list(APPEND CMAKE_MODULE_PATH "${CMAKE_CURRENT_SOURCE_DIR}/CMakeModules")
 list(APPEND CMAKE_MODULE_PATH "${CMAKE_CURRENT_SOURCE_DIR}/lib")
 list(APPEND CMAKE_MODULE_PATH "${CMAKE_CURRENT_SOURCE_DIR}/docs")
 
-include(CTest)
+include(AddCMockaTest)
 include(FetchContent)
 include(ExternalProject)
 include(CMakeDependentOption)

--- a/CMakeModules/AddCMockaTest.cmake
+++ b/CMakeModules/AddCMockaTest.cmake
@@ -1,0 +1,143 @@
+#
+# Copyright (c) 2007      Daniel Gollub <dgollub@suse.de>
+# Copyright (c) 2007-2018 Andreas Schneider <asn@cryptomilk.org>
+# Copyright (c) 2018      Anderson Toshiyuki Sasaki <ansasaki@redhat.com>
+#
+# Redistribution and use is allowed according to the terms of the BSD license.
+# For details see the accompanying COPYING-CMAKE-SCRIPTS file.
+
+#.rst:
+# AddCMockaTest
+# -------------
+#
+# This file provides a function to add a test
+#
+# Functions provided
+# ------------------
+#
+# ::
+#
+#   add_cmocka_test(target_name
+#                   SOURCES src1 src2 ... srcN
+#                   [COMPILE_OPTIONS opt1 opt2 ... optN]
+#                   [LINK_LIBRARIES lib1 lib2 ... libN]
+#                   [LINK_OPTIONS lopt1 lop2 .. loptN]
+#                  )
+#
+# ``target_name``:
+#   Required, expects the name of the test which will be used to define a target
+#
+# ``SOURCES``:
+#   Required, expects one or more source files names
+#
+# ``COMPILE_OPTIONS``:
+#   Optional, expects one or more options to be passed to the compiler
+#
+# ``LINK_LIBRARIES``:
+#   Optional, expects one or more libraries to be linked with the test
+#   executable.
+#
+# ``LINK_OPTIONS``:
+#   Optional, expects one or more options to be passed to the linker
+#
+#
+# Example:
+#
+# .. code-block:: cmake
+#
+#   add_cmocka_test(my_test
+#                   SOURCES my_test.c other_source.c
+#                   COMPILE_OPTIONS -g -Wall
+#                   LINK_LIBRARIES mylib
+#                   LINK_OPTIONS -Wl,--enable-syscall-fixup
+#                  )
+#
+# Where ``my_test`` is the name of the test, ``my_test.c`` and
+# ``other_source.c`` are sources for the binary, ``-g -Wall`` are compiler
+# options to be used, ``mylib`` is a target of a library to be linked, and
+# ``-Wl,--enable-syscall-fixup`` is an option passed to the linker.
+#
+
+enable_testing()
+include(CTest)
+
+if (CMAKE_CROSSCOMPILING)
+    if (WIN32)
+        find_program(WINE_EXECUTABLE
+                     NAMES wine)
+        set(TARGET_SYSTEM_EMULATOR ${WINE_EXECUTABLE} CACHE INTERNAL "")
+    endif()
+endif()
+
+function(ADD_CMOCKA_TEST _TARGET_NAME)
+
+    set(one_value_arguments
+    )
+
+    set(multi_value_arguments
+        SOURCES
+        COMPILE_OPTIONS
+        LINK_LIBRARIES
+        LINK_OPTIONS
+    )
+
+    cmake_parse_arguments(_add_cmocka_test
+        ""
+        "${one_value_arguments}"
+        "${multi_value_arguments}"
+        ${ARGN}
+    )
+
+    if (NOT DEFINED _add_cmocka_test_SOURCES)
+        message(FATAL_ERROR "No sources provided for target ${_TARGET_NAME}")
+    endif()
+
+    add_executable(${_TARGET_NAME} ${_add_cmocka_test_SOURCES})
+
+    if (DEFINED _add_cmocka_test_COMPILE_OPTIONS)
+        target_compile_options(${_TARGET_NAME}
+            PRIVATE ${_add_cmocka_test_COMPILE_OPTIONS}
+        )
+    endif()
+
+    if (DEFINED _add_cmocka_test_LINK_LIBRARIES)
+        target_link_libraries(${_TARGET_NAME}
+            PRIVATE ${_add_cmocka_test_LINK_LIBRARIES}
+        )
+    endif()
+
+    if (DEFINED _add_cmocka_test_LINK_OPTIONS)
+        set_target_properties(${_TARGET_NAME}
+            PROPERTIES LINK_FLAGS
+            ${_add_cmocka_test_LINK_OPTIONS}
+        )
+    endif()
+
+    add_test(${_TARGET_NAME}
+        ${TARGET_SYSTEM_EMULATOR} ${_TARGET_NAME}
+    )
+
+endfunction (ADD_CMOCKA_TEST)
+
+function(ADD_CMOCKA_TEST_ENVIRONMENT _TARGET_NAME)
+    if (WIN32 OR CYGWIN OR MINGW OR MSVC)
+        file(TO_NATIVE_PATH "${cmocka-library_BINARY_DIR}" CMOCKA_DLL_PATH)
+
+        if (TARGET_SYSTEM_EMULATOR)
+            set(DLL_PATH_ENV "WINEPATH=${CMOCKA_DLL_PATH};$ENV{WINEPATH}")
+        else()
+            set(DLL_PATH_ENV "PATH=${CMOCKA_DLL_PATH}\\${CMAKE_BUILD_TYPE};$ENV{PATH}")
+        endif()
+        #
+        # IMPORTANT NOTE: The set_tests_properties(), below, internally
+        # stores its name/value pairs with a semicolon delimiter.
+        # because of this we must protect the semicolons in the path
+        #
+        string(REPLACE ";" "\\;" DLL_PATH_ENV "${DLL_PATH_ENV}")
+
+        set_tests_properties(${_TARGET_NAME}
+                             PROPERTIES
+                                ENVIRONMENT
+                                    "${DLL_PATH_ENV}")
+    endif()
+endfunction()

--- a/CMakeModules/AddCMockaTest.cmake
+++ b/CMakeModules/AddCMockaTest.cmake
@@ -1,10 +1,14 @@
+# SPDX-License-Identifier: BSD-3-Clause
+# SPDX-FileCopyrightText: Copyright (c) 2007      Daniel Gollub <dgollub@suse.de>
+# SPDX-FileCopyrightText: Copyright (c) 2007-2018 Andreas Schneider <asn@cryptomilk.org>
+# SPDX-FileCopyrightText: Copyright (c) 2018      Anderson Toshiyuki Sasaki <ansasaki@redhat.com>
 #
-# Copyright (c) 2007      Daniel Gollub <dgollub@suse.de>
-# Copyright (c) 2007-2018 Andreas Schneider <asn@cryptomilk.org>
-# Copyright (c) 2018      Anderson Toshiyuki Sasaki <ansasaki@redhat.com>
+# Redistribution and use is allowed according to the terms of the BSD 3-Clause license.
+# For details see the
+# https://gitlab.com/cmocka/cmocka/-/blob/a7a1ae83d567ccd6b469e157fc0a3db872039a49/cmake/Modules/COPYING-CMAKE-SCRIPTS
+# file.
 #
-# Redistribution and use is allowed according to the terms of the BSD license.
-# For details see the accompanying COPYING-CMAKE-SCRIPTS file.
+# File originally taken from https://gitlab.com/cmocka/cmocka/-/blob/a7a1ae83d567ccd6b469e157fc0a3db872039a49/cmake/Modules/AddCMockaTest.cmake
 
 #.rst:
 # AddCMockaTest

--- a/debian/copyright
+++ b/debian/copyright
@@ -20,6 +20,12 @@ Copyright: 2000-2022 Kitware, Inc. and Contributors
 License: BSD-3-clause
 Source: https://gitlab.kitware.com/cmake/cmake/-/blob/master/Source/Modules/FindLibUUID.cmake
 
+Files: CMakeModules/AddCMockaTest.cmake
+Copyright: 2007, Daniel Gollub <dgollub@suse.de>
+           2007-2018, Andreas Schneider <asn@cryptomilk.org>
+           2018, Anderson Toshiyuki Sasaki <ansasaki@redhat.com>
+License: BSD-3-clause
+
 Files: lib/netlink/*
 Copyright: 2010, see individual files for details
 License: GPL-2+

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -36,11 +36,15 @@ if (USE_MDNS_SERVICE)
   add_subdirectory(dns)
 endif ()
 
-add_executable(test_config test_config.c)
-target_link_libraries(test_config PRIVATE cmocka::cmocka log config)
+add_cmocka_test(test_config
+  SOURCES test_config.c
+  LINK_LIBRARIES cmocka::cmocka log config
+)
 
-add_executable(test_runctl test_runctl.c)
-target_link_libraries(test_runctl PUBLIC SQLite::SQLite3 LibUTHash::LibUTHash PRIVATE runctl log os supervisor_config mac_mapper cmocka::cmocka)
+add_cmocka_test(test_runctl
+  SOURCES test_runctl.c
+  LINK_LIBRARIES SQLite::SQLite3 LibUTHash::LibUTHash runctl log os supervisor_config mac_mapper cmocka::cmocka
+)
 
 target_link_options(test_runctl PRIVATE
   "LINKER:--wrap=get_vlan_mapper,--wrap=eloop_run,--wrap=get_commands_paths,--wrap=hmap_str_keychar_get"
@@ -66,13 +70,3 @@ endif()
 if (USE_UCI_SERVICE)
   target_link_libraries(test_runctl PUBLIC __wrap_uwrt_init_context)
 endif()
-
-add_test(NAME test_config COMMAND test_config)
-set_tests_properties(test_config
-  PROPERTIES
-  WILL_FAIL FALSE)
-
-add_test(NAME test_runctl COMMAND test_runctl)
-set_tests_properties(test_runctl
-  PROPERTIES
-  WILL_FAIL FALSE)

--- a/tests/ap/CMakeLists.txt
+++ b/tests/ap/CMakeLists.txt
@@ -2,8 +2,10 @@ include_directories(
   "${PROJECT_SOURCE_DIR}/src"
 )
 
-add_executable(test_hostapd test_hostapd.c)
-target_link_libraries(test_hostapd PRIVATE hostapd iface os log cmocka::cmocka)
+add_cmocka_test(test_hostapd
+  SOURCES test_hostapd.c
+  LINK_LIBRARIES hostapd iface os log cmocka::cmocka
+)
 target_link_options(test_hostapd
   PRIVATE
   "LINKER:--wrap=kill_process,--wrap=signal_process,--wrap=reset_interface,--wrap=run_process,--wrap=list_dir,--wrap=check_sock_file_exists"
@@ -13,20 +15,11 @@ if (USE_UCI_SERVICE)
   target_link_libraries(test_hostapd PRIVATE __wrap_uwrt_init_context)
 endif()
 
-add_executable(test_ap_service test_ap_service.c)
-target_link_libraries(test_ap_service PRIVATE ap_service hostapd iface os log cmocka::cmocka)
-# sqlite3.h required by src/supervisor/supervisor_config.h
+add_cmocka_test(test_ap_service
+  SOURCES test_ap_service.c
+  LINK_LIBRARIES ap_service hostapd iface os log cmocka::cmocka
+)
 target_link_options(test_ap_service
   PRIVATE
   "LINKER:--wrap=close,--wrap=generate_vlan_conf,--wrap=run_ap_process,--wrap=generate_hostapd_conf,--wrap=signal_ap_process,--wrap=create_domain_client,--wrap=eloop_register_read_sock,--wrap=write_domain_data_s,--wrap=writeread_domain_data_str"
 )
-
-add_test(NAME test_hostapd COMMAND test_hostapd)
-set_tests_properties(test_hostapd
-  PROPERTIES
-  WILL_FAIL FALSE)
-
-add_test(NAME test_ap_service COMMAND test_ap_service)
-set_tests_properties(test_ap_service
-  PROPERTIES
-  WILL_FAIL FALSE)

--- a/tests/capture/CMakeLists.txt
+++ b/tests/capture/CMakeLists.txt
@@ -4,14 +4,11 @@ include_directories (
   "${PROJECT_SOURCE_DIR}/src"
 )
 
-add_executable(test_capture_service test_capture_service.c)
-target_link_libraries(test_capture_service PUBLIC PCAP::pcap SQLite::SQLite3 PRIVATE capture_service packet_decoder os log cmocka::cmocka)
+add_cmocka_test(test_capture_service
+  SOURCES test_capture_service.c
+  LINK_LIBRARIES PCAP::pcap SQLite::SQLite3 capture_service packet_decoder os log cmocka::cmocka
+)
 target_link_options(test_capture_service
   PRIVATE
   "LINKER:--wrap=open_sqlite_header_db,--wrap=open_sqlite_pcap_db,--wrap=free_sqlite_header_db,--wrap=free_sqlite_pcap_db,--wrap=run_pcap,--wrap=close_pcap,--wrap=eloop_init,--wrap=eloop_register_read_sock,--wrap=eloop_register_timeout,--wrap=eloop_run,--wrap=eloop_free,--wrap=run_register_db,--wrap=extract_packets,--wrap=push_packet_queue,--wrap=push_pcap_queue"
 )
-
-add_test(NAME test_capture_service COMMAND test_capture_service)
-set_tests_properties(test_capture_service
-  PROPERTIES
-  WILL_FAIL FALSE)

--- a/tests/capture/middlewares/CMakeLists.txt
+++ b/tests/capture/middlewares/CMakeLists.txt
@@ -1,55 +1,40 @@
-add_executable(test_header_middleware test_header_middleware.c)
-target_link_libraries(test_header_middleware PUBLIC PCAP::pcap SQLite::SQLite3 PRIVATE header_middleware sqliteu os log cmocka::cmocka)
+add_cmocka_test(test_header_middleware
+  SOURCES test_header_middleware.c
+  LINK_LIBRARIES PCAP::pcap SQLite::SQLite3 header_middleware sqliteu os log cmocka::cmocka
+)
 target_link_options(test_header_middleware
   PRIVATE
   "LINKER:--wrap=sqlite3_open"
 )
 
 if (USE_PROTOBUF_MIDDLEWARE)
-  add_executable(test_protobuf_utils test_protobuf_utils.c)
-  target_link_libraries(test_protobuf_utils PUBLIC PCAP::pcap PRIVATE protobuf_utils sync.pb-c eth.pb-c os log cmocka::cmocka)
+  add_cmocka_test(test_protobuf_utils
+    SOURCES test_protobuf_utils.c
+    LINK_LIBRARIES PCAP::pcap protobuf_utils sync.pb-c eth.pb-c os log cmocka::cmocka
+  )
+endif()
 
-  add_test(NAME test_protobuf_utils COMMAND test_protobuf_utils)
-  set_tests_properties(test_protobuf_utils
-    PROPERTIES
-    WILL_FAIL FALSE)
-endif (USE_PROTOBUF_MIDDLEWARE)
-
-add_executable(test_sqlite_header test_sqlite_header.c)
-target_link_libraries(test_sqlite_header PRIVATE sqlite_header os log Threads::Threads cmocka::cmocka SQLite::SQLite3)
-
-add_executable(test_packet_queue test_packet_queue.c)
-target_link_libraries(test_packet_queue PUBLIC PCAP::pcap SQLite::SQLite3 PRIVATE packet_queue os log cmocka::cmocka)
-
-add_executable(test_pcap_queue test_pcap_queue.c)
-target_link_libraries(test_pcap_queue PRIVATE pcap_queue os log cmocka::cmocka)
-
-add_executable(test_sqlite_pcap test_sqlite_pcap.c)
-target_link_libraries(test_sqlite_pcap PRIVATE sqlite_pcap sqliteu os log Threads::Threads cmocka::cmocka)
-
-add_test(NAME test_header_middleware COMMAND test_header_middleware)
-set_tests_properties(test_header_middleware
-  PROPERTIES
-  WILL_FAIL FALSE)
-
-add_test(NAME test_sqlite_header COMMAND test_sqlite_header)
+add_cmocka_test(test_sqlite_header
+  SOURCES test_sqlite_header.c
+  LINK_LIBRARIES sqlite_header os log Threads::Threads cmocka::cmocka SQLite::SQLite3
+)
 set_tests_properties(test_sqlite_header
   PROPERTIES
   WILL_FAIL FALSE
   ENVIRONMENT CMOCKA_TEST_ABORT='1' # these tests uses threading
 )
 
-add_test(NAME test_packet_queue COMMAND test_packet_queue)
-set_tests_properties(test_packet_queue
-  PROPERTIES
-  WILL_FAIL FALSE)
+add_cmocka_test(test_packet_queue
+  SOURCES test_packet_queue.c
+  LINK_LIBRARIES PCAP::pcap SQLite::SQLite3 packet_queue os log cmocka::cmocka
+)
 
-add_test(NAME test_pcap_queue COMMAND test_pcap_queue)
-set_tests_properties(test_pcap_queue
-  PROPERTIES
-  WILL_FAIL FALSE)
+add_cmocka_test(test_pcap_queue
+  SOURCES test_pcap_queue.c
+  LINK_LIBRARIES pcap_queue os log cmocka::cmocka
+)
 
-add_test(NAME test_sqlite_pcap COMMAND test_sqlite_pcap)
-set_tests_properties(test_sqlite_pcap
-  PROPERTIES
-  WILL_FAIL FALSE)
+add_cmocka_test(test_sqlite_pcap
+  SOURCES test_sqlite_pcap.c
+  LINK_LIBRARIES sqlite_pcap sqliteu os log Threads::Threads cmocka::cmocka
+)

--- a/tests/crypt/CMakeLists.txt
+++ b/tests/crypt/CMakeLists.txt
@@ -2,26 +2,21 @@ include_directories (
   "${PROJECT_SOURCE_DIR}/src"
 )
 
-add_executable(test_sqlite_crypt_writer test_sqlite_crypt_writer.c)
-target_link_libraries(test_sqlite_crypt_writer PRIVATE sqlite_crypt_writer sqliteu os log SQLite::SQLite3 cmocka::cmocka)
+add_cmocka_test(
+  test_sqlite_crypt_writer
+  SOURCES test_sqlite_crypt_writer.c
+  LINK_LIBRARIES sqlite_crypt_writer sqliteu os log SQLite::SQLite3 cmocka::cmocka
+)
 target_link_options(test_sqlite_crypt_writer
   PRIVATE
   "LINKER:--wrap=sqlite3_open"
 )
 
-add_executable(test_crypt_service test_crypt_service.c)
-target_link_libraries(test_crypt_service PRIVATE crypt_service sqlite_crypt_writer sqliteu os log cmocka::cmocka)
+add_cmocka_test(test_crypt_service
+  SOURCES test_crypt_service.c
+  LINK_LIBRARIES crypt_service sqlite_crypt_writer sqliteu os log cmocka::cmocka
+)
 target_link_options(test_crypt_service
   PRIVATE
   "LINKER:--wrap=crypto_decrypt,--wrap=init_hsm"
 )
-
-add_test(NAME test_sqlite_crypt_writer COMMAND test_sqlite_crypt_writer)
-set_tests_properties(test_sqlite_crypt_writer
-  PROPERTIES
-  WILL_FAIL FALSE)
-
-add_test(NAME test_crypt_service COMMAND test_crypt_service)
-set_tests_properties(test_crypt_service
-  PROPERTIES
-  WILL_FAIL FALSE)

--- a/tests/dhcp/CMakeLists.txt
+++ b/tests/dhcp/CMakeLists.txt
@@ -2,8 +2,10 @@ include_directories(
   "${PROJECT_SOURCE_DIR}/src"
 )
 
-add_executable(test_dnsmasq test_dnsmasq.c)
-target_link_libraries(test_dnsmasq PRIVATE dnsmasq log cmocka::cmocka)
+add_cmocka_test(test_dnsmasq
+  SOURCES test_dnsmasq.c
+  LINK_LIBRARIES dnsmasq log cmocka::cmocka
+)
 target_link_options(test_dnsmasq
   PRIVATE
   "LINKER:--wrap=kill_process,--wrap=run_process,--wrap=is_proc_running,--wrap=signal_process"
@@ -12,19 +14,11 @@ if (USE_UCI_SERVICE)
   target_link_libraries(test_dnsmasq PRIVATE __wrap_uwrt_init_context)
 endif()
 
-add_executable(test_dhcp_service test_dhcp_service.c)
-target_link_libraries(test_dhcp_service PRIVATE dhcp_service dnsmasq log cmocka::cmocka)
+add_cmocka_test(test_dhcp_service
+  SOURCES test_dhcp_service.c
+  LINK_LIBRARIES dhcp_service dnsmasq log cmocka::cmocka
+)
 target_link_options(test_dhcp_service
   PRIVATE
   "LINKER:--wrap=generate_dnsmasq_conf,--wrap=generate_dnsmasq_script,--wrap=run_dhcp_process,--wrap=kill_dhcp_process,--wrap=clear_dhcp_lease_entry"
 )
-
-add_test(NAME test_dnsmasq COMMAND test_dnsmasq)
-set_tests_properties(test_dnsmasq
-  PROPERTIES
-  WILL_FAIL FALSE)
-
-add_test(NAME test_dhcp_service COMMAND test_dhcp_service)
-set_tests_properties(test_dhcp_service
-  PROPERTIES
-  WILL_FAIL FALSE)

--- a/tests/dns/CMakeLists.txt
+++ b/tests/dns/CMakeLists.txt
@@ -2,50 +2,33 @@ include_directories(
   "${PROJECT_SOURCE_DIR}/src"
 )
 
-add_executable(test_mdns_list test_mdns_list.c)
-target_link_libraries(test_mdns_list PRIVATE os mdns_list log cmocka::cmocka)
+add_cmocka_test(test_mdns_list
+  SOURCES test_mdns_list.c
+  LINK_LIBRARIES os mdns_list log cmocka::cmocka
+)
 
-add_executable(test_mdns_mapper test_mdns_mapper.c)
-target_link_libraries(test_mdns_mapper PRIVATE mdns_mapper log cmocka::cmocka)
+add_cmocka_test(test_mdns_mapper
+  SOURCES test_mdns_mapper.c
+  LINK_LIBRARIES mdns_mapper log cmocka::cmocka
+)
 
-add_executable(test_command_mapper test_command_mapper.c)
-target_link_libraries(test_command_mapper PRIVATE command_mapper log cmocka::cmocka)
+add_cmocka_test(test_command_mapper
+  SOURCES test_command_mapper.c
+  LINK_LIBRARIES command_mapper log cmocka::cmocka
+)
 
-add_executable(test_reflection_list test_reflection_list.c)
-target_link_libraries(test_reflection_list PRIVATE os reflection_list log cmocka::cmocka)
+add_cmocka_test(test_reflection_list
+  SOURCES test_reflection_list.c
+  LINK_LIBRARIES os reflection_list log cmocka::cmocka
+)
 
 if (USE_MDNS_SERVICE AND USE_CAPTURE_SERVICE)
-  add_executable(test_mdns_service test_mdns_service.c)
-  target_link_libraries(test_mdns_service PRIVATE mdns_service pcap_service log cmocka::cmocka)
+  add_cmocka_test(test_mdns_service
+    SOURCES test_mdns_service.c
+    LINK_LIBRARIES mdns_service pcap_service log cmocka::cmocka
+  )
   target_link_options(test_mdns_service
     PRIVATE
     "LINKER:--wrap=run_pcap,--wrap=eloop_register_read_sock,--wrap=eloop_init,--wrap=eloop_run,--wrap=eloop_free"
   )
-endif ()
-
-add_test(NAME test_mdns_list COMMAND test_mdns_list)
-set_tests_properties(test_mdns_list
-  PROPERTIES
-  WILL_FAIL FALSE)
-
-add_test(NAME test_mdns_mapper COMMAND test_mdns_mapper)
-set_tests_properties(test_mdns_mapper
-  PROPERTIES
-  WILL_FAIL FALSE)
-
-add_test(NAME test_command_mapper COMMAND test_command_mapper)
-set_tests_properties(test_command_mapper
-  PROPERTIES
-  WILL_FAIL FALSE)
-
-add_test(NAME test_reflection_list COMMAND test_reflection_list)
-set_tests_properties(test_reflection_list
-  PROPERTIES
-  WILL_FAIL FALSE)
-
-if (USE_MDNS_SERVICE AND USE_CAPTURE_SERVICE)
-  add_test(NAME test_mdns_service COMMAND test_mdns_service)
-  set_tests_properties(test_mdns_service
-    PROPERTIES
-    WILL_FAIL FALSE)
 endif ()

--- a/tests/radius/CMakeLists.txt
+++ b/tests/radius/CMakeLists.txt
@@ -8,10 +8,7 @@ target_link_libraries(ip_addr PRIVATE os allocs)
 add_library(radius_client radius_client.c)
 target_link_libraries(radius_client ip_addr radius md5 wpabuf log os eloop)
 
-add_executable(test_radius_server test_radius_server.c)
-target_link_libraries(test_radius_server PRIVATE radius_client ip_addr radius radius_server md5 wpabuf log os eloop cmocka::cmocka)
-
-add_test(NAME test_radius_server COMMAND test_radius_server)
-set_tests_properties(test_radius_server
-  PROPERTIES
-  WILL_FAIL FALSE)
+add_cmocka_test(test_radius_server
+  SOURCES test_radius_server.c
+  LINK_LIBRARIES radius_client ip_addr radius radius_server md5 wpabuf log os eloop cmocka::cmocka
+)

--- a/tests/supervisor/CMakeLists.txt
+++ b/tests/supervisor/CMakeLists.txt
@@ -2,25 +2,35 @@ include_directories(
   "${PROJECT_SOURCE_DIR}/src"
 )
 
-add_executable(test_bridge_list test_bridge_list.c)
-target_link_libraries(test_bridge_list PRIVATE bridge_list net log cmocka::cmocka)
+add_cmocka_test(test_bridge_list
+  SOURCES test_bridge_list.c
+  LINK_LIBRARIES bridge_list net log cmocka::cmocka
+)
 
-add_executable(test_supervisor_utils test_supervisor_utils.c)
-target_link_libraries(test_supervisor_utils PRIVATE supervisor_utils net log cmocka::cmocka)
+add_cmocka_test(test_supervisor_utils
+  SOURCES test_supervisor_utils.c
+  LINK_LIBRARIES supervisor_utils net log cmocka::cmocka
+)
 
-add_executable(test_supervisor test_supervisor.c)
-target_link_libraries(test_supervisor PRIVATE sqlite_macconn_writer supervisor net log cmocka::cmocka)
+add_cmocka_test(test_supervisor
+  SOURCES test_supervisor.c
+  LINK_LIBRARIES sqlite_macconn_writer supervisor net log cmocka::cmocka
+)
 
-add_executable(test_sockctl_server test_sockctl_server.c)
-target_link_libraries(test_sockctl_server PRIVATE sockctl os log cmocka::cmocka)
+add_cmocka_test(test_sockctl_server
+  SOURCES test_sockctl_server.c
+  LINK_LIBRARIES sockctl os log cmocka::cmocka
+)
 if(${CMAKE_SYSTEM_NAME} STREQUAL "Linux")
   # Abstract Unix domain sockets are only supported on Linux, but save a bit of writing
   # to the disk
   target_compile_definitions(test_sockctl_server PRIVATE USE_ABSTRACT_UNIX_DOMAIN_SOCKETS)
 endif()
 
-add_executable(test_cmd_processor test_cmd_processor.c)
-target_link_libraries(test_cmd_processor PRIVATE cmd_processor iptables log cmocka::cmocka)
+add_cmocka_test(test_cmd_processor
+  SOURCES test_cmd_processor.c
+  LINK_LIBRARIES cmd_processor iptables log cmocka::cmocka
+)
 target_link_options(test_cmd_processor PRIVATE
   "LINKER:--wrap=write_socket_data,--wrap=accept_mac_cmd,--wrap=deny_mac_cmd"
   "LINKER:--wrap=add_nat_cmd,--wrap=remove_nat_cmd,--wrap=assign_psk_cmd"
@@ -29,7 +39,6 @@ target_link_options(test_cmd_processor PRIVATE
   "LINKER:--wrap=clear_psk_cmd,--wrap=get_mac_mapper,--wrap=remove_bridge_cmd"
   "LINKER:--wrap=clear_bridges_cmd,--wrap=subscribe_events_cmd,--wrap=register_ticket_cmd"
 )
-
 if (USE_CRYPTO_SERVICE)
   target_link_options(test_cmd_processor PRIVATE
     "LINKER:--wrap=gen_randkey_cmd,--wrap=gen_privkey_cmd,--wrap=gen_pubkey_cmd"
@@ -38,47 +47,16 @@ if (USE_CRYPTO_SERVICE)
   )
 endif ()
 
-add_executable(test_mac_mapper test_mac_mapper.c)
-target_link_libraries(test_mac_mapper PRIVATE log os mac_mapper cmocka::cmocka)
+add_cmocka_test(test_mac_mapper
+  SOURCES test_mac_mapper.c
+  LINK_LIBRARIES log os mac_mapper cmocka::cmocka
+)
 
-add_executable(test_sqlite_macconn_writer test_sqlite_macconn_writer.c)
-target_link_libraries(test_sqlite_macconn_writer PRIVATE sqlite_macconn_writer sqliteu os log cmocka::cmocka)
+add_cmocka_test(test_sqlite_macconn_writer
+  SOURCES test_sqlite_macconn_writer.c
+  LINK_LIBRARIES sqlite_macconn_writer sqliteu os log cmocka::cmocka
+)
 target_link_options(test_sqlite_macconn_writer
   PRIVATE
   "LINKER:--wrap=sqlite3_open"
 )
-
-add_test(NAME test_supervisor_utils COMMAND test_supervisor_utils)
-set_tests_properties(test_supervisor_utils
-  PROPERTIES
-  WILL_FAIL FALSE)
-
-add_test(NAME test_supervisor COMMAND test_supervisor)
-set_tests_properties(test_supervisor
-  PROPERTIES
-  WILL_FAIL FALSE)
-
-add_test(NAME test_bridge_list COMMAND test_bridge_list)
-set_tests_properties(test_bridge_list
-  PROPERTIES
-  WILL_FAIL FALSE)
-
-add_test(NAME test_sockctl_server COMMAND test_sockctl_server)
-set_tests_properties(test_sockctl_server
-  PROPERTIES
-  WILL_FAIL FALSE)
-
-add_test(NAME test_cmd_processor COMMAND test_cmd_processor)
-set_tests_properties(test_cmd_processor
-  PROPERTIES
-  WILL_FAIL FALSE)
-
-add_test(NAME test_mac_mapper COMMAND test_mac_mapper)
-set_tests_properties(test_mac_mapper
-  PROPERTIES
-  WILL_FAIL FALSE)
-
-add_test(NAME test_sqlite_macconn_writer COMMAND test_sqlite_macconn_writer)
-set_tests_properties(test_sqlite_macconn_writer
-  PROPERTIES
-  WILL_FAIL FALSE)

--- a/tests/system/CMakeLists.txt
+++ b/tests/system/CMakeLists.txt
@@ -2,10 +2,7 @@ include_directories (
   "${PROJECT_SOURCE_DIR}/src"
 )
 
-add_executable(test_system_checks test_system_checks.c)
-target_link_libraries(test_system_checks PRIVATE log system_checks os hashmap cmocka::cmocka)
-
-add_test(NAME test_system_checks COMMAND test_system_checks)
-set_tests_properties(test_system_checks
-  PROPERTIES
-  WILL_FAIL FALSE)
+add_cmocka_test(test_system_checks
+  SOURCES test_system_checks.c
+  LINK_LIBRARIES log system_checks os hashmap cmocka::cmocka
+)

--- a/tests/utils/CMakeLists.txt
+++ b/tests/utils/CMakeLists.txt
@@ -6,153 +6,95 @@ add_library(tmpdir OBJECT tmpdir.c)
 target_link_libraries(tmpdir PRIVATE log cmocka::cmocka)
 
 if (USE_UCI_SERVICE)
-  add_executable(test_uci_wrt test_uci_wrt.c)
-  target_link_libraries(test_uci_wrt PRIVATE uci_wrt cmocka::cmocka iface_mapper)
+  add_cmocka_test(test_uci_wrt
+    SOURCES test_uci_wrt.c
+    LINK_LIBRARIES uci_wrt cmocka::cmocka iface_mapper)
 endif ()
 
-add_executable(test_iface_mapper test_iface_mapper.c)
-target_link_libraries(test_iface_mapper PRIVATE iface_mapper cmocka::cmocka)
+add_cmocka_test(test_iface_mapper
+  SOURCES test_iface_mapper.c
+  LINK_LIBRARIES iface_mapper cmocka::cmocka)
 
-add_executable(test_ifaceu test_ifaceu.c)
-target_link_libraries(test_ifaceu PRIVATE ifaceu cmocka::cmocka)
+add_cmocka_test(test_ifaceu
+  SOURCES test_ifaceu.c
+  LINK_LIBRARIES ifaceu cmocka::cmocka)
 
-add_executable(test_net test_net.c)
-target_link_libraries(test_net PRIVATE net cmocka::cmocka)
+add_cmocka_test(test_net
+  SOURCES test_net.c
+  LINK_LIBRARIES net cmocka::cmocka)
 
-add_executable(test_os test_os.c)
-target_link_libraries(test_os PRIVATE tmpdir os allocs hashmap cmocka::cmocka)
+add_cmocka_test(test_os
+  SOURCES test_os.c
+  LINK_LIBRARIES tmpdir os allocs hashmap cmocka::cmocka)
 
-add_executable(test_eloop test_eloop.c)
-target_link_libraries(test_eloop PRIVATE tmpdir sockctl os allocs eloop cmocka::cmocka)
+add_cmocka_test(test_eloop
+  SOURCES test_eloop.c
+  LINK_LIBRARIES tmpdir sockctl os allocs eloop cmocka::cmocka)
 
-add_executable(test_eloop_handles_null test_eloop_handles_null.c)
-target_link_libraries(test_eloop_handles_null
+add_cmocka_test(test_eloop_handles_null
+  SOURCES test_eloop_handles_null.c
+  LINK_LIBRARIES
   PRIVATE eloop cmocka::cmocka wrap_log_error
 )
 
-add_executable(test_eloop_threaded test_eloop_threaded.c)
-target_link_libraries(test_eloop_threaded PRIVATE eloop cmocka::cmocka sockctl LibUTHash::LibUTHash Threads::Threads)
-
-add_executable(test_sqliteu test_sqliteu.c)
-target_link_libraries(test_sqliteu PRIVATE sqliteu cmocka::cmocka)
-
-add_executable(test_hashmap test_hashmap.c)
-target_link_libraries(test_hashmap PRIVATE hashmap cmocka::cmocka)
-
-add_executable(test_utarray test_utarray.c)
-target_link_libraries(test_utarray PRIVATE LibUTHash::LibUTHash cmocka::cmocka)
-
-add_executable(test_minIni test_minIni.c)
-target_link_libraries(test_minIni PRIVATE MinIni::minIni cmocka::cmocka)
-
-add_executable(test_squeue test_squeue.c)
-target_link_libraries(test_squeue PRIVATE squeue os cmocka::cmocka)
-
-add_executable(test_log_thread_safe test_log_thread_safe.c)
-target_link_libraries(test_log_thread_safe log Threads::Threads)
-
-add_executable(test_log_level test_log_level.c)
-target_link_libraries(test_log_level PRIVATE log)
-
-add_executable(test_log_err test_log_err.c)
-target_link_libraries(test_log_err PRIVATE log)
-
-add_library(wrap_log_error OBJECT wrap_log_error.c)
-target_link_libraries(wrap_log_error PRIVATE log cmocka::cmocka)
-target_link_options(wrap_log_error PUBLIC "LINKER:--wrap=log_levels")
-
-add_executable(test_wrap_log_error test_wrap_log_error.c)
-target_link_libraries(test_wrap_log_error PRIVATE log cmocka::cmocka wrap_log_error)
-
-if (USE_NETLINK_SERVICE)
-  add_executable(test_nl test_nl.c)
-  target_link_libraries(test_nl PRIVATE cmocka::cmocka nl wrap_log_error)
-
-  add_test(NAME test_nl COMMAND test_nl)
-  set_tests_properties(test_nl
-    PROPERTIES
-    WILL_FAIL FALSE)
-endif()
-
-if (USE_UCI_SERVICE)
-  add_test(NAME test_uci_wrt COMMAND test_uci_wrt)
-  set_tests_properties(test_uci_wrt
-   PROPERTIES
-   WILL_FAIL FALSE)
-endif ()
-
-add_test(NAME test_ifaceu COMMAND test_ifaceu)
-set_tests_properties(test_ifaceu
- PROPERTIES
- WILL_FAIL FALSE)
-
-add_test(NAME test_net COMMAND test_net)
-set_tests_properties(test_net
- PROPERTIES
- WILL_FAIL FALSE)
-
-add_test(NAME test_os COMMAND test_os)
-set_tests_properties(test_os
-  PROPERTIES
-  WILL_FAIL FALSE)
-
-add_test(NAME test_eloop COMMAND test_eloop)
-set_tests_properties(test_eloop
-  PROPERTIES
-  WILL_FAIL FALSE)
-
-add_test(NAME test_eloop_handles_null COMMAND test_eloop_handles_null)
-set_tests_properties(test_eloop_handles_null
-  PROPERTIES
-  WILL_FAIL FALSE)
-
-add_test(NAME test_eloop_threaded COMMAND test_eloop_threaded)
+add_cmocka_test(test_eloop_threaded
+  SOURCES test_eloop_threaded.c
+  LINK_LIBRARIES eloop cmocka::cmocka sockctl LibUTHash::LibUTHash Threads::Threads
+)
 set_tests_properties(test_eloop_threaded
   PROPERTIES
   WILL_FAIL FALSE
   ENVIRONMENT CMOCKA_TEST_ABORT='1' # these tests uses threading
 )
 
-add_test(NAME test_sqliteu COMMAND test_sqliteu)
-  set_tests_properties(test_sqliteu
-    PROPERTIES
-    WILL_FAIL FALSE)
+add_cmocka_test(test_sqliteu
+  SOURCES test_sqliteu.c
+  LINK_LIBRARIES sqliteu cmocka::cmocka)
 
-add_test(NAME test_hashmap COMMAND test_hashmap)
-set_tests_properties(test_hashmap
-  PROPERTIES
-  WILL_FAIL FALSE)
+add_cmocka_test(test_hashmap
+  SOURCES test_hashmap.c
+  LINK_LIBRARIES hashmap cmocka::cmocka)
 
-add_test(NAME test_utarray COMMAND test_utarray)
-set_tests_properties(test_utarray
-  PROPERTIES
-  WILL_FAIL FALSE)
+add_cmocka_test(test_utarray
+  SOURCES test_utarray.c
+  LINK_LIBRARIES LibUTHash::LibUTHash cmocka::cmocka)
 
-add_test(NAME test_minIni COMMAND test_minIni)
-set_tests_properties(test_minIni
-  PROPERTIES
-  WILL_FAIL FALSE)
+add_cmocka_test(test_minIni
+  SOURCES test_minIni.c
+  LINK_LIBRARIES MinIni::minIni cmocka::cmocka)
 
-add_test(NAME test_squeue COMMAND test_squeue)
-set_tests_properties(test_squeue
-  PROPERTIES
-  WILL_FAIL FALSE)
+add_cmocka_test(test_squeue
+  SOURCES test_squeue.c
+  LINK_LIBRARIES squeue os cmocka::cmocka)
 
-add_test(NAME test_log_thread_safe COMMAND test_log_thread_safe)
-set_tests_properties(test_log_thread_safe
-  PROPERTIES
-  WILL_FAIL FALSE)
+add_cmocka_test(test_log_thread_safe
+  SOURCES test_log_thread_safe.c
+  LINK_LIBRARIES log Threads::Threads)
 
-add_test(NAME test_log_level COMMAND test_log_level)
+add_cmocka_test(test_log_level
+  SOURCES test_log_level.c
+  LINK_LIBRARIES log)
 set_tests_properties(test_log_level
   PROPERTIES PASS_REGULAR_EXPRESSION ".+TRACE.+Hello world;.+DEBUG.+Hello world;.+INFO.+Hello world;.+WARN.+Hello world")
 
-add_test(NAME test_log_err COMMAND test_log_err)
+add_cmocka_test(test_log_err
+  SOURCES test_log_err.c
+  LINK_LIBRARIES log)
 set_tests_properties(test_log_err
   PROPERTIES
   PASS_REGULAR_EXPRESSION ".+ERROR")
 
-add_test(NAME test_wrap_log_error COMMAND test_wrap_log_error)
-set_tests_properties(test_wrap_log_error
-  PROPERTIES
-  WILL_FAIL FALSE)
+add_library(wrap_log_error OBJECT wrap_log_error.c)
+target_link_libraries(wrap_log_error PRIVATE log cmocka::cmocka)
+target_link_options(wrap_log_error PUBLIC "LINKER:--wrap=log_levels")
+
+add_cmocka_test(test_wrap_log_error
+  SOURCES test_wrap_log_error.c
+  LINK_LIBRARIES log cmocka::cmocka wrap_log_error)
+
+if (USE_NETLINK_SERVICE)
+  add_cmocka_test(test_nl
+    SOURCES test_nl.c
+    LINK_LIBRARIES cmocka::cmocka nl wrap_log_error
+  )
+endif()


### PR DESCRIPTION
## Summary

Uses the `AddCMockaTest.cmake` script from the CMocka library to simplify building and adding tests.

Because it's only a build script (it's not a statically-linked executable), we don't need to add licensing information to the `edgesec` software under the BSD 3-Clause license.

## Commits

#### [build(cmocka): add AddCMockaTest.cmake script](https://github.com/nqminds/edgesec/commit/23da1a8b1344b1d33ef2d4063475c560a10c7ab6) 

Adds the `AddCMockaTest.cmake` helper script from https://gitlab.com/cmocka/cmocka/-/blob/a7a1ae83d567ccd6b469e157fc0a3db872039a49/cmake/Modules/AddCMockaTest.cmake

#### [docs(AddCMockaTest): add licensing info](https://github.com/nqminds/edgesec/commit/a8319cda47b6fa5ec057670be8b10d1eff23a71e) 

Add licensing and copyright information for AddCMockaTest.cmake

It uses the BSD 3-Clause license.

#### [test: use AddCMockaTest to simplify cmake files](https://github.com/nqminds/edgesec/commit/5cd467ed6ea2c0c6a774e09ade8bef3b68585402) 

Use the AddCMockaTest.cmake script to simplify the test CMake build scripts.

By default, all `LINK_LIBRARIES` are linked privately by default, since the tests are executables and are not expected to be linked to by other CMake targets.

There is a LINK_OPTIONS variable that the script uses, but confusingly,
it is not actually passed to CMake's `LINK_OPTIONS`. It's instead passed to [`LINK_FLAGS`][1]

[1]: https://cmake.org/cmake/help/latest/prop_tgt/LINK_FLAGS.html
