### PR TITLE
build: enable `-Wwrite-strings` for the `src/` dir

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -1,5 +1,9 @@
-# Error on all C/C++ warnings in the src/ directory if making a Debug build
-add_compile_options($<$<CONFIG:Debug>:-Werror>)
+add_compile_options(
+  # Error on all C/C++ warnings in the src/ directory if making a Debug build
+  $<$<CONFIG:Debug>:-Werror>
+  # Warn/error if using a non-const pointer to a string literal
+  $<$<COMPILE_LANGUAGE:C>:-Wwrite-strings>
+)
 
 add_subdirectory(utils)
 add_subdirectory(supervisor)


### PR DESCRIPTION
In C, it's undefined behaviour to modify a string literal.

However, because C previously didn't have a `const` specifier, for backwards compatibility, string literals have the type `char *` not `const char *` by default.

The GNU `-Wwrite-strings` option changes string literals to have type `const char *` by default, which should make it less likely for us to modify string literals accidentally.

This is currently only enabled in the `src/` dir since it fails in the `test/` dir.