### PR TITLE
Compile edgesec `src/` dir with `-Wpedantic` and fix errors

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -3,6 +3,7 @@ add_compile_options(
   $<$<CONFIG:Debug>:-Werror>
   # Warn/error if using a non-const pointer to a string literal
   $<$<COMPILE_LANGUAGE:C>:-Wwrite-strings>
+  $<$<COMPILE_LANGUAGE:C>:-Wpedantic>
   $<$<COMPILE_LANGUAGE:C>:-Wformat-security> # required by debian builds
 )
 

--- a/src/ap/ap_service.h
+++ b/src/ap/ap_service.h
@@ -42,17 +42,28 @@
 #define DENYACL_DEL_COMMAND                                                    \
   "DENY_ACL DEL_MAC" /* Command name to remove a station from the deny ACL */
 
+/** Type of callback for AP service in run_ap()*/
+typedef void (*ap_service_fn)(struct supervisor_context *context,
+                              uint8_t mac_addr[],
+                              enum AP_CONNECTION_STATUS status);
+
+/** Structure containing @p ap_callback_fn callback pointer for run_ap() */
+struct run_ap_callback_fn_struct {
+  /** The callback for the AP service. */
+  ap_service_fn ap_service_fn;
+};
+
 /**
  * @brief Runs the AP service
  *
  * @param context The supervisor context structure
  * @param exec_ap Flag to execute/signal the AP process
  * @param generate_ssid Flag to generate the SSID for AP
- * @param ap_callback_fn The callback for AP service
+ * @param[in] ap_callback_fn A stuct containing the callback for AP service
  * @return int 0 on success, -1 on failure
  */
 int run_ap(struct supervisor_context *context, bool exec_ap, bool generate_ssid,
-           void *ap_callback_fn);
+           struct run_ap_callback_fn_struct *ap_callback_fn);
 
 /**
  * @brief Closes (terminates) AP process

--- a/src/capture/CMakeLists.txt
+++ b/src/capture/CMakeLists.txt
@@ -103,7 +103,7 @@ if (USE_CAPTURE_SERVICE)
     # C array initialiser for capture middleware
     # e.g. `middleware1, middleware2`
     list(JOIN arg_CAPTURE_MIDDLEWARES ", " _CAPTURE_MIDDLEWARES_LIST_INITIALISER)
-
+    list(LENGTH arg_CAPTURE_MIDDLEWARES _CAPTURE_MIDDLEWARES_COUNT)
     set(_CAPTURE_MIDDLEWARES_DEFINITIONS "extern struct capture_middleware ${_CAPTURE_MIDDLEWARES_LIST_INITIALISER};")
 
     configure_file(

--- a/src/capture/middlewares/header_middleware/dns_decoder.c
+++ b/src/capture/middlewares/header_middleware/dns_decoder.c
@@ -36,15 +36,15 @@ void decode_dns_questions(uint8_t *payload, struct capture_packet *cpac) {
 }
 
 bool decode_dns_packet(struct capture_packet *cpac) {
-  int payload_offset = 0;
+  ptrdiff_t payload_offset = 0;
 
-  if ((void *)cpac->tcph != NULL && (void *)cpac->udph == NULL) {
+  if (cpac->tcph != NULL && cpac->udph == NULL) {
     cpac->dnsh =
-        (struct dns_header *)((void *)cpac->tcph + sizeof(struct tcphdr));
+        (struct dns_header *)((char *)cpac->tcph + sizeof(struct tcphdr));
     payload_offset = 2;
-  } else if ((void *)cpac->tcph == NULL && (void *)cpac->udph != NULL) {
+  } else if (cpac->tcph == NULL && cpac->udph != NULL) {
     cpac->dnsh =
-        (struct dns_header *)((void *)cpac->udph + sizeof(struct udphdr));
+        (struct dns_header *)((char *)cpac->udph + sizeof(struct udphdr));
     payload_offset = 0;
   } else
     return false;
@@ -58,11 +58,11 @@ bool decode_dns_packet(struct capture_packet *cpac) {
   cpac->dnss.nauth = ntohs(cpac->dnsh->nauth);
   cpac->dnss.nother = ntohs(cpac->dnsh->nother);
 
-  int pos = (int)((void *)cpac->dnsh - (void *)cpac->ethh);
+  ptrdiff_t pos = ((char *)cpac->dnsh - (char *)cpac->ethh);
   // We consider only the UDP encapsulation
   if (pos + payload_offset + sizeof(struct dns_header) <= cpac->length &&
       !payload_offset) {
-    void *payload = (void *)cpac->dnsh + sizeof(struct dns_header);
+    void *payload = (char *)cpac->dnsh + sizeof(struct dns_header);
     if (cpac->dnss.nqueries)
       decode_dns_questions((uint8_t *)payload, cpac);
   }

--- a/src/capture/middlewares/header_middleware/dns_decoder.c
+++ b/src/capture/middlewares/header_middleware/dns_decoder.c
@@ -36,9 +36,7 @@ void decode_dns_questions(uint8_t *payload, struct capture_packet *cpac) {
 }
 
 bool decode_dns_packet(struct capture_packet *cpac) {
-  void *payload;
   int payload_offset = 0;
-  int pos = 0;
 
   if ((void *)cpac->tcph != NULL && (void *)cpac->udph == NULL) {
     cpac->dnsh =
@@ -60,11 +58,11 @@ bool decode_dns_packet(struct capture_packet *cpac) {
   cpac->dnss.nauth = ntohs(cpac->dnsh->nauth);
   cpac->dnss.nother = ntohs(cpac->dnsh->nother);
 
-  pos = (int)((void *)cpac->dnsh - (void *)cpac->ethh);
+  int pos = (int)((void *)cpac->dnsh - (void *)cpac->ethh);
   // We consider only the UDP encapsulation
   if (pos + payload_offset + sizeof(struct dns_header) <= cpac->length &&
       !payload_offset) {
-    payload = (void *)cpac->dnsh + sizeof(struct dns_header);
+    void *payload = (void *)cpac->dnsh + sizeof(struct dns_header);
     if (cpac->dnss.nqueries)
       decode_dns_questions((uint8_t *)payload, cpac);
   }

--- a/src/capture/middlewares/header_middleware/mdns_decoder.c
+++ b/src/capture/middlewares/header_middleware/mdns_decoder.c
@@ -207,9 +207,9 @@ bool decode_mdns_packet(struct capture_packet *cpac) {
   // char *qname = NULL;
   // size_t first;
 
-  if ((void *)cpac->udph != NULL) {
+  if (cpac->udph != NULL) {
     cpac->mdnsh =
-        (struct mdns_header *)((void *)cpac->udph + sizeof(struct udphdr));
+        (struct mdns_header *)((char *)cpac->udph + sizeof(struct udphdr));
   } else
     return false;
 

--- a/src/capture/middlewares/header_middleware/packet_decoder.c
+++ b/src/capture/middlewares/header_middleware/packet_decoder.c
@@ -52,9 +52,9 @@
 #define MAX_PACKET_TYPES 10
 
 bool decode_dhcp_packet(struct capture_packet *cpac) {
-  if ((void *)cpac->udph != NULL) {
+  if (cpac->udph != NULL) {
     cpac->dhcph =
-        (struct dhcp_header *)((void *)cpac->udph + sizeof(struct udphdr));
+        (struct dhcp_header *)((char *)cpac->udph + sizeof(struct udphdr));
   } else
     return false;
 
@@ -77,10 +77,10 @@ bool decode_dhcp_packet(struct capture_packet *cpac) {
 }
 
 bool decode_udp_packet(struct capture_packet *cpac) {
-  if ((void *)cpac->ip4h != NULL && (void *)cpac->ip6h == NULL)
-    cpac->udph = (struct udphdr *)((void *)cpac->ip4h + sizeof(struct ip));
-  else if ((void *)cpac->ip4h == NULL && (void *)cpac->ip6h != NULL)
-    cpac->udph = (struct udphdr *)((void *)cpac->ip6h + sizeof(struct ip6_hdr));
+  if (cpac->ip4h != NULL && cpac->ip6h == NULL)
+    cpac->udph = (struct udphdr *)((char *)cpac->ip4h + sizeof(struct ip));
+  else if (cpac->ip4h == NULL && cpac->ip6h != NULL)
+    cpac->udph = (struct udphdr *)((char *)cpac->ip6h + sizeof(struct ip6_hdr));
   else
     return false;
 
@@ -97,10 +97,10 @@ bool decode_udp_packet(struct capture_packet *cpac) {
 }
 
 bool decode_tcp_packet(struct capture_packet *cpac) {
-  if ((void *)cpac->ip4h != NULL && (void *)cpac->ip6h == NULL)
-    cpac->tcph = (struct tcphdr *)((void *)cpac->ip4h + sizeof(struct ip));
-  else if ((void *)cpac->ip4h == NULL && (void *)cpac->ip6h != NULL)
-    cpac->tcph = (struct tcphdr *)((void *)cpac->ip6h + sizeof(struct ip6_hdr));
+  if (cpac->ip4h != NULL && cpac->ip6h == NULL)
+    cpac->tcph = (struct tcphdr *)((char *)cpac->ip4h + sizeof(struct ip));
+  else if (cpac->ip4h == NULL && cpac->ip6h != NULL)
+    cpac->tcph = (struct tcphdr *)((char *)cpac->ip6h + sizeof(struct ip6_hdr));
   else
     return false;
 
@@ -128,7 +128,7 @@ bool decode_tcp_packet(struct capture_packet *cpac) {
 
 bool decode_icmp4_packet(struct capture_packet *cpac) {
   // don't use icmphdr, it's non-standard and not supported on FreeBSD
-  cpac->icmp4h = (struct icmp *)((void *)cpac->ip4h + sizeof(struct ip));
+  cpac->icmp4h = (struct icmp *)((char *)cpac->ip4h + sizeof(struct ip));
 
   strcpy(cpac->icmp4s.id, cpac->id);
 
@@ -144,7 +144,7 @@ bool decode_icmp4_packet(struct capture_packet *cpac) {
 
 bool decode_icmp6_packet(struct capture_packet *cpac) {
   cpac->icmp6h =
-      (struct icmp6_hdr *)((void *)cpac->ip6h + sizeof(struct ip6_hdr));
+      (struct icmp6_hdr *)((char *)cpac->ip6h + sizeof(struct ip6_hdr));
 
   strcpy(cpac->icmp6s.id, cpac->id);
 
@@ -166,7 +166,7 @@ bool decode_ip4_packet(struct capture_packet *cpac) {
     return false;
   }
 
-  cpac->ip4h = (struct ip *)((void *)cpac->ethh + sizeof(struct ether_header));
+  cpac->ip4h = (struct ip *)((char *)cpac->ethh + sizeof(struct ether_header));
 
   strcpy(cpac->ip4s.id, cpac->id);
 
@@ -196,7 +196,7 @@ bool decode_ip6_packet(struct capture_packet *cpac) {
   }
 
   cpac->ip6h =
-      (struct ip6_hdr *)((void *)cpac->ethh + sizeof(struct ether_header));
+      (struct ip6_hdr *)((char *)cpac->ethh + sizeof(struct ether_header));
 
   // Wrong IP6 version
   if (((cpac->ip6h)->ip6_vfc & IPV6_VERSION_MASK) != IPV6_VERSION) {
@@ -221,7 +221,7 @@ bool decode_ip6_packet(struct capture_packet *cpac) {
 
 bool decode_arp_packet(struct capture_packet *cpac) {
   cpac->arph =
-      (struct ether_arp *)((void *)cpac->ethh + sizeof(struct ether_header));
+      (struct ether_arp *)((char *)cpac->ethh + sizeof(struct ether_header));
 
   strcpy(cpac->arps.id, cpac->id);
 

--- a/src/capture/middlewares_list.c.in
+++ b/src/capture/middlewares_list.c.in
@@ -2,15 +2,11 @@
 #include "middlewares_list.h"
 
 #cmakedefine _CAPTURE_MIDDLEWARES_DEFINITIONS @_CAPTURE_MIDDLEWARES_DEFINITIONS@
+#cmakedefine _CAPTURE_MIDDLEWARES_COUNT @_CAPTURE_MIDDLEWARES_COUNT@
 #cmakedefine _CAPTURE_MIDDLEWARES_LIST_INITIALISER @_CAPTURE_MIDDLEWARES_LIST_INITIALISER@
 
 #ifdef _CAPTURE_MIDDLEWARES_DEFINITIONS
 _CAPTURE_MIDDLEWARES_DEFINITIONS
-#endif
-
-#ifndef _CAPTURE_MIDDLEWARES_LIST_INITIALISER
-// if this not defined, set it nothing, a.k.a. empty list
-#define _CAPTURE_MIDDLEWARES_LIST_INITIALISER
 #endif
 
 UT_array *assign_middlewares(void) {
@@ -18,9 +14,15 @@ UT_array *assign_middlewares(void) {
 
   utarray_new(handlers, &middleware_icd);
 
+#if _CAPTURE_MIDDLEWARES_COUNT
   struct capture_middleware const capture_middlewares[] = {_CAPTURE_MIDDLEWARES_LIST_INITIALISER};
 
   const size_t middleware_lengths = sizeof(capture_middlewares) / sizeof(capture_middlewares[0]);
+#else
+  // if _CAPTURE_MIDDLEWARES_COUNT is 0, empty lists are illegal, so use a NULL ptr instead
+  struct capture_middleware const * capture_middlewares = NULL;
+  const size_t middleware_lengths = 0;
+#endif
 
   for (size_t i = 0; i < middleware_lengths; i++) {
     struct middleware_handlers handler = {

--- a/src/radius/radius_server.c
+++ b/src/radius/radius_server.c
@@ -770,7 +770,7 @@ void radius_server_free_clients(struct radius_server_data *data,
 }
 
 struct radius_client *init_radius_client(struct radius_conf *conf,
-                                         void *mac_conn_fn,
+                                         mac_conn_fn mac_conn_fn,
                                          void *mac_conn_arg) {
   struct radius_client *entry;
   struct in_addr addr;

--- a/src/radius/radius_server.h
+++ b/src/radius/radius_server.h
@@ -146,7 +146,8 @@ void radius_server_deinit(struct radius_server_data *data);
 int radius_server_get_mib(struct radius_server_data *data, char *buf,
                           size_t buflen);
 struct radius_client *init_radius_client(struct radius_conf *conf,
-                                         void *mac_conn_fn, void *mac_conn_arg);
+                                         mac_conn_fn mac_conn_fn,
+                                         void *mac_conn_arg);
 void radius_server_free_clients(struct radius_server_data *data,
                                 struct radius_client *clients);
 #endif /* RADIUS_SERVER_H */

--- a/src/radius/radius_service.c
+++ b/src/radius/radius_service.c
@@ -23,7 +23,7 @@
 
 struct radius_server_data *run_radius(struct eloop_data *eloop,
                                       struct radius_conf *rconf,
-                                      void *radius_callback_fn,
+                                      mac_conn_fn radius_callback_fn,
                                       void *radius_callback_args) {
   struct radius_client *client =
       init_radius_client(rconf, radius_callback_fn, radius_callback_args);

--- a/src/radius/radius_service.h
+++ b/src/radius/radius_service.h
@@ -27,7 +27,7 @@
  */
 struct radius_server_data *run_radius(struct eloop_data *eloop,
                                       struct radius_conf *rconf,
-                                      void *radius_callback_fn,
+                                      mac_conn_fn radius_callback_fn,
                                       void *radius_callback_args);
 
 /**

--- a/src/runctl.c
+++ b/src/runctl.c
@@ -489,6 +489,11 @@ int run_ctl(struct app_config *app_config, struct eloop_data *eloop) {
     }
   }
 
+  // callback for run_ap()
+  struct run_ap_callback_fn_struct run_ap_callback_fn_struct = {
+      .ap_service_fn = ap_service_callback,
+  };
+
   if (strlen(context->hconfig.interface)) {
     log_info("Running the AP service on %s ...", context->hconfig.interface);
 
@@ -500,7 +505,7 @@ int run_ctl(struct app_config *app_config, struct eloop_data *eloop) {
     }
 
     if (run_ap(context, app_config->exec_ap, app_config->generate_ssid,
-               ap_service_callback) < 0) {
+               &run_ap_callback_fn_struct) < 0) {
       log_error("run_ap fail");
       goto run_engine_fail;
     }

--- a/src/runctl.c
+++ b/src/runctl.c
@@ -512,8 +512,7 @@ int run_ctl(struct app_config *app_config, struct eloop_data *eloop) {
              context->rconfig.radius_port, context->rconfig.radius_client_ip);
 
     if ((context->radius_srv = run_radius(context->eloop, &context->rconfig,
-                                          (void *)get_mac_conn_cmd, context)) ==
-        NULL) {
+                                          get_mac_conn_cmd, context)) == NULL) {
       log_error("run_radius fail");
       goto run_engine_fail;
     }

--- a/src/utils/CMakeLists.txt
+++ b/src/utils/CMakeLists.txt
@@ -42,6 +42,12 @@ if (USE_NETLINK_SERVICE)
   # IFF_UP is a BSD definition, strnlen is a POSIX.1-2008 function
   target_compile_definitions(nl PRIVATE _DEFAULT_SOURCE _BSD_SOURCE)
 
+  # nl include linux/netlink, which includes some 0-length arrays, which are invalid
+  # in ISO C
+  get_target_property(nl_COMPILE_OPTIONS nl COMPILE_OPTIONS)
+  list(REMOVE_ITEM nl_COMPILE_OPTIONS "$<$<COMPILE_LANGUAGE:C>:-Wpedantic>")
+  set_property(TARGET nl PROPERTY COMPILE_OPTIONS ${nl_COMPILE_OPTIONS})
+
   target_link_libraries(iface PUBLIC nl)
 elseif (USE_UCI_SERVICE)
   add_library(uci_wrt uci_wrt.c)


### PR DESCRIPTION
Compile with the `-Wpedandtic` flag in the edgesec `src/` directory.

`-Wpedandtic` checks for a lot more C errors that are often allowed by the GCC/Clang compilers, but are technically incorrect in ISO C.

However, it's worth enabling, as since we are compiling for CheriBSD, we want to follow standard C as much as possible.

We need to disable the `-Wpedandtic` flag when compiling `nl`, however. This is because `nl` includes `linux/netlink`, which includes some 0-length arrays, which are invalid in ISO C.

### Issues fixed

##### [fix(middlewares_list): fix invalid ISO C syntax](https://github.com/nqminds/edgesec/commit/dace5eee7fd76a43cc4a8ef828b989c580418249) 

In ISO C < C23, using an empty initializer list is illegal.
Instead, we can just make a pointer that points to NULL.

##### [refactor(dns_decoder): fix pointer types](https://github.com/nqminds/edgesec/commit/a14198ff724c40abaea07c690af5374bbfc6fda6) 

In ISO C, doing pointer arthemtic with a `(void *)` pointer is
undefined. If we instead switch to a `(char *)`, it's all fine!

I've also used ptrdiff_t and size_t when appropriate, instead of
basic `int` types.

##### [refactor(packet_decoder): fix pointer types](https://github.com/nqminds/edgesec/pull/370/commits/ec4893b6242c07edc58e9730ae2ab06c3dc2a470) 

In ISO C, doing pointer arthemtic with a `(void *)` pointer is
undefined.

##### [refactor(mdns_decoder): fix pointer types](https://github.com/nqminds/edgesec/pull/370/commits/0aa02878242141a7d02698bf9304502f2812dbbd) 

In ISO C, doing pointer arthemtic with a `(void *)` pointer is
undefined.

##### [refactor(radius): fix mac_conn_fn type](https://github.com/nqminds/edgesec/pull/370/commits/154b071ab3b34c766e8cce4b3420b407cd9f0897) 

In ISO C, casting from a function pointer to a void pointer is
undefined. Some platforms (e.g. z/OS or MS-DOS) have different sized
pointers for functions and data.

##### [refactor(ap_service): fix run_ap callback type](https://github.com/nqminds/edgesec/pull/370/commits/9e411ed3d799fa6986b5dc2ac1aa459453f90239)

In ISO C, casting from a function pointer to a void pointer is
undefined. Some platforms (e.g. z/OS or MS-DOS) have different sized
pointers for functions and data.

To get around this, we can instead pass run_ap() a pointer to a
struct that has a pointer to a function.

**This commit had the most changes, but they're still pretty minor**.