### PR TITLE
build(debian): use uuid-dev dependency

### DIFF
--- a/debian/control
+++ b/debian/control
@@ -15,7 +15,8 @@ Build-Depends: debhelper-compat (= 12),
     libminini-dev (>=1.2),
     libsqlite3-dev (>=3.31.1),
     libpcap0.8-dev (>=1.9.1),
-    libmnl-dev (>= 1.0.4)
+    libmnl-dev (>= 1.0.4),
+    uuid-dev (>= 2.34)
 Standards-Version: 4.5.0
 Homepage: https://github.com/nqminds/EDGESec
 Vcs-Browser: https://github.com/nqminds/EDGESec

--- a/debian/rules
+++ b/debian/rules
@@ -23,6 +23,7 @@ override_dh_auto_configure:
 		 -DBUILD_PCAP_LIB=OFF\
 		 -DBUILD_LIB_MININI=OFF\
 		 -DBUILD_HOSTAPD=ON\
+		 -DBUILD_UUID_LIB=OFF\
 		 -DBUILD_PROTOBUFC_LIB=OFF
 
 # make sure to always install into `debian/tmp` and use


### PR DESCRIPTION
Add build dependency on `uuid-dev (>= 2.34)`.

See https://packages.ubuntu.com/focal/uuid-dev

This should automatically turn into a runtime depedency for libuuid1.

This means that we can set `DBUILD_UUID_LIB=OFF` to disable building and bundling libuuid.