### PR TITLE
Fix invalid function prototype

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -7,6 +7,7 @@ add_compile_options(
   $<$<COMPILE_LANGUAGE:C>:-Wformat-security> # required by debian builds
   $<$<COMPILE_LANGUAGE:C>:-Wfloat-equal> # warn/error if checking for equality between floats
   $<$<COMPILE_LANGUAGE:C>:-Wnull-dereference> # warn if dereferencing NULL
+  $<$<COMPILE_LANGUAGE:C>:-Wstrict-prototypes> # warn if creating a function without specifiying args
 )
 
 add_subdirectory(utils)

--- a/src/utils/sockctl.c
+++ b/src/utils/sockctl.c
@@ -50,7 +50,7 @@ void init_domain_addr(struct sockaddr_un *unaddr, const char *addr) {
  * @post Please delete the temporary folder,
  * e.g. by using cleanup_tmp_domain_socket_path()
  */
-static const char *create_tmp_domain_socket_path() {
+static const char *create_tmp_domain_socket_path(void) {
   char socket_dir[] = TMP_UNIX_SOCK_FOLDER_TEMPLATE;
   if (make_dirs_to_path(socket_dir, 0755)) {
     log_errno("Failed to make_dirs_to_path(%s, 0755)", socket_dir);


### PR DESCRIPTION
Compile with `-Wstrict-prototypes` enabled.

This flag warns if creating a function in C without specifying params.

For example:

```c
// error: very dangerous, unspecified params
void my_function();

// correct! no params
void my_function(void);
```