### PR TITLE
ci(build): use ubuntu-22.04 to run CI

### DIFF
--- a/.github/workflows/create-debs.yml
+++ b/.github/workflows/create-debs.yml
@@ -27,7 +27,7 @@ jobs:
           - recap # Uses the generic IP service
     permissions:
       contents: read
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     steps:
       - name: Checkout code
         uses: actions/checkout@v2
@@ -41,13 +41,6 @@ jobs:
         if: matrix.cmake-preset == 'clang'
         run: |
           sudo apt-get install llvm -y
-          llvm-cov gcov --version
-          clang --version
-          # Very annoyingly, the Ubuntu-20.04 image uses Clang 11 by default
-          # however, the default version of LLVM that is installed is v10,
-          # which is too old for Clang 11 compatibility
-          echo 'set(CMAKE_C_COMPILER clang-10)
-          set(CMAKE_CXX_COMPILER clang++-10)' > CMakeModules/CMakeToolchains/clang.cmake
       - name: Cache CMake build/dl folder
         uses: actions/cache@v3
         with:


### PR DESCRIPTION
`ubuntu-latest` is in the process of migrating to using `ubuntu-22.04`. This means that it is effectively random whether our CI runner uses `ubuntu-20.04` or `ubuntu-22.04`, which is a problem, as due to a version mismatch in `ubuntu-20.04`'s default clang and default LLVM version, we currently manually specify clang v10.

`ubuntu-22.04` uses the same version for both clang and LLVM by default, so using that runner means we can remove our workaround. We should also get better error messages and more optimized code.