### PR TITLE
Fix `-Wformat-security` errors

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -3,6 +3,7 @@ add_compile_options(
   $<$<CONFIG:Debug>:-Werror>
   # Warn/error if using a non-const pointer to a string literal
   $<$<COMPILE_LANGUAGE:C>:-Wwrite-strings>
+  $<$<COMPILE_LANGUAGE:C>:-Wformat-security> # required by debian builds
 )
 
 add_subdirectory(utils)

--- a/src/sqlhook.c
+++ b/src/sqlhook.c
@@ -151,7 +151,8 @@ __declspec(dllexport)
     return rc;
   }
 
-  strncpy(sock_path, env_key_value, MAX_OS_PATH_LEN);
+  strncpy(sock_path, env_key_value, MAX_OS_PATH_LEN - 1);
+  sock_path[MAX_OS_PATH_LEN - 1] = '\0';
 
   if ((domain_fd = create_domain_client(NULL)) < 0) {
     return rc;

--- a/tests/dhcp/test_dnsmasq.c
+++ b/tests/dhcp/test_dnsmasq.c
@@ -155,6 +155,9 @@ static void test_define_dhcp_interface_name(void **state) {
     char ifname[IFNAMSIZ] = {0};
     assert_return_code(define_dhcp_interface_name(&dconf, vlanid, ifname), 0);
     assert_string_equal(ifname, "abcdefghij.512");
+
+    // should return -1 if vlanid is over 4 digits in decimal
+    assert_int_equal(define_dhcp_interface_name(&dconf, 12345, ifname), -1);
   }
 #endif
 }


### PR DESCRIPTION
Debian builds compile with `-Wformat-security` enabled.

This PR enables this flag, and fixes those errors.

See <https://gcc.gnu.org/onlinedocs/gcc/Warning-Options.html> for docs.

This caught a potential truncation bug in `dnsmasq.c` and a potential buffer overflow in `sqlhook.c`