### PR TITLE
Update uthash to commit 85bf75ab7189858f97b83a90a1426a1d5420d2d6 (2022-11-07 master)

### DIFF
--- a/lib/uthash.cmake
+++ b/lib/uthash.cmake
@@ -3,11 +3,13 @@ if (BUILD_ONLY_DOCS)
 else ()
     # it's possible to find uthash on Ubuntu/Debian repos, but it's a tiny
     # download, so we might as well download it
-    set(UTHASH_VERSION 2.1.0)
+
+    # this version removes the strdup requirement for better ISO C compatibility
+    set(UTHASH_VERSION 85bf75ab7189858f97b83a90a1426a1d5420d2d6)
     FetchContent_Declare(
         uthash
-        URL "https://github.com/troydhanson/uthash/archive/refs/tags/v${UTHASH_VERSION}.tar.gz"
-        URL_HASH SHA512=c8005113a48ec7636715ecec0286a5d9086971a7267947aba9e0ad031b6113a4f38a1fb512d33d6fefb5891635fdd31169ce4d6ab04b938bda612ebbccb3eda0
+        URL "https://api.github.com/repos/troydhanson/uthash/tarball/${UTHASH_VERSION}"
+        URL_HASH SHA512=2343ea488694e3d982a20cde0a2dfe371fc4cf7873f692eaca86f4ba36ad1e082797ad2006450cc0e68c504de689c0d7c12942622e724213782c6887f671512b
         DOWNLOAD_NAME "uthash-${UTHASH_VERSION}.tar.gz"
         DOWNLOAD_DIR "${EP_DOWNLOAD_DIR}" # if empty string, uses default download dir
     )
@@ -20,7 +22,4 @@ else ()
     add_library(LibUTHash::LibUTHash INTERFACE IMPORTED)
     target_include_directories(LibUTHash::LibUTHash INTERFACE "${UTHASH_INCLUDE_DIR}")
     add_dependencies(LibUTHash::LibUTHash uthash)
-    # utarray.h requires strdup, which is a POSIX.1-2008 function
-    # (it may also be in C23)
-    target_compile_definitions(LibUTHash::LibUTHash INTERFACE _POSIX_C_SOURCE=200809L)
 endif ()

--- a/src/dhcp/dnsmasq.c
+++ b/src/dhcp/dnsmasq.c
@@ -9,6 +9,9 @@
  * utilities.
  */
 
+// needed for fileno()
+#define _POSIX_C_SOURCE 200809L
+
 #include <stdbool.h>
 #include <stdio.h>
 #include <errno.h>

--- a/src/edgesec.c
+++ b/src/edgesec.c
@@ -8,6 +8,9 @@
  * @brief File containing the edgesec tool implementations.
  */
 
+// needed for getopt()
+#define _POSIX_C_SOURCE 200809L
+
 #include <stdarg.h>
 #include <stdbool.h>
 #include <stdio.h>

--- a/src/utils/hashmap.c
+++ b/src/utils/hashmap.c
@@ -7,6 +7,8 @@
  * SPDX-License-Identifier: LGPL-3.0-or-later
  * @brief File containing the implementation of the hashmap utilities.
  */
+// needed for strnlen() and strdup()
+#define _POSIX_C_SOURCE 200809L
 
 #include <stdlib.h>
 
@@ -15,7 +17,6 @@
 // strnlen_s() is available in our <string.h> library
 #else
 // declare strnlen_s() in terms of POSIX strnlen()
-#define _POSIX_C_SOURCE 200809L
 #define strnlen_s(_string, _maxlen)                                            \
   ((_string) == NULL ? 0 : strnlen((_string), (_maxlen)))
 #endif


### PR DESCRIPTION
Use commit https://github.com/troydhanson/uthash/commit/85bf75ab7189858f97b83a90a1426a1d5420d2d6
of uthash, which contains some bug fixes, such as removing the need for `strdup`.

Since we removed `_POSIX_C_SOURCE=200809L` from `uthash`, I had to set it manually on some files that still use POSIX extension functions.