### PR TITLE
test: fix casting ints to pointers

### DIFF
--- a/tests/dhcp/test_dhcp_service.c
+++ b/tests/dhcp/test_dhcp_service.c
@@ -41,7 +41,7 @@ char *__wrap_run_dhcp_process(char *dhcp_bin_path, char *dhcp_conf_path) {
   (void)dhcp_bin_path;
   (void)dhcp_conf_path;
 
-  return mock_type(char *);
+  return mock_ptr_type(char *);
 }
 
 bool __wrap_kill_dhcp_process(void) { return true; }

--- a/tests/dns/test_mdns_service.c
+++ b/tests/dns/test_mdns_service.c
@@ -50,7 +50,7 @@ int __wrap_eloop_register_read_sock(struct eloop_data *eloop, int sock,
 }
 
 struct eloop_data *__wrap_eloop_init(void) {
-  return mock_type(struct eloop_data *);
+  return mock_ptr_type(struct eloop_data *);
 }
 
 void __wrap_eloop_free(struct eloop_data *eloop) { os_free(eloop); }

--- a/tests/test_runctl.c
+++ b/tests/test_runctl.c
@@ -72,7 +72,7 @@ int __wrap_fw_set_ip_forward(void) { return 0; }
 char *__wrap_iface_get_vlan(char *buf) {
   (void)buf;
 
-  return (char *)mock();
+  return mock_ptr_type(char *);
 }
 struct fwctx *__wrap_fw_init_context(hmap_if_conn *if_mapper,
                                      hmap_vlan_conn *vlan_mapper,
@@ -89,7 +89,7 @@ struct fwctx *__wrap_fw_init_context(hmap_if_conn *if_mapper,
   (void)exec_firewall;
   (void)path;
 
-  return (struct fwctx *)mock();
+  return mock_ptr_type(struct fwctx *);
 }
 
 int __wrap_run_supervisor(char *server_path,
@@ -119,7 +119,7 @@ struct radius_server_data *__wrap_run_radius(struct eloop_data *eloop,
   (void)radius_callback_fn;
   (void)radius_callback_args;
 
-  return (struct radius_server_data *)mock();
+  return mock_ptr_type(struct radius_server_data *);
 }
 #endif
 


### PR DESCRIPTION
For some our tests, in order to create some fake values, we were casting integers to pointers, which Cheri LLVM does not like.

Instead, we can use `mock_ptr_type()` to return a pointer type directly.

See: https://api.cmocka.org/group__cmocka__mock.html#gac267dacf70a0f82aa1521b01a1c98238