### PR TITLE
fix: fix unused variable error on non-Linux OSes

### DIFF
--- a/src/dns/mcast.c
+++ b/src/dns/mcast.c
@@ -158,6 +158,9 @@ int create_recv_mcast(const struct sockaddr_storage *sa, socklen_t sa_len,
         close(fd);
         return -1;
       }
+#else
+      (void)ifindex; /* binding a socket to a specific interface is very
+                        complicated for except for Linux/Darwin */
 #endif
       break;
     case AF_INET:

--- a/src/radius/radius_server.c
+++ b/src/radius/radius_server.c
@@ -714,6 +714,8 @@ static int radius_server_disable_pmtu_discovery(int s) {
   r = setsockopt(s, IPPROTO_IP, IP_MTU_DISCOVER, &action, sizeof(action));
   if (r == -1)
     log_errno("Failed to set IP_MTU_DISCOVER:");
+#else
+  (void)s; /* this function is a no-op on non-Linux machines */
 #endif
   return r;
 }

--- a/tests/radius/radius_client.c
+++ b/tests/radius/radius_client.c
@@ -1208,6 +1208,8 @@ static int radius_client_disable_pmtu_discovery(int s) {
   r = setsockopt(s, IPPROTO_IP, IP_MTU_DISCOVER, &action, sizeof(action));
   if (r == -1)
     log_errno("RADIUS: Failed to set IP_MTU_DISCOVER");
+#else
+  (void)s; /* this function is a no-op on non-Linux machines */
 #endif
   return r;
 }


### PR DESCRIPTION
Some functions (e.g. `radius_client_disable_pmtu_discovery()`) are no-ops on platforms that are missing Linux (or Darwin) specific features.

This is normally fine, except we have `-Wunused` and `-Werror` enabled, so an error is thrown for unused varaibles.

This commit casts them to `(void)` in these cases. In the future, once we only use C23, we can use the `[[maybe_unused]]` C23 attribute, see https://en.cppreference.com/w/c/language/attributes/maybe_unused