### PR TITLE
perf(os): improve performance of os_strlcpy (300% speed increase!)

### DIFF
--- a/src/utils/os.c
+++ b/src/utils/os.c
@@ -191,27 +191,18 @@ int hexstr2bin(const char *hex, uint8_t *buf, size_t len) {
   return 0;
 }
 
-size_t os_strlcpy(char *dest, const char *src, size_t siz) {
-  const char *s = src;
-  size_t left = siz;
+size_t os_strlcpy(char *restrict dest, const char *restrict src, size_t siz) {
+  /* Copy string up to the maximum size of the dest buffer */
+  const char *char_after_NUL = memccpy(dest, src, '\0', siz);
 
-  if (left) {
-    /* Copy string up to the maximum size of the dest buffer */
-    while (--left != 0) {
-      if ((*dest++ = *s++) == '\0')
-        break;
-    }
-  }
-
-  if (left == 0) {
+  if (char_after_NUL != NULL) {
+    return (size_t)(char_after_NUL - dest - 1);
+  } else {
     /* Not enough room for the string; force NUL-termination */
-    if (siz != 0)
-      *dest = '\0';
-    while (*s++)
-      ; /* determine total src string length */
+    dest[siz - 1] = '\0';
+    /* determine total src string length */
+    return strlen(src);
   }
-
-  return s - src - 1;
 }
 
 int os_memcmp_const(const void *a, const void *b, size_t len) {

--- a/src/utils/os.h
+++ b/src/utils/os.h
@@ -225,7 +225,7 @@ bool is_number(const char *ptr);
  * @return size_t Total length of the target string (length of src) (not
  * including NUL-termination)
  */
-size_t os_strlcpy(char *dest, const char *src, size_t siz);
+size_t os_strlcpy(char *restrict dest, const char *restrict src, size_t siz);
 
 /**
  * @brief Returns the size of string with a give max length


### PR DESCRIPTION
Implement `os_strlcpy` in terms of `memccpy()` and `strlen()`.

For most C libraries, `memccpy()` and `strlen()` are well optimized,
e.g. glibc uses AVX2 SIMD instructions, see https://sourceware.org/git/?p=glibc.git;a=blob;f=sysdeps/x86_64/multiarch/strlen-avx2.S;h=b9b58ef599c19d2b13f9ff27c8af4bfbffecb735;hb=f049f52dfeed8129c11ab1641a815705d09ff7e8

I did a quick test doing `os_strlcpy(buffer, "my test "string");` 1'000'000'000 times and the old implementation took ~20 seconds, the new implementation takes ~5 seconds (4x speedup).

This change also fixes the `-Wconversion` warning thrown by both GCC and Clang.