### PR TITLE
Optimize the `os_zalloc` and `os_calloc` functions by using `calloc`

### DIFF
--- a/src/utils/allocs.c
+++ b/src/utils/allocs.c
@@ -18,12 +18,7 @@
 
 #include "allocs.h"
 
-void *os_zalloc(size_t size) {
-  void *n = os_malloc(size);
-  if (n != NULL)
-    os_memset(n, 0, size);
-  return n;
-}
+void *os_zalloc(size_t size) { return os_calloc(size, 1); }
 
 void *os_memdup(const void *src, size_t len) {
   void *r = os_malloc(len);

--- a/src/utils/allocs.h
+++ b/src/utils/allocs.h
@@ -29,25 +29,6 @@
  */
 void *os_zalloc(size_t size);
 
-/**
- * @brief Allocate and zero memory for an array
- *
- * This function can be used as a wrapper for os_zalloc(nmemb * size) when an
- * allocation is used for an array. The main benefit over os_zalloc() is in
- * having an extra check to catch integer overflows in multiplication.
- *
- * Caller is responsible for freeing the returned buffer with os_free().
- *
- * @param nmemb Number of members in the array
- * @param size Number of bytes in each member
- * @return void* Pointer to allocated and zeroed memory or %NULL on failure
- */
-static inline void *os_calloc(size_t nmemb, size_t size) {
-  if (size && nmemb > (~(size_t)0) / size)
-    return NULL;
-  return os_zalloc(nmemb * size);
-}
-
 // void *os_malloc(size_t size);
 // void os_free(void* ptr);
 


### PR DESCRIPTION
Instead of using our own implementation of calloc, we should use the C standard library version of [`calloc`](https://en.cppreference.com/w/c/memory/calloc).

This is because it will likely be faster, as instead of manually zero-ing memory in edgesec, the OS can just return pre-zeroed memory for us. See https://blogs.fau.de/hager/archives/825 for an example.

Additionally, by default, Linux uses overcommits memory using copy-on-write for memory allocation.

E.g., if you do `calloc(1, 2**40); // 1 GiB)`, Linux/MMU will allocate all 1 GiB of the memory to a single 4 KiB zero-ed page. Linux will then create a new memory page whenever you modify a page (so by default, `calloc(1, 2**40);` will use up 1 GiB of virtual RAM, and no physical RAM).

Physical RAM will only be used for any pages that you actually modify.