### PR TITLE
Add support for compiling edgesec using Ninja

### DIFF
--- a/.github/workflows/create-debs.yml
+++ b/.github/workflows/create-debs.yml
@@ -148,10 +148,13 @@ jobs:
       - name: Install Dependencies
         run: |
           sudo apt-get update
-          sudo apt-get install devscripts equivs -y # install mk-build-depends
+          sudo apt-get install devscripts equivs ninja-build -y # install mk-build-depends
           sudo mk-build-deps --install --tool='apt-get -o Debug::pkgProblemResolver=yes --no-install-recommends --yes'  debian/control
-      - name: Configure
-        run: cmake --preset recap -DCMAKE_BUILD_TYPE=Release
+      - name: Configure using Ninja
+        # Ninja is actually slightly slower than using Make, since then
+        # the ExternalProjects have to run in invidividual GNU Make sessions
+        # It's mainly here just to confirm that a Ninja build works.
+        run: cmake --preset recap -DCMAKE_BUILD_TYPE=Release -G Ninja
       - name: Build
         run: cmake --build --preset recap -j="$(($(nproc) + 1))"
       - name: Archive built recap

--- a/lib/mnl.cmake
+++ b/lib/mnl.cmake
@@ -3,6 +3,13 @@ if (BUILD_ONLY_DOCS OR NOT USE_NETLINK_SERVICE)
 elseif(BUILD_MNL_LIB)
   set(LIBMNL_INSTALL_ROOT "${CMAKE_CURRENT_BINARY_DIR}/lib/mnl")
 
+  if ("${CMAKE_GENERATOR}" MATCHES "Makefiles")
+    set(MAKE_COMMAND "$(MAKE)") # recursive make (uses the same make as the main project)
+  else()
+    # just run make in a subprocess. We use single-process, but libmnl is a small project
+    set(MAKE_COMMAND "make")
+  endif ()
+
   ExternalProject_Add(
     libmnl_src
     URL https://www.netfilter.org/pub/libmnl/libmnl-1.0.4.tar.bz2
@@ -16,8 +23,8 @@ elseif(BUILD_MNL_LIB)
       --with-pic=on
       "CC=${CMAKE_C_COMPILER}" "CXX=${CMAKE_CXX_COMPILER}"
     # need to manually specify PATH, so that make knows where to find cross-compiling GCC
-    BUILD_COMMAND ${CMAKE_COMMAND} -E env "PATH=$ENV{PATH}" $(MAKE)
-    INSTALL_COMMAND ${CMAKE_COMMAND} -E env "PATH=$ENV{PATH}" $(MAKE) install
+    BUILD_COMMAND ${CMAKE_COMMAND} -E env "PATH=$ENV{PATH}" "${MAKE_COMMAND}"
+    INSTALL_COMMAND ${CMAKE_COMMAND} -E env "PATH=$ENV{PATH}" "${MAKE_COMMAND}" install
   )
 
   ExternalProject_Get_Property(libmnl_src INSTALL_DIR)

--- a/lib/mnl.cmake
+++ b/lib/mnl.cmake
@@ -1,7 +1,7 @@
 # Compile libmnl library used for libnetlink
 if (BUILD_ONLY_DOCS OR NOT USE_NETLINK_SERVICE)
 elseif(BUILD_MNL_LIB)
-  set(LIBMNL_INSTALL_ROOT "${CMAKE_CURRENT_BINARY_DIR}/lib/mnl")
+  set(LIBMNLINSTALL_DIR "${CMAKE_CURRENT_BINARY_DIR}/lib/mnl")
 
   if ("${CMAKE_GENERATOR}" MATCHES "Makefiles")
     set(MAKE_COMMAND "$(MAKE)") # recursive make (uses the same make as the main project)
@@ -10,11 +10,17 @@ elseif(BUILD_MNL_LIB)
     set(MAKE_COMMAND "make")
   endif ()
 
+  # set these variables so that find_package(MNL REQUIRED) works
+  # when called later
+  add_library(MNL::mnl SHARED IMPORTED)
+  set(MNL_LIBRARY "${LIBMNLINSTALL_DIR}/lib/libmnl.so")
+  set(MNL_INCLUDE_DIR "${LIBMNLINSTALL_DIR}/include")
+
   ExternalProject_Add(
     libmnl_src
     URL https://www.netfilter.org/pub/libmnl/libmnl-1.0.4.tar.bz2
     URL_HASH SHA256=171f89699f286a5854b72b91d06e8f8e3683064c5901fb09d954a9ab6f551f81
-    INSTALL_DIR "${LIBMNL_INSTALL_ROOT}"
+    INSTALL_DIR "${LIBMNLINSTALL_DIR}"
     CONFIGURE_COMMAND autoreconf -f -i <SOURCE_DIR>
     COMMAND
       ${CMAKE_COMMAND} -E env "PATH=$ENV{PATH}"
@@ -25,20 +31,13 @@ elseif(BUILD_MNL_LIB)
     # need to manually specify PATH, so that make knows where to find cross-compiling GCC
     BUILD_COMMAND ${CMAKE_COMMAND} -E env "PATH=$ENV{PATH}" "${MAKE_COMMAND}"
     INSTALL_COMMAND ${CMAKE_COMMAND} -E env "PATH=$ENV{PATH}" "${MAKE_COMMAND}" install
+    # technically this is an INSTALL_BYPRODUCT, but we only ever need this to make Ninja happy
+    BUILD_BYPRODUCTS "${MNL_LIBRARY}"
   )
-
-  ExternalProject_Get_Property(libmnl_src INSTALL_DIR)
-  set(LIBMNLINSTALL_DIR "${INSTALL_DIR}")
-
-  # set these variables so that find_package(MNL REQUIRED) works
-  # when called later
-  add_library(MNL::mnl SHARED IMPORTED)
-  set(MNL_LIBRARY "${LIBMNLINSTALL_DIR}/lib/libmnl.so")
-  set(MNL_INCLUDE_DIR "${LIBMNLINSTALL_DIR}/include")
 
   file(MAKE_DIRECTORY "${MNL_INCLUDE_DIR}")
     set_target_properties(MNL::mnl PROPERTIES
-    IMPORTED_LOCATION "${LIBMNLINSTALL_DIR}/lib/libmnl.so"
+    IMPORTED_LOCATION "${MNL_LIBRARY}"
     INTERFACE_INCLUDE_DIRECTORIES "${MNL_INCLUDE_DIR}"
   )
   add_dependencies(MNL::mnl libmnl_src)

--- a/lib/openssl.cmake
+++ b/lib/openssl.cmake
@@ -45,6 +45,13 @@ if (USE_CRYPTO_SERVICE)
       no-dso no-engine no-threads no-unit-test
     )
 
+    if ("${CMAKE_GENERATOR}" MATCHES "Makefiles")
+      set(MAKE_COMMAND "$(MAKE)") # recursive make (uses the same make as the main project)
+    else()
+      # just run make in a subprocess. Will be very slow, since it's single-process.
+      set(MAKE_COMMAND "make")
+    endif ()
+
     set(LIBOPENSSL_INSTALL_ROOT "${CMAKE_CURRENT_BINARY_DIR}/lib")
     set(LIBOPENSSL_INSTALL_DIR "${LIBOPENSSL_INSTALL_ROOT}/openssl")
     ExternalProject_Add(
@@ -57,7 +64,7 @@ if (USE_CRYPTO_SERVICE)
         <SOURCE_DIR>/Configure ${OpenSSL_Configure_Args}
       LIST_SEPARATOR " " # expand ${OpenSSL_Configure_Args} to space-separated list
       # only install software, don't install or build docs
-      INSTALL_COMMAND $(MAKE) install_sw
+      INSTALL_COMMAND "${MAKE_COMMAND}" install_sw
     )
 
     set(LIBOPENSSL_INCLUDE_PATH "${LIBOPENSSL_INSTALL_DIR}/include")

--- a/lib/protobuf-c.cmake
+++ b/lib/protobuf-c.cmake
@@ -24,6 +24,14 @@ else()
     endif()
   endif()
 
+  if(BUILD_SHARED_LIBS)
+    set(LIBPROTOBUFC_LIB "${LIBPROTOBUFC_INSTALL_DIR}/lib/libprotobuf-c.so")
+    add_library(protobufc::protobufc SHARED IMPORTED)
+  else()
+    set(LIBPROTOBUFC_LIB "${LIBPROTOBUFC_INSTALL_DIR}/lib/libprotobuf-c.a")
+    add_library(protobufc::protobufc STATIC IMPORTED)
+  endif()
+
   message("Downloading and compiling our own libprotobuf-c library")
   ExternalProject_Add(
     libprotobuf-c
@@ -43,17 +51,9 @@ else()
       "-DCMAKE_C_COMPILER=${CMAKE_C_COMPILER}"
       # CMAKE_TOOLCHAIN_FILE, if it exists
       ${CMAKE_CROSSCOMPILING_ARGS}
+    # technically this is an INSTALL_BYPRODUCT, but we only ever need this to make Ninja happy
+    BUILD_BYPRODUCTS "${LIBPROTOBUFC_LIB}"
   )
-  ExternalProject_Get_Property(libprotobuf-c INSTALL_DIR)
-
-  set(LIBPROTOBUFC_INSTALL_DIR "${INSTALL_DIR}")
-  if(BUILD_SHARED_LIBS)
-    set(LIBPROTOBUFC_LIB "${LIBPROTOBUFC_INSTALL_DIR}/lib/libprotobuf-c.so")
-    add_library(protobufc::protobufc SHARED IMPORTED)
-  else()
-    set(LIBPROTOBUFC_LIB "${LIBPROTOBUFC_INSTALL_DIR}/lib/libprotobuf-c.a")
-    add_library(protobufc::protobufc STATIC IMPORTED)
-  endif()
 
   # folder might not yet exist if using ExternalProject_Add
   set(LIBPROTOBUFC_INCLUDE_DIR "${LIBPROTOBUFC_INSTALL_DIR}/include")

--- a/lib/sqlite.cmake
+++ b/lib/sqlite.cmake
@@ -26,6 +26,14 @@ else()
     set(MAKE_COMMAND "make")
   endif ()
 
+  if(BUILD_SHARED_LIBS)
+    set(LIBSQLITE_LIB "${LIBSQLITE_INSTALL_DIR}/lib/libsqlite3.so")
+    add_library(SQLite::SQLite3 SHARED IMPORTED)
+  else()
+    set(LIBSQLITE_LIB "${LIBSQLITE_INSTALL_DIR}/lib/libsqlite3.a")
+    add_library(SQLite::SQLite3 STATIC IMPORTED)
+  endif()
+
   message("Downloading and compiling our own libsqlite library")
   ExternalProject_Add(
     libsqlite
@@ -44,6 +52,8 @@ else()
     # need to manually specify PATH, so that make knows where to find cross-compiling GCC
     BUILD_COMMAND ${CMAKE_COMMAND} -E env "PATH=$ENV{PATH}" "${MAKE_COMMAND}"
     INSTALL_COMMAND ${CMAKE_COMMAND} -E env "PATH=$ENV{PATH}" "${MAKE_COMMAND}" install
+    # technically this is an INSTALL_BYPRODUCT, but we only ever need this to make Ninja happy
+    BUILD_BYPRODUCTS "${LIBSQLITE_LIB}"
   )
   ExternalProject_Get_Property(libsqlite INSTALL_DIR)
 

--- a/lib/sqlite.cmake
+++ b/lib/sqlite.cmake
@@ -19,6 +19,13 @@ else()
     set(configure_args "--enable-static" "--disable-shared")
   endif()
 
+  if ("${CMAKE_GENERATOR}" MATCHES "Makefiles")
+    set(MAKE_COMMAND "$(MAKE)") # recursive make (uses the same make as the main project)
+  else()
+    # just run make in a subprocess. We use single-process, but libmnl is a small project
+    set(MAKE_COMMAND "make")
+  endif ()
+
   message("Downloading and compiling our own libsqlite library")
   ExternalProject_Add(
     libsqlite
@@ -35,19 +42,10 @@ else()
       --with-pic=on ${configure_args}
       "CC=${CMAKE_C_COMPILER}" "CXX=${CMAKE_CXX_COMPILER}"
     # need to manually specify PATH, so that make knows where to find cross-compiling GCC
-    BUILD_COMMAND ${CMAKE_COMMAND} -E env "PATH=$ENV{PATH}" $(MAKE)
-    INSTALL_COMMAND ${CMAKE_COMMAND} -E env "PATH=$ENV{PATH}" $(MAKE) install
+    BUILD_COMMAND ${CMAKE_COMMAND} -E env "PATH=$ENV{PATH}" "${MAKE_COMMAND}"
+    INSTALL_COMMAND ${CMAKE_COMMAND} -E env "PATH=$ENV{PATH}" "${MAKE_COMMAND}" install
   )
   ExternalProject_Get_Property(libsqlite INSTALL_DIR)
-
-  set(LIBSQLITE_INSTALL_DIR "${INSTALL_DIR}")
-  if(BUILD_SHARED_LIBS)
-    set(LIBSQLITE_LIB "${LIBSQLITE_INSTALL_DIR}/lib/libsqlite3.so")
-    add_library(SQLite::SQLite3 SHARED IMPORTED)
-  else()
-    set(LIBSQLITE_LIB "${LIBSQLITE_INSTALL_DIR}/lib/libsqlite3.a")
-    add_library(SQLite::SQLite3 STATIC IMPORTED)
-  endif()
 
   set(sqlite_link_libs "pthread" "dl")
 

--- a/lib/uuid.cmake
+++ b/lib/uuid.cmake
@@ -12,6 +12,13 @@ if (BUILD_UUID_LIB AND NOT (BUILD_ONLY_DOCS))
 
   message("Will install libuuid into ${LIBUUID_INSTALL_DIR}")
 
+  if ("${CMAKE_GENERATOR}" MATCHES "Makefiles")
+    set(MAKE_COMMAND "$(MAKE)") # recursive make (uses the same make as the main project)
+  else()
+    # just run make in a subprocess. We use single-process, but libmnl is a small project
+    set(MAKE_COMMAND "make")
+  endif ()
+
   # ExternalProject downloads/builds/installs at **build** time
   # (e.g. during the `cmake --build` step)
   ExternalProject_Add(
@@ -28,8 +35,8 @@ if (BUILD_UUID_LIB AND NOT (BUILD_ONLY_DOCS))
       "CC=${CMAKE_C_COMPILER}" "CXX=${CMAKE_CXX_COMPILER}"
     INSTALL_DIR "${LIBUUID_INSTALL_DIR}"
     # need to manually specify PATH, so that make knows where to find GCC
-    BUILD_COMMAND ${CMAKE_COMMAND} -E env "PATH=$ENV{PATH}" $(MAKE)
-    INSTALL_COMMAND ${CMAKE_COMMAND} -E env "PATH=$ENV{PATH}" $(MAKE) install
+    BUILD_COMMAND ${CMAKE_COMMAND} -E env "PATH=$ENV{PATH}" "${MAKE_COMMAND}"
+    INSTALL_COMMAND ${CMAKE_COMMAND} -E env "PATH=$ENV{PATH}" "${MAKE_COMMAND}" install
   )
   ExternalProject_Get_Property(util_linux INSTALL_DIR)
 

--- a/lib/uuid.cmake
+++ b/lib/uuid.cmake
@@ -37,6 +37,8 @@ if (BUILD_UUID_LIB AND NOT (BUILD_ONLY_DOCS))
     # need to manually specify PATH, so that make knows where to find GCC
     BUILD_COMMAND ${CMAKE_COMMAND} -E env "PATH=$ENV{PATH}" "${MAKE_COMMAND}"
     INSTALL_COMMAND ${CMAKE_COMMAND} -E env "PATH=$ENV{PATH}" "${MAKE_COMMAND}" install
+    # technically this is an INSTALL_BYPRODUCT, but we only ever need this to make Ninja happy
+    BUILD_BYPRODUCTS "<INSTALL_DIR>/lib/libuuid.a"
   )
   ExternalProject_Get_Property(util_linux INSTALL_DIR)
 


### PR DESCRIPTION
Ninja is much faster than GNU Make, and is now the default CMake generator for OpenWRT, see https://github.com/openwrt/openwrt/commit/0c7c24d40aedcee25d5243e25a87d38246be128b.

This PR adds support for compiling edgesec using Ninja.

### [build: support non-makefile CMake generators](https://github.com/nqminds/edgesec/commit/ad71f799b5165503890726bbe6331956c469d715)

Currently, all of our `ExternalProjects` using `make` are using `$(MAKE)` so that their builds are run in the same `make` invocation as the main repo.

(e.g. this means things like multiprocessing get shared with all ExternalProjects).

However, this does not work when the main project is using a non-Makefile generator.

Instead, I've changed the CMake files to use `make` when not running in a Makefile generator.

Unfortunately, this change actually means that build edgesec with Ninja is **slower** than using GNU Make. This is because then the ExternalProjects have to run in individual GNU Make sessions, which I've set to run in single-process mode, while normally, they can use the shared GNU Make job server (interestingly, both CMake and OpenWRT use a fork of Ninja that does have compatibility with GNU Make job server, but it hasn't yet been upstreamed, see https://github.com/ninja-build/ninja/issues/1139)


#### Benchmarks

GNU Make

```console
alois@nqm-alois-entroware:~/Documents/edgesec (build/add-ninja-support)$ export PRESET=linux; cmake --preset "$PRESET" && time nice -n19 cmake --build --preset "$PRESET" -j=$(nproc)
...
[100%] Built target edgesec

real	0m39.455s
user	1m58.707s
sys	0m12.376s

```

Ninja

```console
alois@nqm-alois-entroware:~/Documents/edgesec (build/add-ninja-support)$ export PRESET=linux; cmake --preset "$PRESET" -G Ninja && time nice -n19 cmake --build --preset "$PRESET" -j=$(nproc)
...
[333/333] Linking C executable src/edgesec

real	1m4.380s
user	1m37.235s
sys	0m9.267s
```

### [build: support using Ninja with CMake](https://github.com/nqminds/edgesec/commit/c073ac8a78c1754df3ebe3972daf265b15e80d2d)


One of the reasons why Ninja is so fast is that underspecified build dependencies are not supported. However, these are used in edgesec.

To fix this, we need to manually declare the library files for our ExternalProject libraries, using `BUILD_BYPRODUCTS`.

Technically, all of the library files are actually generated by the ExternalProject INSTALL step, not the BUILD step, but we only need to add these rules to make Ninja happy, so it's fine.

In the future, if CMake adds an `INSTALL_BYPRODUCTS` option, we should use that instead.

See https://gitlab.kitware.com/cmake/cmake/-/issues/23056

### [ci(recap): build recap using Ninja](https://github.com/nqminds/edgesec/commit/6bd9c372bd8ea2860d5e6308e9e8e0dfd890b60e) 

Builds the Recap library using Ninja in GitHub Actions as a test case for Ninja compatibility.

This is may be slightly slower than using GNU Make, since then the ExternalProjects have to run in individual GNU Make sessions (see my comment earlier in this PR). But GitHub Actions only has 2 cores by default, so this shouldn't make too much of a difference.