### PR TITLE
Fix cross-compiling libs using autotools with cheribuild

### DIFF
--- a/lib/mnl.cmake
+++ b/lib/mnl.cmake
@@ -28,7 +28,7 @@ elseif(BUILD_MNL_LIB)
       <SOURCE_DIR>/configure --prefix=<INSTALL_DIR> "--host=${target_autoconf_triple}"
       # use position independent code, even for static lib, in case we want to make shared lib later
       --with-pic=on
-      "CC=${CMAKE_C_COMPILER}"
+      "CC=${CMAKE_C_COMPILER}" "CFLAGS=${CMAKE_C_FLAGS}"
     # need to manually specify PATH, so that make knows where to find cross-compiling GCC
     BUILD_COMMAND ${CMAKE_COMMAND} -E env "PATH=$ENV{PATH}" "${MAKE_COMMAND}"
     INSTALL_COMMAND ${CMAKE_COMMAND} -E env "PATH=$ENV{PATH}" "${MAKE_COMMAND}" install

--- a/lib/mnl.cmake
+++ b/lib/mnl.cmake
@@ -28,7 +28,7 @@ elseif(BUILD_MNL_LIB)
       <SOURCE_DIR>/configure --prefix=<INSTALL_DIR> "--host=${target_autoconf_triple}"
       # use position independent code, even for static lib, in case we want to make shared lib later
       --with-pic=on
-      "CC=${CMAKE_C_COMPILER}" "CFLAGS=${CMAKE_C_FLAGS}"
+      "CC=${CMAKE_C_COMPILER}" "CFLAGS=${CMAKE_C_FLAGS}" "LDFLAGS=${CMAKE_SHARED_LINKER_FLAGS}"
     # need to manually specify PATH, so that make knows where to find cross-compiling GCC
     BUILD_COMMAND ${CMAKE_COMMAND} -E env "PATH=$ENV{PATH}" "${MAKE_COMMAND}"
     INSTALL_COMMAND ${CMAKE_COMMAND} -E env "PATH=$ENV{PATH}" "${MAKE_COMMAND}" install

--- a/lib/mnl.cmake
+++ b/lib/mnl.cmake
@@ -28,7 +28,7 @@ elseif(BUILD_MNL_LIB)
       <SOURCE_DIR>/configure --prefix=<INSTALL_DIR> "--host=${target_autoconf_triple}"
       # use position independent code, even for static lib, in case we want to make shared lib later
       --with-pic=on
-      "CC=${CMAKE_C_COMPILER}" "CXX=${CMAKE_CXX_COMPILER}"
+      "CC=${CMAKE_C_COMPILER}"
     # need to manually specify PATH, so that make knows where to find cross-compiling GCC
     BUILD_COMMAND ${CMAKE_COMMAND} -E env "PATH=$ENV{PATH}" "${MAKE_COMMAND}"
     INSTALL_COMMAND ${CMAKE_COMMAND} -E env "PATH=$ENV{PATH}" "${MAKE_COMMAND}" install

--- a/lib/sqlite.cmake
+++ b/lib/sqlite.cmake
@@ -49,7 +49,7 @@ else()
       <SOURCE_DIR>/configure --prefix=<INSTALL_DIR> "--host=${target_autoconf_triple}"
       # use position independent code, even for static lib, in case we want to make shared lib later
       --with-pic=on ${configure_args}
-      "CC=${CMAKE_C_COMPILER}" "CXX=${CMAKE_CXX_COMPILER}"
+      "CC=${CMAKE_C_COMPILER}"
     # need to manually specify PATH, so that make knows where to find cross-compiling GCC
     BUILD_COMMAND ${CMAKE_COMMAND} -E env "PATH=$ENV{PATH}" "${MAKE_COMMAND}"
     INSTALL_COMMAND ${CMAKE_COMMAND} -E env "PATH=$ENV{PATH}" "${MAKE_COMMAND}" install

--- a/lib/sqlite.cmake
+++ b/lib/sqlite.cmake
@@ -49,7 +49,7 @@ else()
       <SOURCE_DIR>/configure --prefix=<INSTALL_DIR> "--host=${target_autoconf_triple}"
       # use position independent code, even for static lib, in case we want to make shared lib later
       --with-pic=on ${configure_args}
-      "CC=${CMAKE_C_COMPILER}" "CFLAGS=${CMAKE_C_FLAGS}"
+      "CC=${CMAKE_C_COMPILER}" "CFLAGS=${CMAKE_C_FLAGS}" "LDFLAGS=${CMAKE_SHARED_LINKER_FLAGS}"
     # need to manually specify PATH, so that make knows where to find cross-compiling GCC
     BUILD_COMMAND ${CMAKE_COMMAND} -E env "PATH=$ENV{PATH}" "${MAKE_COMMAND}"
     INSTALL_COMMAND ${CMAKE_COMMAND} -E env "PATH=$ENV{PATH}" "${MAKE_COMMAND}" install

--- a/lib/sqlite.cmake
+++ b/lib/sqlite.cmake
@@ -49,7 +49,7 @@ else()
       <SOURCE_DIR>/configure --prefix=<INSTALL_DIR> "--host=${target_autoconf_triple}"
       # use position independent code, even for static lib, in case we want to make shared lib later
       --with-pic=on ${configure_args}
-      "CC=${CMAKE_C_COMPILER}"
+      "CC=${CMAKE_C_COMPILER}" "CFLAGS=${CMAKE_C_FLAGS}"
     # need to manually specify PATH, so that make knows where to find cross-compiling GCC
     BUILD_COMMAND ${CMAKE_COMMAND} -E env "PATH=$ENV{PATH}" "${MAKE_COMMAND}"
     INSTALL_COMMAND ${CMAKE_COMMAND} -E env "PATH=$ENV{PATH}" "${MAKE_COMMAND}" install

--- a/lib/uuid.cmake
+++ b/lib/uuid.cmake
@@ -35,7 +35,7 @@ if (BUILD_UUID_LIB AND NOT (BUILD_ONLY_DOCS))
       --prefix=<INSTALL_DIR>
       "--host=${target_autoconf_triple}"
       --disable-all-programs --enable-libuuid
-      "CC=${CMAKE_C_COMPILER}"
+      "CC=${CMAKE_C_COMPILER}" "CFLAGS=${CMAKE_C_FLAGS}"
     INSTALL_DIR "${LIBUUID_INSTALL_DIR}"
     # need to manually specify PATH, so that make knows where to find GCC
     BUILD_COMMAND ${CMAKE_COMMAND} -E env "PATH=$ENV{PATH}" "${MAKE_COMMAND}"

--- a/lib/uuid.cmake
+++ b/lib/uuid.cmake
@@ -35,7 +35,7 @@ if (BUILD_UUID_LIB AND NOT (BUILD_ONLY_DOCS))
       --prefix=<INSTALL_DIR>
       "--host=${target_autoconf_triple}"
       --disable-all-programs --enable-libuuid
-      "CC=${CMAKE_C_COMPILER}" "CFLAGS=${CMAKE_C_FLAGS}"
+      "CC=${CMAKE_C_COMPILER}" "CFLAGS=${CMAKE_C_FLAGS}" "LDFLAGS=${CMAKE_SHARED_LINKER_FLAGS}"
     INSTALL_DIR "${LIBUUID_INSTALL_DIR}"
     # need to manually specify PATH, so that make knows where to find GCC
     BUILD_COMMAND ${CMAKE_COMMAND} -E env "PATH=$ENV{PATH}" "${MAKE_COMMAND}"

--- a/lib/uuid.cmake
+++ b/lib/uuid.cmake
@@ -19,6 +19,18 @@ if (BUILD_UUID_LIB AND NOT (BUILD_ONLY_DOCS))
     set(MAKE_COMMAND "make")
   endif ()
 
+  # util-unix uses SOLIB_LDFLAGS as libtool flags for linking
+  set(SOLIB_LDFLAGS "${CMAKE_SHARED_LINKER_FLAGS}")
+  if (CMAKE_CROSSCOMPILING AND "${CMAKE_C_COMPILER_ID}" MATCHES "Clang")
+    # util-linux links with libtool
+    # unfortunately, libtool ignores the `-target=...` parameter in it's flags,
+    # which breaks cross-compiling for CheriBSD using cheribuild.
+    # We can specify `-XCClinker` to force libtool to pass the value to the
+    # underlying clang linker command.
+    list(APPEND SOLIB_LDFLAGS "-XCClinker --target=${target_autoconf_triple}")
+  endif()
+  list(JOIN SOLIB_LDFLAGS " " SOLIB_LDFLAGS)
+
   set(UTIL_LINUX_VERSION 2.37.2)
   # ExternalProject downloads/builds/installs at **build** time
   # (e.g. during the `cmake --build` step)
@@ -36,6 +48,7 @@ if (BUILD_UUID_LIB AND NOT (BUILD_ONLY_DOCS))
       "--host=${target_autoconf_triple}"
       --disable-all-programs --enable-libuuid
       "CC=${CMAKE_C_COMPILER}" "CFLAGS=${CMAKE_C_FLAGS}" "LDFLAGS=${CMAKE_SHARED_LINKER_FLAGS}"
+      "SOLIB_LDFLAGS=${SOLIB_LDFLAGS}" # util-linux uses a custom ldflags for linking
     INSTALL_DIR "${LIBUUID_INSTALL_DIR}"
     # need to manually specify PATH, so that make knows where to find GCC
     BUILD_COMMAND ${CMAKE_COMMAND} -E env "PATH=$ENV{PATH}" "${MAKE_COMMAND}"

--- a/lib/uuid.cmake
+++ b/lib/uuid.cmake
@@ -35,7 +35,7 @@ if (BUILD_UUID_LIB AND NOT (BUILD_ONLY_DOCS))
       --prefix=<INSTALL_DIR>
       "--host=${target_autoconf_triple}"
       --disable-all-programs --enable-libuuid
-      "CC=${CMAKE_C_COMPILER}" "CXX=${CMAKE_CXX_COMPILER}"
+      "CC=${CMAKE_C_COMPILER}"
     INSTALL_DIR "${LIBUUID_INSTALL_DIR}"
     # need to manually specify PATH, so that make knows where to find GCC
     BUILD_COMMAND ${CMAKE_COMMAND} -E env "PATH=$ENV{PATH}" "${MAKE_COMMAND}"


### PR DESCRIPTION
Improves the flags passed to autotools (used by libuuid, libmnl, libsqlite) to get edgesec compiled using [cheribuild](https://github.com/CTSRD-CHERI/cheribuild).

To do this, we need to pass `CFLAGS` (C compiler flags) and `LDFLAGS` (linker flags).

Additionally, `util-linux` uses [`SOLIB_LDFLAGS`](https://github.com/util-linux/util-linux/blob/5099e004b486e7c4f7153abc9843f49c1593fe66/configure.ac#L2721-L2722) to control linking for libraries.

However, these flags are first passed through [`libtool`](https://www.gnu.org/software/libtool). This causes issues when linking for ARM Morello PureCap on CheriBSD using cheribuild, as `libtool` clobbers the `-target aarch64-unknown-freebsd13` parameter.

Instead, we need to prepend the `-target aarch64-unknown-freebsd13` with `-XCClinker`, as that tells libtool to:

> Pass a link-specific flag to the compiler driver (CC) during linking

See https://www.gnu.org/software/libtool/manual/libtool.html#Link-mode