### PR TITLE
refactor(capture_service): use `=` not `memcpy`

### DIFF
--- a/src/capture/capture_service.c
+++ b/src/capture/capture_service.c
@@ -170,7 +170,7 @@ int run_capture_thread(char *ifname, struct capture_conf const *config,
   }
 
   os_strlcpy(context->ifname, ifname, IF_NAMESIZE);
-  os_memcpy(&context->config, config, sizeof(struct capture_conf));
+  context->config = *config;
 
   log_info("Running the capture thread");
   if (pthread_create(id, NULL, capture_thread, (void *)context) != 0) {


### PR DESCRIPTION
Using `=` should be at least as fast as memcpy, or even faster, when copying from one struct to another struct.

The main differences are:

1. assignment can ignore padding bytes
2. On CHERI architectures, when copying pointers, you must use load/store to keep capability metadata.
  CHERI may do this automatically for `memcpy`, but there is a higher chance of success when using assignment, see https://github.com/CTSRD-CHERI/llvm-project/wiki/Unaligned-capability-copies