### PR TITLE
build(tests): disable LTO for tests

### DIFF
--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -1,6 +1,12 @@
 # Error on all C/C++ warnings in the tests/ directory if making a Debug build
 add_compile_options($<$<CONFIG:Debug>:-Werror>)
 
+# Link time optimization has some issues with linker `--wrap` (mocking) arg
+# See https://gcc.gnu.org/bugzilla/show_bug.cgi?id=88643 and
+# https://sourceware.org/bugzilla/show_bug.cgi?id=24415
+set(CMAKE_INTERPROCEDURAL_OPTIMIZATION OFF)
+string(REPLACE "-flto=auto" "" CMAKE_C_FLAGS "${CMAKE_C_FLAGS}") # might be set by debian build
+
 include_directories (
   "${PROJECT_SOURCE_DIR}/src"
 )


### PR DESCRIPTION
Link time optimization (LTO) seems to be causing some issues when doing `-Wl,--wrap` (e.g. link-time mocking).

See https://gcc.gnu.org/bugzilla/show_bug.cgi?id=88643 and https://sourceware.org/bugzilla/show_bug.cgi?id=24415 for the bug reports.

Fixes a ``undefined reference to `log_levels'`` when compiling `wrap_log_levels` in the debian build (which uses `-flto=auto`).