### PR TITLE
docs(README): improve one-liner for build/test

### DIFF
--- a/README.md
+++ b/README.md
@@ -53,12 +53,12 @@ cmake --build --preset linux -j4 # build edgesec for Linux using 4 threads
 ctest --preset linux # test edgesec for Linux
 ```
 
-A useful one-liner is the following, which given a preset, automatically
+A useful one-liner (i.e. for `git rebase`) is the following, which given a preset, automatically
 configures, compiles (using all cores, but `nice -n19` for lower CPU priority),
 tests (if a test config exists), then installs into the `./tmp` folder.
 
 ```bash
-export PRESET=linux; cmake --preset "$PRESET" && nice -n19 cmake --build --preset "$PRESET" -j=$(nproc) && ( ctest --list-presets | grep "\"$PRESET\"" ) && ctest --preset "$PRESET"; cmake --install "./build/$PRESET" --prefix "./tmp/$PRESET"
+export PRESET=linux && cmake --preset "$PRESET" && nice -n19 cmake --build --preset "$PRESET" -j=$(nproc) && { if ctest --list-presets | grep "\"$PRESET\""; then ctest --preset "$PRESET" --output-on-failure; fi } && cmake --install "./build/$PRESET" --prefix "./tmp/$PRESET"
 ```
 
 For older versions of CMake, or for manual configuration, please see the next headings for more details.


### PR DESCRIPTION
Improves the one-liner in the README.md that can be used to
  - configure
  - build
  - test (if present)
  - install (to `./tmp`)

Changes made:
  - Add `--output-on-failure` to `ctest` command to print output on test failure.
  - Move everything into one command.
  - Fails the line if any of the subcommands fail. Currently, the `cmake --install` command still runs, even if the `ctest` command fails, which is a bit confusing since it hides the error messages.

---

Side-note @mereacre, I find this command really useful when doing `git rebase`, since you can do `git rebase --exec 'my_command_here'` and `git` will automatically run that command after every commit! https://git-scm.com/docs/git-rebase#Documentation/git-rebase.txt---execltcmdgt