### PR TITLE
ci(cirrus): cache EP_DOWNLOAD_DIR folder

### DIFF
--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -4,6 +4,13 @@ task:
     matrix:
       - image_family: freebsd-14-0-snap
       # - image_family: freebsd-13-1 # currently not working
+  cmake_dependencies_cache:
+    # cache CMake dependencies
+    folder: ./build/dl
+    fingerprint_script:
+      - echo $CIRRUS_OS
+      # lib/*.cmake files contains the dependencies that we use
+      - cat lib/*.cmake
   install_script: |
     # autoconf/automake/pkgconf is required by sqlite
     # bison/libtool/gettext is required by util-linux (uuid library)


### PR DESCRIPTION
Cache the `build/dl` folder (aka the `EP_DOWNLOAD_DIR`), on Cirrus CI. This should speed up our CI, and prevent us from wasting open-source project's bandwidth.

See https://cirrus-ci.org/guide/writing-tasks/#cache-instruction