### PR TITLE
build(cmake): allow adjusting target triplet

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -137,6 +137,12 @@ if (CMAKE_CROSSCOMPILING)
   message("Cross-compiling, setting cross-compiling autoconf/pkg-config vars")
   message("Build (autoconf --build) autoconf triple is ${build_autoconf_triple}")
   message("Target (autoconf --host) autoconf triple is ${TRIPLET}")
+  if (target_autoconf_triple STREQUAL "")
+    message(WARNING
+      "edgesec is configured for cross-compiling, but could not detect a valid TRIPLET value."
+      " This may cause issues when cross-compiling sqlite/other libs.")
+  endif()
+
   # tell PKG_CONFIG (required by hostap) to search correct folders when cross-compiling
   set(ENV{PKG_CONFIG_LIBDIR} "/usr/lib/${CMAKE_LIBRARY_ARCHITECTURE}/pkgconfig:/usr/share/pkgconfig")
   message("Setting cross-compiling PKG_CONFIG_LIBDIR to $ENV{PKG_CONFIG_LIBDIR}")

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -107,6 +107,8 @@ option(CONFIGURE_COVERAGE "Configure for code coverage (requires lcov)" OFF)
 #     (e.g. OpenWRT SDK or default `pdebuild` environment)
 set(EP_DOWNLOAD_DIR "" CACHE PATH "ExternalProject default DOWNLOAD_DIR")
 
+set(TRIPLET "${CMAKE_LIBRARY_ARCHITECTURE}" CACHE STRING "Target triplet to use for autoconf (e.g. output of `cc -dumpmachine`)")
+
 # Set a default build type if none was specified
 if(NOT CMAKE_BUILD_TYPE AND NOT CMAKE_CONFIGURATION_TYPES)
   message(STATUS "Setting build type to 'Debug' as none was specified.")
@@ -129,12 +131,12 @@ endfunction(get_autoconf_os)
 
 get_autoconf_os(${CMAKE_HOST_SYSTEM_NAME} build_autoconf_os)
 string(TOLOWER "${CMAKE_HOST_SYSTEM_PROCESSOR}-${build_autoconf_os}" build_autoconf_triple)
-set(target_autoconf_triple "${CMAKE_LIBRARY_ARCHITECTURE}")
+set(target_autoconf_triple "${TRIPLET}")
 
 if (CMAKE_CROSSCOMPILING)
   message("Cross-compiling, setting cross-compiling autoconf/pkg-config vars")
   message("Build (autoconf --build) autoconf triple is ${build_autoconf_triple}")
-  message("Target (autoconf --host) autoconf triple is ${CMAKE_LIBRARY_ARCHITECTURE}")
+  message("Target (autoconf --host) autoconf triple is ${TRIPLET}")
   # tell PKG_CONFIG (required by hostap) to search correct folders when cross-compiling
   set(ENV{PKG_CONFIG_LIBDIR} "/usr/lib/${CMAKE_LIBRARY_ARCHITECTURE}/pkgconfig:/usr/share/pkgconfig")
   message("Setting cross-compiling PKG_CONFIG_LIBDIR to $ENV{PKG_CONFIG_LIBDIR}")

--- a/lib/mnl.cmake
+++ b/lib/mnl.cmake
@@ -25,7 +25,7 @@ elseif(BUILD_MNL_LIB)
     CONFIGURE_COMMAND autoreconf -f -i <SOURCE_DIR>
     COMMAND
       ${CMAKE_COMMAND} -E env "PATH=$ENV{PATH}"
-      <SOURCE_DIR>/configure --prefix=<INSTALL_DIR> "--host=${CMAKE_LIBRARY_ARCHITECTURE}"
+      <SOURCE_DIR>/configure --prefix=<INSTALL_DIR> "--host=${target_autoconf_triple}"
       # use position independent code, even for static lib, in case we want to make shared lib later
       --with-pic=on
       "CC=${CMAKE_C_COMPILER}" "CXX=${CMAKE_CXX_COMPILER}"

--- a/lib/sqlite.cmake
+++ b/lib/sqlite.cmake
@@ -46,7 +46,7 @@ else()
     CONFIGURE_COMMAND autoreconf -f -i <SOURCE_DIR>
     COMMAND
       ${CMAKE_COMMAND} -E env "PATH=$ENV{PATH}"
-      <SOURCE_DIR>/configure --prefix=<INSTALL_DIR> "--host=${CMAKE_LIBRARY_ARCHITECTURE}"
+      <SOURCE_DIR>/configure --prefix=<INSTALL_DIR> "--host=${target_autoconf_triple}"
       # use position independent code, even for static lib, in case we want to make shared lib later
       --with-pic=on ${configure_args}
       "CC=${CMAKE_C_COMPILER}" "CXX=${CMAKE_CXX_COMPILER}"


### PR DESCRIPTION
Allow modifying the `autoconf --host` target triplet without modifying CMAKE_LIBRARY_ARCHITECTURE.

CMAKE_LIBRARY_ARCHITECTURE is used on systems that store their libraries in /usr/lib/CMAKE_LIBRARY_ARCHITECTURE/...

(e.g. Ubuntu uses /usr/lib/x86_64-linux-gnu).

Systems like FreeBSD do not have use this, but we would still like to set a custom TRIPLET to target specific hosts when cross-compiling.