### PR TITLE
feat: Added cheribsd preset

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -158,7 +158,7 @@ else()
   # only use standard C and opt-in to non-standard includes
   set(CMAKE_C_EXTENSIONS OFF)
 endif()
-set(CMAKE_C_FLAGS "-Wunused-variable -Wall -Wextra")
+set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -Wunused-variable -Wall -Wextra")
 
 set(CMAKE_CXX_STANDARD 11)
 set(CMAKE_CXX_STANDARD_REQUIRED ON)

--- a/CMakePresets.json
+++ b/CMakePresets.json
@@ -41,6 +41,24 @@
       }
     },
     {
+      "name": "cheribsd",
+      "inherits": "default",
+      "description": "CheriBSD build (alpha)",
+      "toolchainFile": "${sourceDir}/CMakeModules/CMakeToolchains/cheri.cmake",
+      "cacheVariables": {
+        "BUILD_MNL_LIB": false,
+        "BUILD_NETLINK_LIB": false,
+        "USE_NETLINK_SERVICE": false,
+        "USE_UCI_SERVICE": false,
+        "USE_GENERIC_IP_SERVICE": true,
+        "USE_RADIUS_SERVICE": true,
+        "BUILD_HOSTAPD": false,
+        "USE_CRYPTO_SERVICE": false,
+        "BUILD_OPENSSL_LIB": false,
+        "BUILD_CMOCKA_LIB": true
+      }
+    },
+    {
       "name": "linux",
       "inherits": "default",
       "displayName": "Linux",
@@ -253,6 +271,10 @@
       "configurePreset": "freebsd"
     },
     {
+      "name": "cheribsd",
+      "configurePreset": "cheribsd"
+    },
+    {
       "name": "linux/header",
       "configurePreset": "linux/header"
     },
@@ -337,6 +359,10 @@
     {
       "name": "freebsd",
       "configurePreset": "freebsd"
+    },
+    {
+      "name": "cheribsd",
+      "configurePreset": "cheribsd"
     },
     {
       "name": "openwrt",


### PR DESCRIPTION
Adds a new `cheribsd` preset with a different set of C flags specific for Cheri architecture in purecap mode.