### PR TITLE
fix(os): check chdir return code in become_daemon

### DIFF
--- a/src/utils/os.c
+++ b/src/utils/os.c
@@ -76,7 +76,9 @@ int become_daemon(int flags) {
 
   /* Change to root directory */
   if (!(flags & BD_NO_CHDIR)) {
-    chdir("/");
+    if (chdir("/") == -1) {
+      return -1;
+    }
   }
 
   /* Close all open files */


### PR DESCRIPTION
Check the return code for `chdir("/")` in the function `become_daemon().`

There's a bunch of error cases for `chdir`, which we should never run into, but it's worth checking anyway (plus sometimes the compiler throws a warning/error if you don't check the return code).

See https://man7.org/linux/man-pages/man2/fchdir.2.html#ERRORS