### PR TITLE
fix(log): fix `errno` overflow

### DIFF
--- a/src/utils/log.h
+++ b/src/utils/log.h
@@ -88,6 +88,6 @@ void log_error_exit_proc(uint8_t level, const char *file, uint32_t line,
                          const char *format, ...);
 
 void printf_encode(char *txt, size_t maxlen, const uint8_t *data, size_t len);
-int printf_hex(char *buf, size_t buf_size, const uint8_t *data, size_t len,
-               int uppercase);
+size_t printf_hex(char *buf, size_t buf_size, const uint8_t *data, size_t len,
+                  int uppercase);
 #endif


### PR DESCRIPTION
Fix `-Wconversion` warnings in the log library.

This fixes a potential bug when `errno` was above 255.

For example, QNX uses 256 for `EISCONN`, which would currently overflow in our current code.