### PR TITLE
ci(dependabot): setup GitHub Actions dependabot

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,8 @@
+# Please see the documentation for all configuration options:
+# https://docs.github.com/github/administering-a-repository/configuration-options-for-dependency-updates
+version: 2
+updates:
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "weekly"


### PR DESCRIPTION
Setup @dependabot to automatically update GitHub Actions dependencies.

A bunch of our GitHub actions workflows are using very out-dated workflows that are deprecated and will soon be removed/broken. Instead of updating them all manually, we can let a robot do it for us!