### PR TITLE
ci(build): update `actions/checkout` to v3

### DIFF
--- a/.github/workflows/create-debs.yml
+++ b/.github/workflows/create-debs.yml
@@ -30,7 +30,7 @@ jobs:
     runs-on: ubuntu-22.04
     steps:
       - name: Checkout code
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
       - name: Install Dependencies
         shell: bash # we're using bash arrays here
         run: |
@@ -216,7 +216,7 @@ jobs:
         deb [arch=arm64] http://ports.ubuntu.com/ubuntu-ports ${{ matrix.distribution }} main universe | deb [arch=amd64] http://archive.ubuntu.com/ubuntu ${{ matrix.distribution }} main universe
     steps:
       - name: Checkout code
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
       - name: Create pbuilder cache dir
         # The actions/cache action does not have permissions to create the pbuilder
         # cache folder if it doesn't exist


### PR DESCRIPTION
Updates the `actions/checkout` to version 3.

Version 3 uses Node.JS v16 instead of v12, but this is fine, since we run our code on the official GitHub Actions runners, which have both versions of Node.JS pre-installed.

I'm surprised dependabot didn't make a PR for this (maybe we don't have it enabled for GitHub Actions in this repo?)