### PR TITLE
Compile with `-Wfloat-equal` and `-Wnull-dereference`

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -6,6 +6,7 @@ add_compile_options(
   $<$<COMPILE_LANGUAGE:C>:-Wpedantic>
   $<$<COMPILE_LANGUAGE:C>:-Wformat-security> # required by debian builds
   $<$<COMPILE_LANGUAGE:C>:-Wfloat-equal> # warn/error if checking for equality between floats
+  $<$<COMPILE_LANGUAGE:C>:-Wnull-dereference> # warn if dereferencing NULL
 )
 
 add_subdirectory(utils)

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -5,6 +5,7 @@ add_compile_options(
   $<$<COMPILE_LANGUAGE:C>:-Wwrite-strings>
   $<$<COMPILE_LANGUAGE:C>:-Wpedantic>
   $<$<COMPILE_LANGUAGE:C>:-Wformat-security> # required by debian builds
+  $<$<COMPILE_LANGUAGE:C>:-Wfloat-equal> # warn/error if checking for equality between floats
 )
 
 add_subdirectory(utils)


### PR DESCRIPTION
Enables two more compiler warnings in an attempt to find and fix issues in edgesec.

Unfortunately, (or fortunately), these warnings didn't find any issues in our code, but at least we've got them enabled now, so they won't be added in the future!

### [build(src): compile with -Wfloat-equal](https://github.com/nqminds/edgesec/commit/744fbf50148e05f0e60234377b22234eebcd847a) 

Warn/error if checking for equality between floats.

This is because with floating point numbers, `0.1 + 0.1 + 0.1 != 0.3` (try it in Node.JS)

### [build(src): compile with -Wnull-dereference](https://github.com/nqminds/edgesec/commit/520cf5faa670db636d575bf2a340eebc18e67b00) 

Compile the edgesec src/ directory with `-Wnull-dereference`.

This warns if the compiler detects that you are attempting to
derefence NULL.

(otherwise, this is undefined behaviour, and the compiler may do some
crazy optimziations that breaks your program)