### PR TITLE
feat: Added pragma options to speedup the recap

### DIFF
--- a/src/recap.c
+++ b/src/recap.c
@@ -72,12 +72,9 @@ struct pcap_stream_context {
 };
 
 const char *pragma_options[] = {
-  "PRAGMA journal_mode = OFF",
-  "PRAGMA synchronous = 0",
-  "PRAGMA cache_size = -4000",
-  "PRAGMA locking_mode = EXCLUSIVE",
-  "PRAGMA temp_store = MEMORY"
-};
+    "PRAGMA journal_mode = OFF", "PRAGMA synchronous = 0",
+    "PRAGMA cache_size = -4000", "PRAGMA locking_mode = EXCLUSIVE",
+    "PRAGMA temp_store = MEMORY"};
 
 void show_app_version(void) {
   fprintf(stdout, "recap app version %s\n", EDGESEC_VERSION);


### PR DESCRIPTION
Added the below sqlite pragma options to speed the db recapture:
```
  PRAGMA journal_mode = OFF;
  PRAGMA synchronous = 0;
  PRAGMA cache_size = -4000;
  PRAGMA locking_mode = EXCLUSIVE;
  PRAGMA temp_store = MEMORY;
```

### Performance difference:

Seems to be about 112× faster!!!

> The speed difference is huge 16 secs compared to around 30 minute for the 400 Mb dataset.
>
> From https://github.com/nqminds/edgesec/pull/347#issuecomment-1313823525