### PR TITLE
build(cmake): use add_compile_options not C_FLAGS

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -166,7 +166,11 @@ else()
   # only use standard C and opt-in to non-standard includes
   set(CMAKE_C_EXTENSIONS OFF)
 endif()
-set(CMAKE_C_FLAGS "-Wunused-variable -Wall -Wextra")
+add_compile_options(
+  $<$<COMPILE_LANGUAGE:C>:-Wunused-variable>
+  $<$<COMPILE_LANGUAGE:C>:-Wall>
+  $<$<COMPILE_LANGUAGE:C>:-Wextra>
+)
 
 set(CMAKE_CXX_STANDARD 11)
 set(CMAKE_CXX_STANDARD_REQUIRED ON)


### PR DESCRIPTION
CMake does not recommend modifying `CMAKE_C_FLAGS` directly if we can help it. Instead, we should be using `add_compile_options()`.

This also means that we no longer overwrite `CMAKE_C_FLAGS`, which will mean that `edgesec` works better with other build systems (e.g. pdebuild).

Depends on #360 and #363 (since we no longer overwrite `CMAKE_C_FLAGS`, some of the debian build's C_FLAGS cause errors that need to be fixed).