### PR TITLE
refactor(eloop): add `edgesec_` prefix to funcs

### DIFF
--- a/lib/eloop.cmake
+++ b/lib/eloop.cmake
@@ -1,14 +1,19 @@
 if (NOT (BUILD_ONLY_DOCS))
     include(FetchContent)
 
-    # To generate or modify these patch files, do:
-    # cd "${eloop_download_SOURCE_DIR}"
-    # git init
-    # git add . && git commit -m "initial commit"
-    # git am ~/edgesec/lib/eloop/patches/*.patch
+    # To generate or modify these patch files, do the following to recreate
+    # the hostapd code in a git repo:
+    #
+    #     cd "${eloop_download_SOURCE_DIR}"
+    #     git init
+    #     git add . && git commit -m "initial commit"
+    #     git am ~/edgesec/lib/eloop/patches/*.patch
+    #
+    # To make this easier, you can use https://github.com/nqminds/hostap/tree/edgesec
+    # which may already has these patches applied.
     #
     # Then you can use `git rebase` to modify your git history.
-    # When done, do `git format-patch <FIRST_COMMID_ID>` to remake the patches
+    # When done, do `git format-patch hostap_2_10` to remake the patches
     file(GLOB eloop_patches CONFIGURE_DEPENDS "${CMAKE_CURRENT_SOURCE_DIR}/lib/eloop/patches/*.patch")
 
     function(cat IN_FILE OUT_FILE)

--- a/lib/eloop/patches/0001-Replace-eloop-logging-with-edgesec-logs.patch
+++ b/lib/eloop/patches/0001-Replace-eloop-logging-with-edgesec-logs.patch
@@ -1,7 +1,7 @@
-From 90507aa857a7d9703788f67fe000fd18cbda5035 Mon Sep 17 00:00:00 2001
+From 5460b966705ead1b350d43fef51e2a8e21877a8e Mon Sep 17 00:00:00 2001
 From: Alois Klink <alois@nquiringminds.com>
 Date: Tue, 6 Sep 2022 18:24:27 +0100
-Subject: [PATCH 1/3] Replace eloop logging with edgesec logs
+Subject: [PATCH 1/4] Replace eloop logging with edgesec logs
 
 ---
  src/utils/eloop.c | 51 ++++++++++++++++++++++-------------------------
@@ -9,7 +9,7 @@ Subject: [PATCH 1/3] Replace eloop logging with edgesec logs
  2 files changed, 26 insertions(+), 27 deletions(-)
 
 diff --git a/src/utils/eloop.c b/src/utils/eloop.c
-index 00b0bef..66e05d1 100644
+index 00b0beff0..66e05d1ba 100644
 --- a/src/utils/eloop.c
 +++ b/src/utils/eloop.c
 @@ -6,13 +6,20 @@
@@ -173,7 +173,7 @@ index 00b0bef..66e05d1 100644
  			   sec, usec, timeout->eloop_data, timeout->user_data,
  			   timeout->handler);
 diff --git a/src/utils/eloop.h b/src/utils/eloop.h
-index 04ee6d1..6241beb 100644
+index 04ee6d183..6241beb5f 100644
 --- a/src/utils/eloop.h
 +++ b/src/utils/eloop.h
 @@ -22,6 +22,8 @@
@@ -186,5 +186,5 @@ index 04ee6d1..6241beb 100644
   * eloop_event_type - eloop socket event type for eloop_register_sock()
   * @EVENT_TYPE_READ: Socket has data available for reading
 -- 
-2.25.1
+2.34.1
 

--- a/lib/eloop/patches/0001-Replace-eloop-logging-with-edgesec-logs.patch
+++ b/lib/eloop/patches/0001-Replace-eloop-logging-with-edgesec-logs.patch
@@ -1,7 +1,7 @@
 From 5460b966705ead1b350d43fef51e2a8e21877a8e Mon Sep 17 00:00:00 2001
 From: Alois Klink <alois@nquiringminds.com>
 Date: Tue, 6 Sep 2022 18:24:27 +0100
-Subject: [PATCH 1/4] Replace eloop logging with edgesec logs
+Subject: [PATCH 1/5] Replace eloop logging with edgesec logs
 
 ---
  src/utils/eloop.c | 51 ++++++++++++++++++++++-------------------------

--- a/lib/eloop/patches/0002-Allow-multiple-eloops-to-run-at-same-time.patch
+++ b/lib/eloop/patches/0002-Allow-multiple-eloops-to-run-at-same-time.patch
@@ -1,7 +1,7 @@
 From cfd320e14f72a8dbd6c86897fcb31599379889dc Mon Sep 17 00:00:00 2001
 From: Alois Klink <alois@nquiringminds.com>
 Date: Tue, 6 Sep 2022 18:28:04 +0100
-Subject: [PATCH 2/4] Allow multiple eloops to run at same time
+Subject: [PATCH 2/5] Allow multiple eloops to run at same time
 
 Passes the `eloop_data eloop` variable as a parameter to all
 eloop functions, instead of using a static/shared eloop variable.

--- a/lib/eloop/patches/0002-Allow-multiple-eloops-to-run-at-same-time.patch
+++ b/lib/eloop/patches/0002-Allow-multiple-eloops-to-run-at-same-time.patch
@@ -1,7 +1,7 @@
-From f03a7d46df0966fc764c7fa97130cebedb95ed7c Mon Sep 17 00:00:00 2001
+From cfd320e14f72a8dbd6c86897fcb31599379889dc Mon Sep 17 00:00:00 2001
 From: Alois Klink <alois@nquiringminds.com>
 Date: Tue, 6 Sep 2022 18:28:04 +0100
-Subject: [PATCH 2/3] Allow multiple eloops to run at same time
+Subject: [PATCH 2/4] Allow multiple eloops to run at same time
 
 Passes the `eloop_data eloop` variable as a parameter to all
 eloop functions, instead of using a static/shared eloop variable.
@@ -17,7 +17,7 @@ https://github.com/nqminds/edgesec/commit/09d9bed9d31496d62da44d37aef37cec97ff5b
  2 files changed, 414 insertions(+), 486 deletions(-)
 
 diff --git a/src/utils/eloop.c b/src/utils/eloop.c
-index 66e05d1..4035a9a 100644
+index 66e05d1ba..4035a9af3 100644
 --- a/src/utils/eloop.c
 +++ b/src/utils/eloop.c
 @@ -10,118 +10,15 @@
@@ -1168,7 +1168,7 @@ index 66e05d1..4035a9a 100644
  
  
 diff --git a/src/utils/eloop.h b/src/utils/eloop.h
-index 6241beb..d38e2a9 100644
+index 6241beb5f..d38e2a98d 100644
 --- a/src/utils/eloop.h
 +++ b/src/utils/eloop.h
 @@ -22,6 +22,8 @@
@@ -1605,5 +1605,5 @@ index 6241beb..d38e2a9 100644
   *
   * Do a blocking wait for a single read socket.
 -- 
-2.25.1
+2.34.1
 

--- a/lib/eloop/patches/0003-Bump-timeout-parameters-from-int-to-long.patch
+++ b/lib/eloop/patches/0003-Bump-timeout-parameters-from-int-to-long.patch
@@ -1,7 +1,7 @@
-From 03270444add875925fef1e2cb97647f45a394d30 Mon Sep 17 00:00:00 2001
+From 2987c02110ef3c80d05944c894ef81985f36aa00 Mon Sep 17 00:00:00 2001
 From: Alois Klink <alois@nquiringminds.com>
 Date: Tue, 6 Sep 2022 18:34:47 +0100
-Subject: [PATCH 3/3] Bump timeout parameters from int to long
+Subject: [PATCH 3/4] Bump timeout parameters from int to long
 
 I'm not 100% sure why this was done.
 I'm guessing that on some platforms, the max int value is only
@@ -15,7 +15,7 @@ https://github.com/nqminds/edgesec/commit/00d465d8705fa439b52a513541dc03c1f4231e
  2 files changed, 9 insertions(+), 9 deletions(-)
 
 diff --git a/src/utils/eloop.c b/src/utils/eloop.c
-index 4035a9a..d1affd2 100644
+index 4035a9af3..d1affd29f 100644
 --- a/src/utils/eloop.c
 +++ b/src/utils/eloop.c
 @@ -694,7 +694,7 @@ void eloop_unregister_sock(struct eloop_data *eloop, int sock, eloop_event_type
@@ -46,7 +46,7 @@ index 4035a9a..d1affd2 100644
  			    void *user_data)
  {
 diff --git a/src/utils/eloop.h b/src/utils/eloop.h
-index d38e2a9..3269f02 100644
+index d38e2a98d..3269f02b0 100644
 --- a/src/utils/eloop.h
 +++ b/src/utils/eloop.h
 @@ -297,8 +297,8 @@ void eloop_unregister_event(struct eloop_data *eloop, void *event,
@@ -83,5 +83,5 @@ index d38e2a9..3269f02 100644
                              void *user_data);
  
 -- 
-2.25.1
+2.34.1
 

--- a/lib/eloop/patches/0003-Bump-timeout-parameters-from-int-to-long.patch
+++ b/lib/eloop/patches/0003-Bump-timeout-parameters-from-int-to-long.patch
@@ -1,7 +1,7 @@
 From 2987c02110ef3c80d05944c894ef81985f36aa00 Mon Sep 17 00:00:00 2001
 From: Alois Klink <alois@nquiringminds.com>
 Date: Tue, 6 Sep 2022 18:34:47 +0100
-Subject: [PATCH 3/4] Bump timeout parameters from int to long
+Subject: [PATCH 3/5] Bump timeout parameters from int to long
 
 I'm not 100% sure why this was done.
 I'm guessing that on some platforms, the max int value is only

--- a/lib/eloop/patches/0004-list-add-missing-include-on-stdddef.h.patch
+++ b/lib/eloop/patches/0004-list-add-missing-include-on-stdddef.h.patch
@@ -1,7 +1,7 @@
 From 203dddf79ec58094eff4b2e3c20f6b86999722fc Mon Sep 17 00:00:00 2001
 From: Alois Klink <alois@nquiringminds.com>
 Date: Fri, 11 Nov 2022 14:59:44 +0000
-Subject: [PATCH 4/4] list: add missing include on <stdddef.h>
+Subject: [PATCH 4/5] list: add missing include on <stdddef.h>
 
 The `list.h` header uses `NULL`, which is defined in stddef.h
 ---

--- a/lib/eloop/patches/0005-eloop-add-edge_-prefix-to-all-external-funcs.patch
+++ b/lib/eloop/patches/0005-eloop-add-edge_-prefix-to-all-external-funcs.patch
@@ -1,0 +1,613 @@
+From 4f93b015d84cb583f4dcfbe683598c25341172bb Mon Sep 17 00:00:00 2001
+From: Alois Klink <alois@nquiringminds.com>
+Date: Fri, 27 Jan 2023 10:57:15 +0000
+Subject: [PATCH 5/5] eloop: add `edge_` prefix to all external funcs
+
+Add the `edge_` prefix to all functions with external linkage
+in eloop.h
+
+In the edgesec project, we're having difficulties, as we use our own
+patched version of `eloop`. However, another library we want to use has
+their own version of `eloop`, which is causing linking errors since
+they both use the same names for different functions.
+
+Unfortunately, we're not using C++, so we can't just wrap everything
+in a namespace, so we have to manually namespace the functions by
+adding our own custom prefix to every externally linked function.
+---
+ src/utils/eloop.c | 111 ++++++++++++++++++-------------
+ src/utils/eloop.h | 163 +++++++++++++++++++++++++---------------------
+ 2 files changed, 154 insertions(+), 120 deletions(-)
+
+diff --git a/src/utils/eloop.c b/src/utils/eloop.c
+index d1affd29f..61c65514e 100644
+--- a/src/utils/eloop.c
++++ b/src/utils/eloop.c
+@@ -64,7 +64,7 @@ static void eloop_trace_sock_remove_ref(struct eloop_sock_table *table)
+ #endif /* WPA_TRACE */
+ 
+ 
+-struct eloop_data *eloop_init(void)
++struct eloop_data *edge_eloop_init(void)
+ {
+ 	struct eloop_data *eloop = NULL;
+ 
+@@ -586,7 +586,7 @@ static int eloop_sock_table_requeue(struct eloop_data *eloop, struct eloop_sock_
+ #endif /* CONFIG_ELOOP_KQUEUE */
+ 
+ 
+-int eloop_sock_requeue(struct eloop_data *eloop)
++int edge_eloop_sock_requeue(struct eloop_data *eloop)
+ {
+ 	int r = 0;
+ 
+@@ -594,7 +594,7 @@ int eloop_sock_requeue(struct eloop_data *eloop)
+ 	close(eloop->kqueuefd);
+ 	eloop->kqueuefd = kqueue();
+ 	if (eloop->kqueuefd < 0) {
+-		log_errno("eloop_sock_requeue: kqueue failed");
++		log_errno("edge_eloop_sock_requeue: kqueue failed");
+ 		return -1;
+ 	}
+ 
+@@ -635,17 +635,18 @@ static void eloop_sock_table_destroy(struct eloop_sock_table *table)
+ }
+ 
+ 
+-int eloop_register_read_sock(struct eloop_data *eloop, int sock, eloop_sock_handler handler,
+-			     void *eloop_data, void *user_data)
++int edge_eloop_register_read_sock(struct eloop_data *eloop, int sock,
++				  eloop_sock_handler handler,
++				  void *eloop_data, void *user_data)
+ {
+-	return eloop_register_sock(eloop, sock, EVENT_TYPE_READ, handler,
+-				   eloop_data, user_data);
++	return edge_eloop_register_sock(eloop, sock, EVENT_TYPE_READ,
++					handler, eloop_data, user_data);
+ }
+ 
+ 
+-void eloop_unregister_read_sock(struct eloop_data *eloop, int sock)
++void edge_eloop_unregister_read_sock(struct eloop_data *eloop, int sock)
+ {
+-	eloop_unregister_sock(eloop, sock, EVENT_TYPE_READ);
++	edge_eloop_unregister_sock(eloop, sock, EVENT_TYPE_READ);
+ }
+ 
+ 
+@@ -668,9 +669,10 @@ static struct eloop_sock_table *eloop_get_sock_table(struct eloop_data *eloop, e
+ }
+ 
+ 
+-int eloop_register_sock(struct eloop_data *eloop, int sock, eloop_event_type type,
+-			eloop_sock_handler handler,
+-			void *eloop_data, void *user_data)
++int edge_eloop_register_sock(struct eloop_data *eloop, int sock,
++				eloop_event_type type,
++				eloop_sock_handler handler,
++				void *eloop_data, void *user_data)
+ {
+ 	if (eloop == NULL) {
+ 		log_error("eloop param is NULL");
+@@ -685,7 +687,8 @@ int eloop_register_sock(struct eloop_data *eloop, int sock, eloop_event_type typ
+ }
+ 
+ 
+-void eloop_unregister_sock(struct eloop_data *eloop, int sock, eloop_event_type type)
++void edge_eloop_unregister_sock(struct eloop_data *eloop, int sock,
++				eloop_event_type type)
+ {
+ 	struct eloop_sock_table *table;
+ 
+@@ -694,9 +697,10 @@ void eloop_unregister_sock(struct eloop_data *eloop, int sock, eloop_event_type
+ }
+ 
+ 
+-int eloop_register_timeout(struct eloop_data *eloop, unsigned long secs, unsigned long usecs,
+-			   eloop_timeout_handler handler,
+-			   void *eloop_data, void *user_data)
++int edge_eloop_register_timeout(struct eloop_data *eloop, unsigned long secs,
++				unsigned long usecs,
++				eloop_timeout_handler handler,
++				void *eloop_data, void *user_data)
+ {
+ 	if (eloop == NULL) {
+ 		log_error("eloop param is NULL");
+@@ -764,8 +768,9 @@ static void eloop_remove_timeout(struct eloop_timeout *timeout)
+ }
+ 
+ 
+-int eloop_cancel_timeout(struct eloop_data *eloop, eloop_timeout_handler handler,
+-			 void *eloop_data, void *user_data)
++int edge_eloop_cancel_timeout(struct eloop_data *eloop,
++			      eloop_timeout_handler handler,
++			      void *eloop_data, void *user_data)
+ {
+ 	if (eloop == NULL) {
+ 		log_error("eloop param is NULL");
+@@ -791,9 +796,10 @@ int eloop_cancel_timeout(struct eloop_data *eloop, eloop_timeout_handler handler
+ }
+ 
+ 
+-int eloop_cancel_timeout_one(struct eloop_data *eloop, eloop_timeout_handler handler,
+-			     void *eloop_data, void *user_data,
+-			     struct os_reltime *remaining)
++int edge_eloop_cancel_timeout_one(struct eloop_data *eloop,
++				  eloop_timeout_handler handler,
++				  void *eloop_data, void *user_data,
++				  struct os_reltime *remaining)
+ {
+ 	if (eloop == NULL) {
+ 		log_error("eloop param is NULL");
+@@ -823,8 +829,9 @@ int eloop_cancel_timeout_one(struct eloop_data *eloop, eloop_timeout_handler han
+ }
+ 
+ 
+-int eloop_is_timeout_registered(struct eloop_data *eloop, eloop_timeout_handler handler,
+-				void *eloop_data, void *user_data)
++int edge_eloop_is_timeout_registered(struct eloop_data *eloop,
++				     eloop_timeout_handler handler,
++				     void *eloop_data, void *user_data)
+ {
+ 	if (eloop == NULL) {
+ 		log_error("eloop param is NULL");
+@@ -843,9 +850,12 @@ int eloop_is_timeout_registered(struct eloop_data *eloop, eloop_timeout_handler
+ }
+ 
+ 
+-int eloop_deplete_timeout(struct eloop_data *eloop, unsigned long req_secs, unsigned long req_usecs,
+-			  eloop_timeout_handler handler, void *eloop_data,
+-			  void *user_data)
++int edge_eloop_deplete_timeout(struct eloop_data *eloop,
++			       unsigned long req_secs,
++			       unsigned long req_usecs,
++			       eloop_timeout_handler handler,
++			       void *eloop_data,
++			       void *user_data)
+ {
+ 	if (eloop == NULL) {
+ 		log_error("eloop param is NULL");
+@@ -864,12 +874,15 @@ int eloop_deplete_timeout(struct eloop_data *eloop, unsigned long req_secs, unsi
+ 			os_get_reltime(&now);
+ 			os_reltime_sub(&tmp->time, &now, &remaining);
+ 			if (os_reltime_before(&requested, &remaining)) {
+-				eloop_cancel_timeout(eloop, handler, eloop_data,
+-						     user_data);
+-				eloop_register_timeout(eloop, requested.sec,
+-						       requested.usec,
+-						       handler, eloop_data,
+-						       user_data);
++				edge_eloop_cancel_timeout(eloop, handler,
++							  eloop_data,
++							  user_data);
++				edge_eloop_register_timeout(eloop,
++							    requested.sec,
++							    requested.usec,
++							    handler,
++							    eloop_data,
++							    user_data);
+ 				return 1;
+ 			}
+ 			return 0;
+@@ -880,9 +893,12 @@ int eloop_deplete_timeout(struct eloop_data *eloop, unsigned long req_secs, unsi
+ }
+ 
+ 
+-int eloop_replenish_timeout(struct eloop_data *eloop, unsigned long req_secs, unsigned long req_usecs,
+-			    eloop_timeout_handler handler, void *eloop_data,
+-			    void *user_data)
++int edge_eloop_replenish_timeout(struct eloop_data *eloop,
++				 unsigned long req_secs,
++				 unsigned long req_usecs,
++				 eloop_timeout_handler handler,
++				 void *eloop_data,
++				 void *user_data)
+ {
+ 	if (eloop == NULL) {
+ 		log_error("eloop param is NULL");
+@@ -901,12 +917,15 @@ int eloop_replenish_timeout(struct eloop_data *eloop, unsigned long req_secs, un
+ 			os_get_reltime(&now);
+ 			os_reltime_sub(&tmp->time, &now, &remaining);
+ 			if (os_reltime_before(&remaining, &requested)) {
+-				eloop_cancel_timeout(eloop, handler, eloop_data,
+-						     user_data);
+-				eloop_register_timeout(eloop, requested.sec,
+-						       requested.usec,
+-						       handler, eloop_data,
+-						       user_data);
++				edge_eloop_cancel_timeout(eloop, handler,
++							  eloop_data,
++							  user_data);
++				edge_eloop_register_timeout(eloop,
++							    requested.sec,
++							    requested.usec,
++							    handler,
++							    eloop_data,
++							    user_data);
+ 				return 1;
+ 			}
+ 			return 0;
+@@ -916,7 +935,7 @@ int eloop_replenish_timeout(struct eloop_data *eloop, unsigned long req_secs, un
+ 	return -1;
+ }
+ 
+-void eloop_run(struct eloop_data *eloop)
++void edge_eloop_run(struct eloop_data *eloop)
+ {
+ 	if (eloop == NULL) {
+ 		log_error("eloop param is NULL");
+@@ -1089,7 +1108,7 @@ out:
+ }
+ 
+ 
+-void eloop_terminate(struct eloop_data *eloop)
++void edge_eloop_terminate(struct eloop_data *eloop)
+ {
+ 	if (eloop == NULL) {
+ 		log_error("eloop param is NULL");
+@@ -1150,7 +1169,7 @@ void eloop_destroy(struct eloop_data *eloop)
+ #endif /* CONFIG_ELOOP_KQUEUE */
+ }
+ 
+-void eloop_free(struct eloop_data *eloop) {
++void edge_eloop_free(struct eloop_data *eloop) {
+   if (eloop == NULL) {
+     return;
+   }
+@@ -1160,7 +1179,7 @@ void eloop_free(struct eloop_data *eloop) {
+ }
+ 
+ 
+-int eloop_terminated(struct eloop_data *eloop)
++int edge_eloop_terminated(struct eloop_data *eloop)
+ {
+ 	if (eloop == NULL) {
+ 		log_error("eloop param is NULL");
+@@ -1171,7 +1190,7 @@ int eloop_terminated(struct eloop_data *eloop)
+ }
+ 
+ 
+-void eloop_wait_for_read_sock(int sock)
++void edge_eloop_wait_for_read_sock(int sock)
+ {
+ #ifdef CONFIG_ELOOP_POLL
+ 	struct pollfd pfd;
+diff --git a/src/utils/eloop.h b/src/utils/eloop.h
+index 3269f02b0..022f83967 100644
+--- a/src/utils/eloop.h
++++ b/src/utils/eloop.h
+@@ -12,13 +12,17 @@
+  * suitable for most UNIX/POSIX systems. When porting to other operating
+  * systems, it may be necessary to replace that implementation with OS specific
+  * mechanisms.
++ *
++ * Copyright (c) 2023, NquiringMinds
++ * - Added `edge_` prefix to functions to avoid linking conflicts
+  */
+ 
+ #ifndef ELOOP_H
+ #define ELOOP_H
+ 
+ /**
+- * ELOOP_ALL_CTX - eloop_cancel_timeout() magic number to match all timeouts
++ * ELOOP_ALL_CTX - edge_eloop_cancel_timeout() magic number to match all
++ * timeouts
+  */
+ #define ELOOP_ALL_CTX (void *) -1
+ 
+@@ -27,7 +31,7 @@
+ #include "src/utils/os.h"
+ 
+ /**
+- * eloop_event_type - eloop socket event type for eloop_register_sock()
++ * eloop_event_type - eloop socket event type for edge_eloop_register_sock()
+  * @EVENT_TYPE_READ: Socket has data available for reading
+  * @EVENT_TYPE_WRITE: Socket has room for new data to be written
+  * @EVENT_TYPE_EXCEPTION: An exception has been reported
+@@ -169,23 +173,24 @@ struct eloop_data {
+ };
+ 
+ /**
+- * eloop_init() - Initialize global event loop data
++ * edge_edge_eloop_init() - Initialize and returns new event loop data structure.
++ *
+  * Returns: struct eloop_data on success, NULL on failure
+  *
+- * This function must be called before any other eloop_* function.
++ * This function must be called before any other edge_eloop_* function.
+  */
+-struct eloop_data *eloop_init(void);
++struct eloop_data *edge_eloop_init(void);
+ 
+ /**
+- * eloop_free() - Free's the eloop context
++ * edge_eloop_free() - Free's the eloop context
+  * @eloop: eloop context
+  *
+- * This function must be called before any other eloop_* function.
++ * This function must be called before any other edge_eloop_* function.
+  */
+-void eloop_free(struct eloop_data *eloop);
++void edge_eloop_free(struct eloop_data *eloop);
+ 
+ /**
+- * eloop_register_read_sock - Register handler for read events
++ * edge_eloop_register_read_sock - Register handler for read events
+  * @eloop: eloop context
+  * @sock: File descriptor number for the socket
+  * @handler: Callback function to be called when data is available for reading
+@@ -199,22 +204,22 @@ void eloop_free(struct eloop_data *eloop);
+  * having processed it in order to avoid eloop from calling the handler again
+  * for the same event.
+  */
+-int eloop_register_read_sock(struct eloop_data *eloop, int sock,
+-                             eloop_sock_handler handler, void *eloop_data,
+-                             void *user_data);
++int edge_eloop_register_read_sock(struct eloop_data *eloop, int sock,
++				  eloop_sock_handler handler, void *eloop_data,
++				  void *user_data);
+ 
+ /**
+- * eloop_unregister_read_sock - Unregister handler for read events
++ * edge_eloop_unregister_read_sock - Unregister handler for read events
+  * @eloop: eloop context
+  * @sock: File descriptor number for the socket
+  *
+  * Unregister a read socket notifier that was previously registered with
+- * eloop_register_read_sock().
++ * edge_eloop_register_read_sock().
+  */
+-void eloop_unregister_read_sock(struct eloop_data *eloop, int sock);
++void edge_eloop_unregister_read_sock(struct eloop_data *eloop, int sock);
+ 
+ /**
+- * eloop_register_sock - Register handler for socket events
++ * edge_eloop_register_sock - Register handler for socket events
+  * @eloop: eloop context
+  * @sock: File descriptor number for the socket
+  * @type: Type of event to wait for
+@@ -229,24 +234,25 @@ void eloop_unregister_read_sock(struct eloop_data *eloop, int sock);
+  * having processed it in order to avoid eloop from calling the handler again
+  * for the same event.
+  */
+-int eloop_register_sock(struct eloop_data *eloop, int sock,
+-                        eloop_event_type type, eloop_sock_handler handler,
+-                        void *eloop_data, void *user_data);
++int edge_eloop_register_sock(struct eloop_data *eloop, int sock,
++			     eloop_event_type type,
++			     eloop_sock_handler handler,
++			     void *eloop_data, void *user_data);
+ 
+ /**
+- * eloop_unregister_sock - Unregister handler for socket events
++ * edge_eloop_unregister_sock - Unregister handler for socket events
+  * @eloop: eloop context
+  * @sock: File descriptor number for the socket
+  * @type: Type of event for which sock was registered
+  *
+  * Unregister a socket event notifier that was previously registered with
+- * eloop_register_sock().
++ * edge_eloop_register_sock().
+  */
+-void eloop_unregister_sock(struct eloop_data *eloop, int sock,
+-                           eloop_event_type type);
++void edge_eloop_unregister_sock(struct eloop_data *eloop, int sock,
++				eloop_event_type type);
+ 
+ /**
+- * eloop_register_event - Register handler for generic events
++ * edge_eloop_register_event - Register handler for generic events
+  * @eloop: eloop context
+  * @event: Event to wait (eloop implementation specific)
+  * @event_size: Size of event data
+@@ -265,27 +271,27 @@ void eloop_unregister_sock(struct eloop_data *eloop, int sock,
+  *
+  * In case of Windows implementation (eloop_win.c), event pointer is of HANDLE
+  * type, i.e., void*. The callers are likely to have 'HANDLE h' type variable,
+- * and they would call this function with eloop_register_event(h, sizeof(h),
+- * ...).
++ * and they would call this function with
++ * edge_eloop_register_event(h, sizeof(h), ...).
+  */
+-int eloop_register_event(struct eloop_data *eloop, void *event,
+-                         size_t event_size, eloop_event_handler handler,
+-                         void *eloop_data, void *user_data);
++int edge_eloop_register_event(struct eloop_data *eloop, void *event,
++			      size_t event_size, eloop_event_handler handler,
++			      void *eloop_data, void *user_data);
+ 
+ /**
+- * eloop_unregister_event - Unregister handler for a generic event
++ * edge_eloop_unregister_event - Unregister handler for a generic event
+  * @eloop: eloop context
+  * @event: Event to cancel (eloop implementation specific)
+  * @event_size: Size of event data
+  *
+  * Unregister a generic event notifier that was previously registered with
+- * eloop_register_event().
++ * edge_eloop_register_event().
+  */
+-void eloop_unregister_event(struct eloop_data *eloop, void *event,
+-                            size_t event_size);
++void edge_eloop_unregister_event(struct eloop_data *eloop, void *event,
++				 size_t event_size);
+ 
+ /**
+- * eloop_register_timeout - Register timeout
++ * edge_eloop_register_timeout - Register timeout
+  * @eloop: eloop context
+  * @secs: Number of seconds to the timeout
+  * @usecs: Number of microseconds to the timeout
+@@ -297,12 +303,13 @@ void eloop_unregister_event(struct eloop_data *eloop, void *event,
+  * Register a timeout that will cause the handler function to be called after
+  * given time.
+  */
+-int eloop_register_timeout(struct eloop_data *eloop, unsigned long secs,
+-                           unsigned long usecs, eloop_timeout_handler handler,
+-                           void *eloop_data, void *user_data);
++int edge_eloop_register_timeout(struct eloop_data *eloop, unsigned long secs,
++				unsigned long usecs,
++				eloop_timeout_handler handler,
++				void *eloop_data, void *user_data);
+ 
+ /**
+- * eloop_cancel_timeout - Cancel timeouts
++ * edge_eloop_cancel_timeout - Cancel timeouts
+  * @eloop: eloop context
+  * @handler: Matching callback function
+  * @eloop_data: Matching eloop_data or %ELOOP_ALL_CTX to match all
+@@ -310,15 +317,16 @@ int eloop_register_timeout(struct eloop_data *eloop, unsigned long secs,
+  * Returns: Number of cancelled timeouts
+  *
+  * Cancel matching <handler,eloop_data,user_data> timeouts registered with
+- * eloop_register_timeout(). ELOOP_ALL_CTX can be used as a wildcard for
++ * edge_eloop_register_timeout(). ELOOP_ALL_CTX can be used as a wildcard for
+  * cancelling all timeouts regardless of eloop_data/user_data.
+  */
+-int eloop_cancel_timeout(struct eloop_data *eloop,
+-                         eloop_timeout_handler handler, void *eloop_data,
+-                         void *user_data);
++int edge_eloop_cancel_timeout(struct eloop_data *eloop,
++			      eloop_timeout_handler handler,
++			      void *eloop_data,
++			      void *user_data);
+ 
+ /**
+- * eloop_cancel_timeout_one - Cancel a single timeout
++ * edge_eloop_cancel_timeout_one - Cancel a single timeout
+  * @eloop: eloop context
+  * @handler: Matching callback function
+  * @eloop_data: Matching eloop_data
+@@ -327,14 +335,16 @@ int eloop_cancel_timeout(struct eloop_data *eloop,
+  * Returns: Number of cancelled timeouts
+  *
+  * Cancel matching <handler,eloop_data,user_data> timeout registered with
+- * eloop_register_timeout() and return the remaining time left.
++ * edge_eloop_register_timeout() and return the remaining time left.
+  */
+-int eloop_cancel_timeout_one(struct eloop_data *eloop,
+-                             eloop_timeout_handler handler, void *eloop_data,
+-                             void *user_data, struct os_reltime *remaining);
++int edge_eloop_cancel_timeout_one(struct eloop_data *eloop,
++				  eloop_timeout_handler handler,
++				  void *eloop_data,
++				  void *user_data,
++				  struct os_reltime *remaining);
+ 
+ /**
+- * eloop_is_timeout_registered - Check if a timeout is already registered
++ * edge_eloop_is_timeout_registered - Check if a timeout is already registered
+  * @eloop: eloop context
+  * @handler: Matching callback function
+  * @eloop_data: Matching eloop_data
+@@ -342,14 +352,15 @@ int eloop_cancel_timeout_one(struct eloop_data *eloop,
+  * Returns: 1 if the timeout is registered, 0 if the timeout is not registered
+  *
+  * Determine if a matching <handler,eloop_data,user_data> timeout is registered
+- * with eloop_register_timeout().
++ * with edge_eloop_register_timeout().
+  */
+-int eloop_is_timeout_registered(struct eloop_data *eloop,
+-                                eloop_timeout_handler handler, void *eloop_data,
+-                                void *user_data);
++int edge_eloop_is_timeout_registered(struct eloop_data *eloop,
++				     eloop_timeout_handler handler,
++				     void *eloop_data,
++				     void *user_data);
+ 
+ /**
+- * eloop_deplete_timeout - Deplete a timeout that is already registered
++ * edge_eloop_deplete_timeout - Deplete a timeout that is already registered
+  * @eloop: eloop context
+  * @req_secs: Requested number of seconds to the timeout
+  * @req_usecs: Requested number of microseconds to the timeout
+@@ -362,13 +373,15 @@ int eloop_is_timeout_registered(struct eloop_data *eloop,
+  * Find a registered matching <handler,eloop_data,user_data> timeout. If found,
+  * deplete the timeout if remaining time is more than the requested time.
+  */
+-int eloop_deplete_timeout(struct eloop_data *eloop, unsigned long req_secs,
+-                          unsigned long req_usecs,
+-                          eloop_timeout_handler handler, void *eloop_data,
+-                          void *user_data);
++int edge_eloop_deplete_timeout(struct eloop_data *eloop,
++			       unsigned long req_secs,
++			       unsigned long req_usecs,
++			       eloop_timeout_handler handler,
++			       void *eloop_data,
++			       void *user_data);
+ 
+ /**
+- * eloop_replenish_timeout - Replenish a timeout that is already registered
++ * edge_eloop_replenish_timeout - Replenish a timeout that is already registered
+  * @eloop: eloop context
+  * @req_secs: Requested number of seconds to the timeout
+  * @req_usecs: Requested number of microseconds to the timeout
+@@ -381,47 +394,49 @@ int eloop_deplete_timeout(struct eloop_data *eloop, unsigned long req_secs,
+  * Find a registered matching <handler,eloop_data,user_data> timeout. If found,
+  * replenish the timeout if remaining time is less than the requested time.
+  */
+-int eloop_replenish_timeout(struct eloop_data *eloop, unsigned long req_secs,
+-                            unsigned long req_usecs,
+-                            eloop_timeout_handler handler, void *eloop_data,
+-                            void *user_data);
++int edge_eloop_replenish_timeout(struct eloop_data *eloop,
++				 unsigned long req_secs,
++				 unsigned long req_usecs,
++				 eloop_timeout_handler handler,
++				 void *eloop_data,
++				 void *user_data);
+ 
+ /**
+- * eloop_sock_requeue - Requeue sockets
++ * edge_eloop_sock_requeue - Requeue sockets
+  * @eloop: eloop context
+  * Requeue sockets after forking because some implementations require this,
+  * such as epoll and kqueue.
+  */
+-int eloop_sock_requeue(struct eloop_data *eloop);
++int edge_eloop_sock_requeue(struct eloop_data *eloop);
+ 
+ /**
+- * eloop_run - Start the event loop
++ * edge_eloop_run - Start the event loop
+  * @eloop: eloop context
+  * Start the event loop and continue running as long as there are any
+  * registered event handlers. This function is run after event loop has been
+  * initialized with event_init() and one or more events have been registered.
+  */
+-void eloop_run(struct eloop_data *eloop);
++void edge_eloop_run(struct eloop_data *eloop);
+ 
+ /**
+- * eloop_terminate - Terminate event loop
++ * edge_eloop_terminate - Terminate event loop
+  * @eloop: eloop context
+  * Terminate event loop even if there are registered events. This can be used
+  * to request the program to be terminated cleanly.
+  */
+-void eloop_terminate(struct eloop_data *eloop);
++void edge_eloop_terminate(struct eloop_data *eloop);
+ 
+ /**
+- * eloop_terminated - Check whether event loop has been terminated
++ * edge_eloop_terminated - Check whether event loop has been terminated
+  * @eloop: eloop context
+  * Returns: 1 = event loop terminate, 0 = event loop still running
+  *
+- * This function can be used to check whether eloop_terminate() has been called
+- * to request termination of the event loop. This is normally used to abort
+- * operations that may still be queued to be run when eloop_terminate() was
+- * called.
++ * This function can be used to check whether edge_eloop_terminate() has
++ * been called to request termination of the event loop.
++ * This is normally used to abort operations that may still be queued to be run
++ * when edge_eloop_terminate() was called.
+  */
+-int eloop_terminated(struct eloop_data *eloop);
++int edge_eloop_terminated(struct eloop_data *eloop);
+ 
+ /**
+  * eloop_wait_for_read_sock - Wait for a single reader
+-- 
+2.34.1
+

--- a/src/ap/ap_service.c
+++ b/src/ap/ap_service.c
@@ -255,8 +255,8 @@ int register_ap_event(struct supervisor_context *context,
   }
 
   if (edge_eloop_register_read_sock(context->eloop, context->ap_sock,
-                               ap_sock_handler, ap_callback_fn,
-                               (void *)context) == -1) {
+                                    ap_sock_handler, ap_callback_fn,
+                                    (void *)context) == -1) {
     log_error("edge_eloop_register_read_sock fail");
     return -1;
   }

--- a/src/ap/ap_service.c
+++ b/src/ap/ap_service.c
@@ -254,10 +254,10 @@ int register_ap_event(struct supervisor_context *context,
     return -1;
   }
 
-  if (eloop_register_read_sock(context->eloop, context->ap_sock,
+  if (edge_eloop_register_read_sock(context->eloop, context->ap_sock,
                                ap_sock_handler, ap_callback_fn,
                                (void *)context) == -1) {
-    log_error("eloop_register_read_sock fail");
+    log_error("edge_eloop_register_read_sock fail");
     return -1;
   }
 

--- a/src/capture/capture_service.c
+++ b/src/capture/capture_service.c
@@ -82,8 +82,8 @@ int run_capture(struct capture_middleware_context *context) {
     return -1;
   }
 
-  if ((eloop = eloop_init()) == NULL) {
-    log_error("eloop_init fail");
+  if ((eloop = edge_eloop_init()) == NULL) {
+    log_error("edge_eloop_init fail");
     goto capture_fail;
   }
 
@@ -97,9 +97,9 @@ int run_capture(struct capture_middleware_context *context) {
   }
 
   if (pc != NULL) {
-    if (eloop_register_read_sock(eloop, pc->pcap_fd, eloop_read_fd_handler,
+    if (edge_eloop_register_read_sock(eloop, pc->pcap_fd, eloop_read_fd_handler,
                                  (void *)pc, (void *)NULL) == -1) {
-      log_error("eloop_register_read_sock fail");
+      log_error("edge_eloop_register_read_sock fail");
       goto capture_fail;
     }
   } else {
@@ -115,18 +115,18 @@ int run_capture(struct capture_middleware_context *context) {
     goto capture_fail;
   }
 
-  eloop_run(eloop);
+  edge_eloop_run(eloop);
   log_info("Capture ended.");
 
   /* And close the session */
   close_pcap(pc);
-  eloop_free(eloop);
+  edge_eloop_free(eloop);
   sqlite3_close(db);
   return 0;
 
 capture_fail:
   close_pcap(pc);
-  eloop_free(eloop);
+  edge_eloop_free(eloop);
   sqlite3_close(db);
   return -1;
 }

--- a/src/capture/capture_service.c
+++ b/src/capture/capture_service.c
@@ -98,7 +98,7 @@ int run_capture(struct capture_middleware_context *context) {
 
   if (pc != NULL) {
     if (edge_eloop_register_read_sock(eloop, pc->pcap_fd, eloop_read_fd_handler,
-                                 (void *)pc, (void *)NULL) == -1) {
+                                      (void *)pc, (void *)NULL) == -1) {
       log_error("edge_eloop_register_read_sock fail");
       goto capture_fail;
     }

--- a/src/capture/middlewares/cleaner_middleware/cleaner_middleware.c
+++ b/src/capture/middlewares/cleaner_middleware/cleaner_middleware.c
@@ -146,10 +146,10 @@ void eloop_tout_cleaner_handler(void *eloop_ctx, void *user_ctx) {
     cleaner_context->next_timestamp = 0;
   }
 
-  if (eloop_register_timeout(context->eloop, CLEANER_PROCESS_INTERVAL, 0,
+  if (edge_eloop_register_timeout(context->eloop, CLEANER_PROCESS_INTERVAL, 0,
                              eloop_tout_cleaner_handler, NULL,
                              (void *)user_ctx) == -1) {
-    log_error("eloop_register_timeout fail");
+    log_error("edge_eloop_register_timeout fail");
   }
 }
 
@@ -222,10 +222,10 @@ struct middleware_context *init_cleaner_middleware(sqlite3 *db, char *db_path,
   log_info("Cleaning pcap_path=%s", cleaner_context->pcap_path);
   log_info("Cleaning store_size=%llu bytes", cleaner_context->store_size);
 
-  if (eloop_register_timeout(eloop, CLEANER_PROCESS_INTERVAL, 0,
+  if (edge_eloop_register_timeout(eloop, CLEANER_PROCESS_INTERVAL, 0,
                              eloop_tout_cleaner_handler, NULL,
                              (void *)context) == -1) {
-    log_error("eloop_register_timeout fail");
+    log_error("edge_eloop_register_timeout fail");
     free_cleaner_middleware(context);
     return NULL;
   }

--- a/src/capture/middlewares/cleaner_middleware/cleaner_middleware.c
+++ b/src/capture/middlewares/cleaner_middleware/cleaner_middleware.c
@@ -147,8 +147,8 @@ void eloop_tout_cleaner_handler(void *eloop_ctx, void *user_ctx) {
   }
 
   if (edge_eloop_register_timeout(context->eloop, CLEANER_PROCESS_INTERVAL, 0,
-                             eloop_tout_cleaner_handler, NULL,
-                             (void *)user_ctx) == -1) {
+                                  eloop_tout_cleaner_handler, NULL,
+                                  (void *)user_ctx) == -1) {
     log_error("edge_eloop_register_timeout fail");
   }
 }
@@ -223,8 +223,8 @@ struct middleware_context *init_cleaner_middleware(sqlite3 *db, char *db_path,
   log_info("Cleaning store_size=%llu bytes", cleaner_context->store_size);
 
   if (edge_eloop_register_timeout(eloop, CLEANER_PROCESS_INTERVAL, 0,
-                             eloop_tout_cleaner_handler, NULL,
-                             (void *)context) == -1) {
+                                  eloop_tout_cleaner_handler, NULL,
+                                  (void *)context) == -1) {
     log_error("edge_eloop_register_timeout fail");
     free_cleaner_middleware(context);
     return NULL;

--- a/src/capture/middlewares/header_middleware/header_middleware.c
+++ b/src/capture/middlewares/header_middleware/header_middleware.c
@@ -70,8 +70,8 @@ void eloop_tout_header_handler(void *eloop_ctx, void *user_ctx) {
   }
 
   if (edge_eloop_register_timeout(context->eloop, 0, HEADER_PROCESS_INTERVAL,
-                             eloop_tout_header_handler, NULL,
-                             (void *)user_ctx) == -1) {
+                                  eloop_tout_header_handler, NULL,
+                                  (void *)user_ctx) == -1) {
     log_error("edge_eloop_register_timeout fail");
   }
 }
@@ -129,8 +129,8 @@ struct middleware_context *init_header_middleware(sqlite3 *db, char *db_path,
   }
 
   if (edge_eloop_register_timeout(eloop, 0, HEADER_PROCESS_INTERVAL,
-                             eloop_tout_header_handler, NULL,
-                             (void *)context) == -1) {
+                                  eloop_tout_header_handler, NULL,
+                                  (void *)context) == -1) {
     log_error("edge_eloop_register_timeout fail");
     free_header_middleware(context);
     return NULL;

--- a/src/capture/middlewares/header_middleware/header_middleware.c
+++ b/src/capture/middlewares/header_middleware/header_middleware.c
@@ -69,10 +69,10 @@ void eloop_tout_header_handler(void *eloop_ctx, void *user_ctx) {
     }
   }
 
-  if (eloop_register_timeout(context->eloop, 0, HEADER_PROCESS_INTERVAL,
+  if (edge_eloop_register_timeout(context->eloop, 0, HEADER_PROCESS_INTERVAL,
                              eloop_tout_header_handler, NULL,
                              (void *)user_ctx) == -1) {
-    log_error("eloop_register_timeout fail");
+    log_error("edge_eloop_register_timeout fail");
   }
 }
 
@@ -128,10 +128,10 @@ struct middleware_context *init_header_middleware(sqlite3 *db, char *db_path,
     return NULL;
   }
 
-  if (eloop_register_timeout(eloop, 0, HEADER_PROCESS_INTERVAL,
+  if (edge_eloop_register_timeout(eloop, 0, HEADER_PROCESS_INTERVAL,
                              eloop_tout_header_handler, NULL,
                              (void *)context) == -1) {
-    log_error("eloop_register_timeout fail");
+    log_error("edge_eloop_register_timeout fail");
     free_header_middleware(context);
     return NULL;
   }

--- a/src/capture/middlewares/pcap_middleware/pcap_middleware.c
+++ b/src/capture/middlewares/pcap_middleware/pcap_middleware.c
@@ -134,8 +134,8 @@ void eloop_tout_pcap_handler(void *eloop_ctx, void *user_ctx) {
   }
 
   if (edge_eloop_register_timeout(context->eloop, 0, PCAP_PROCESS_INTERVAL,
-                             eloop_tout_pcap_handler, NULL,
-                             (void *)user_ctx) == -1) {
+                                  eloop_tout_pcap_handler, NULL,
+                                  (void *)user_ctx) == -1) {
     log_error("edge_eloop_register_timeout fail");
   }
 }
@@ -221,8 +221,8 @@ struct middleware_context *init_pcap_middleware(sqlite3 *db, char *db_path,
   }
 
   if (edge_eloop_register_timeout(eloop, 0, PCAP_PROCESS_INTERVAL,
-                             eloop_tout_pcap_handler, NULL,
-                             (void *)context) == -1) {
+                                  eloop_tout_pcap_handler, NULL,
+                                  (void *)context) == -1) {
     log_error("edge_eloop_register_timeout fail");
     free_pcap_middleware(context);
     return NULL;

--- a/src/capture/middlewares/pcap_middleware/pcap_middleware.c
+++ b/src/capture/middlewares/pcap_middleware/pcap_middleware.c
@@ -133,10 +133,10 @@ void eloop_tout_pcap_handler(void *eloop_ctx, void *user_ctx) {
     }
   }
 
-  if (eloop_register_timeout(context->eloop, 0, PCAP_PROCESS_INTERVAL,
+  if (edge_eloop_register_timeout(context->eloop, 0, PCAP_PROCESS_INTERVAL,
                              eloop_tout_pcap_handler, NULL,
                              (void *)user_ctx) == -1) {
-    log_error("eloop_register_timeout fail");
+    log_error("edge_eloop_register_timeout fail");
   }
 }
 
@@ -220,10 +220,10 @@ struct middleware_context *init_pcap_middleware(sqlite3 *db, char *db_path,
     return NULL;
   }
 
-  if (eloop_register_timeout(eloop, 0, PCAP_PROCESS_INTERVAL,
+  if (edge_eloop_register_timeout(eloop, 0, PCAP_PROCESS_INTERVAL,
                              eloop_tout_pcap_handler, NULL,
                              (void *)context) == -1) {
-    log_error("eloop_register_timeout fail");
+    log_error("edge_eloop_register_timeout fail");
     free_pcap_middleware(context);
     return NULL;
   }

--- a/src/dns/mdns_service.c
+++ b/src/dns/mdns_service.c
@@ -340,8 +340,9 @@ int register_reflector_if6(struct eloop_data *eloop,
       return -1;
     }
 
-    if (edge_eloop_register_read_sock(eloop, el->recv_fd, eloop_reflector_handler,
-                                 (void *)context, (void *)rif) < 0) {
+    if (edge_eloop_register_read_sock(eloop, el->recv_fd,
+                                      eloop_reflector_handler, (void *)context,
+                                      (void *)rif) < 0) {
       log_error("edge_eloop_register_read_sock fail");
       return -1;
     }
@@ -390,8 +391,9 @@ int register_reflector_if4(struct eloop_data *eloop,
       return -1;
     }
 
-    if (edge_eloop_register_read_sock(eloop, el->recv_fd, eloop_reflector_handler,
-                                 (void *)context, (void *)rif) < 0) {
+    if (edge_eloop_register_read_sock(eloop, el->recv_fd,
+                                      eloop_reflector_handler, (void *)context,
+                                      (void *)rif) < 0) {
       log_error("edge_eloop_register_read_sock fail");
       return -1;
     }
@@ -657,8 +659,8 @@ int run_mdns_capture(struct eloop_data *eloop, struct mdns_context *context) {
     utarray_push_back(context->pctx_list, &pctx);
 
     if (edge_eloop_register_read_sock(eloop, pctx->pcap_fd,
-                                 eloop_read_mdns_fd_handler, (void *)pctx,
-                                 (void *)NULL) == -1) {
+                                      eloop_read_mdns_fd_handler, (void *)pctx,
+                                      (void *)NULL) == -1) {
       log_error("edge_eloop_register_read_sock fail");
       return -1;
     }

--- a/src/dns/mdns_service.c
+++ b/src/dns/mdns_service.c
@@ -340,9 +340,9 @@ int register_reflector_if6(struct eloop_data *eloop,
       return -1;
     }
 
-    if (eloop_register_read_sock(eloop, el->recv_fd, eloop_reflector_handler,
+    if (edge_eloop_register_read_sock(eloop, el->recv_fd, eloop_reflector_handler,
                                  (void *)context, (void *)rif) < 0) {
-      log_error("eloop_register_read_sock fail");
+      log_error("edge_eloop_register_read_sock fail");
       return -1;
     }
 
@@ -390,9 +390,9 @@ int register_reflector_if4(struct eloop_data *eloop,
       return -1;
     }
 
-    if (eloop_register_read_sock(eloop, el->recv_fd, eloop_reflector_handler,
+    if (edge_eloop_register_read_sock(eloop, el->recv_fd, eloop_reflector_handler,
                                  (void *)context, (void *)rif) < 0) {
-      log_error("eloop_register_read_sock fail");
+      log_error("edge_eloop_register_read_sock fail");
       return -1;
     }
 
@@ -656,10 +656,10 @@ int run_mdns_capture(struct eloop_data *eloop, struct mdns_context *context) {
 
     utarray_push_back(context->pctx_list, &pctx);
 
-    if (eloop_register_read_sock(eloop, pctx->pcap_fd,
+    if (edge_eloop_register_read_sock(eloop, pctx->pcap_fd,
                                  eloop_read_mdns_fd_handler, (void *)pctx,
                                  (void *)NULL) == -1) {
-      log_error("eloop_register_read_sock fail");
+      log_error("edge_eloop_register_read_sock fail");
       return -1;
     }
   }
@@ -685,20 +685,20 @@ int run_mdns(struct mdns_context *context) {
     return -1;
   }
 
-  if ((eloop = eloop_init()) == NULL) {
-    log_error("eloop_init fail");
+  if ((eloop = edge_eloop_init()) == NULL) {
+    log_error("edge_eloop_init fail");
     return -1;
   }
 
   if (register_reflector_if6(eloop, context) < 0) {
     log_error("register_reflector_if6 fail");
-    eloop_free(eloop);
+    edge_eloop_free(eloop);
     return -1;
   }
 
   if (register_reflector_if4(eloop, context) < 0) {
     log_error("register_reflector_if4 fail");
-    eloop_free(eloop);
+    edge_eloop_free(eloop);
     return -1;
   }
 
@@ -706,13 +706,13 @@ int run_mdns(struct mdns_context *context) {
 
   if (run_mdns_capture(eloop, context) < 0) {
     log_error("run_mdns_capture fail");
-    eloop_free(eloop);
+    edge_eloop_free(eloop);
     return -1;
   }
 
-  eloop_run(eloop);
+  edge_eloop_run(eloop);
 
-  eloop_free(eloop);
+  edge_eloop_free(eloop);
   return 0;
 }
 

--- a/src/edgesec-recap.c
+++ b/src/edgesec-recap.c
@@ -570,8 +570,8 @@ void eloop_tout_header_handler(void *eloop_ctx, void *user_ctx) {
 
   struct eloop_data *eloop = (struct eloop_data *)eloop_ctx;
   if (edge_eloop_register_timeout(eloop, 0, QUEUE_PROCESS_INTERVAL,
-                             eloop_tout_header_handler, eloop,
-                             (void *)pctx) == -1) {
+                                  eloop_tout_header_handler, eloop,
+                                  (void *)pctx) == -1) {
     log_error("edge_eloop_register_timeout fail");
   }
 }
@@ -598,14 +598,14 @@ int process_pcap_capture(struct recap_context *pctx) {
     }
 
     if (edge_eloop_register_read_sock(eloop, pc->pcap_fd, eloop_read_fd_handler,
-                                 (void *)pc, (void *)NULL) == -1) {
+                                      (void *)pc, (void *)NULL) == -1) {
       log_error("edge_eloop_register_read_sock fail");
       goto process_pcap_capture_fail;
     }
 
     if (edge_eloop_register_timeout(eloop, 0, QUEUE_PROCESS_INTERVAL,
-                               eloop_tout_header_handler, eloop,
-                               (void *)pctx) == -1) {
+                                    eloop_tout_header_handler, eloop,
+                                    (void *)pctx) == -1) {
       log_error("edge_eloop_register_timeout fail");
       goto process_pcap_capture_fail;
     }

--- a/src/edgesec-recap.c
+++ b/src/edgesec-recap.c
@@ -569,10 +569,10 @@ void eloop_tout_header_handler(void *eloop_ctx, void *user_ctx) {
   }
 
   struct eloop_data *eloop = (struct eloop_data *)eloop_ctx;
-  if (eloop_register_timeout(eloop, 0, QUEUE_PROCESS_INTERVAL,
+  if (edge_eloop_register_timeout(eloop, 0, QUEUE_PROCESS_INTERVAL,
                              eloop_tout_header_handler, eloop,
                              (void *)pctx) == -1) {
-    log_error("eloop_register_timeout fail");
+    log_error("edge_eloop_register_timeout fail");
   }
 }
 
@@ -581,8 +581,8 @@ int process_pcap_capture(struct recap_context *pctx) {
   int exit_code = -1;
   struct pcap_context *pc = NULL;
 
-  if ((eloop = eloop_init()) == NULL) {
-    log_error("eloop_init fail");
+  if ((eloop = edge_eloop_init()) == NULL) {
+    log_error("edge_eloop_init fail");
     goto process_pcap_capture_fail;
   }
   if (run_pcap(pctx->ifname, false, false, 10, NULL, true, pcap_callback,
@@ -597,16 +597,16 @@ int process_pcap_capture(struct recap_context *pctx) {
       goto process_pcap_capture_fail;
     }
 
-    if (eloop_register_read_sock(eloop, pc->pcap_fd, eloop_read_fd_handler,
+    if (edge_eloop_register_read_sock(eloop, pc->pcap_fd, eloop_read_fd_handler,
                                  (void *)pc, (void *)NULL) == -1) {
-      log_error("eloop_register_read_sock fail");
+      log_error("edge_eloop_register_read_sock fail");
       goto process_pcap_capture_fail;
     }
 
-    if (eloop_register_timeout(eloop, 0, QUEUE_PROCESS_INTERVAL,
+    if (edge_eloop_register_timeout(eloop, 0, QUEUE_PROCESS_INTERVAL,
                                eloop_tout_header_handler, eloop,
                                (void *)pctx) == -1) {
-      log_error("eloop_register_timeout fail");
+      log_error("edge_eloop_register_timeout fail");
       goto process_pcap_capture_fail;
     }
   } else {
@@ -614,12 +614,12 @@ int process_pcap_capture(struct recap_context *pctx) {
     goto process_pcap_capture_fail;
   }
 
-  eloop_run(eloop);
+  edge_eloop_run(eloop);
 
   exit_code = 0;
 
 process_pcap_capture_fail:
-  eloop_free(eloop);
+  edge_eloop_free(eloop);
   close_pcap(pc);
   free_packet_queue(pctx->pq);
   return exit_code;

--- a/src/radius/radius_server.c
+++ b/src/radius/radius_server.c
@@ -214,9 +214,10 @@ radius_server_get_session(struct radius_client *client, unsigned int sess_id) {
 
 static void radius_server_session_free(struct radius_server_data *data,
                                        struct radius_session *sess) {
-  edge_eloop_cancel_timeout(data->eloop, radius_server_session_timeout, data, sess);
-  edge_eloop_cancel_timeout(data->eloop, radius_server_session_remove_timeout, data,
-                       sess);
+  edge_eloop_cancel_timeout(data->eloop, radius_server_session_timeout, data,
+                            sess);
+  edge_eloop_cancel_timeout(data->eloop, radius_server_session_remove_timeout,
+                            data, sess);
   radius_msg_free(sess->last_msg);
   os_free(sess->last_from_addr);
   radius_msg_free(sess->last_reply);
@@ -232,8 +233,8 @@ static void radius_server_session_remove(struct radius_server_data *data,
   struct radius_client *client = sess->client;
   struct radius_session *session, *prev;
 
-  edge_eloop_cancel_timeout(data->eloop, radius_server_session_remove_timeout, data,
-                       sess);
+  edge_eloop_cancel_timeout(data->eloop, radius_server_session_remove_timeout,
+                            data, sess);
 
   prev = NULL;
   session = client->sessions;
@@ -288,7 +289,7 @@ radius_server_new_session(struct radius_server_data *data,
   sess->next = client->sessions;
   client->sessions = sess;
   edge_eloop_register_timeout(data->eloop, RADIUS_SESSION_TIMEOUT, 0,
-                         radius_server_session_timeout, data, sess);
+                              radius_server_session_timeout, data, sess);
   data->num_sess++;
   return sess;
 }
@@ -612,9 +613,10 @@ static int radius_server_request(struct radius_server_data *data,
     log_trace("Removing RADIUS completed session 0x%x after timeout",
               sess->sess_id);
     edge_eloop_cancel_timeout(data->eloop, radius_server_session_remove_timeout,
-                         data, sess);
+                              data, sess);
     edge_eloop_register_timeout(data->eloop, RADIUS_SESSION_MAINTAIN, 0,
-                           radius_server_session_remove_timeout, data, sess);
+                                radius_server_session_remove_timeout, data,
+                                sess);
   }
 
   return 0;
@@ -846,7 +848,7 @@ struct radius_server_data *radius_server_init(struct eloop_data *eloop,
     goto fail;
   }
   if (edge_eloop_register_read_sock(data->eloop, data->auth_sock,
-                               radius_server_receive_auth, data, NULL)) {
+                                    radius_server_receive_auth, data, NULL)) {
     goto fail;
   }
 

--- a/src/radius/radius_server.c
+++ b/src/radius/radius_server.c
@@ -214,8 +214,8 @@ radius_server_get_session(struct radius_client *client, unsigned int sess_id) {
 
 static void radius_server_session_free(struct radius_server_data *data,
                                        struct radius_session *sess) {
-  eloop_cancel_timeout(data->eloop, radius_server_session_timeout, data, sess);
-  eloop_cancel_timeout(data->eloop, radius_server_session_remove_timeout, data,
+  edge_eloop_cancel_timeout(data->eloop, radius_server_session_timeout, data, sess);
+  edge_eloop_cancel_timeout(data->eloop, radius_server_session_remove_timeout, data,
                        sess);
   radius_msg_free(sess->last_msg);
   os_free(sess->last_from_addr);
@@ -232,7 +232,7 @@ static void radius_server_session_remove(struct radius_server_data *data,
   struct radius_client *client = sess->client;
   struct radius_session *session, *prev;
 
-  eloop_cancel_timeout(data->eloop, radius_server_session_remove_timeout, data,
+  edge_eloop_cancel_timeout(data->eloop, radius_server_session_remove_timeout, data,
                        sess);
 
   prev = NULL;
@@ -287,7 +287,7 @@ radius_server_new_session(struct radius_server_data *data,
   sess->sess_id = data->next_sess_id++;
   sess->next = client->sessions;
   client->sessions = sess;
-  eloop_register_timeout(data->eloop, RADIUS_SESSION_TIMEOUT, 0,
+  edge_eloop_register_timeout(data->eloop, RADIUS_SESSION_TIMEOUT, 0,
                          radius_server_session_timeout, data, sess);
   data->num_sess++;
   return sess;
@@ -611,9 +611,9 @@ static int radius_server_request(struct radius_server_data *data,
   if (is_complete) {
     log_trace("Removing RADIUS completed session 0x%x after timeout",
               sess->sess_id);
-    eloop_cancel_timeout(data->eloop, radius_server_session_remove_timeout,
+    edge_eloop_cancel_timeout(data->eloop, radius_server_session_remove_timeout,
                          data, sess);
-    eloop_register_timeout(data->eloop, RADIUS_SESSION_MAINTAIN, 0,
+    edge_eloop_register_timeout(data->eloop, RADIUS_SESSION_MAINTAIN, 0,
                            radius_server_session_remove_timeout, data, sess);
   }
 
@@ -845,7 +845,7 @@ struct radius_server_data *radius_server_init(struct eloop_data *eloop,
     log_error("Failed to open UDP socket for RADIUS authentication server");
     goto fail;
   }
-  if (eloop_register_read_sock(data->eloop, data->auth_sock,
+  if (edge_eloop_register_read_sock(data->eloop, data->auth_sock,
                                radius_server_receive_auth, data, NULL)) {
     goto fail;
   }
@@ -865,7 +865,7 @@ void radius_server_deinit(struct radius_server_data *data) {
     return;
 
   if (data->auth_sock >= 0) {
-    eloop_unregister_read_sock(data->eloop, data->auth_sock);
+    edge_eloop_unregister_read_sock(data->eloop, data->auth_sock);
     close(data->auth_sock);
   }
 

--- a/src/runctl.c
+++ b/src/runctl.c
@@ -416,7 +416,7 @@ int run_ctl(struct app_config *app_config, struct eloop_data *eloop) {
   }
 
   if (eloop == NULL) {
-    if ((context->eloop = (struct eloop_data *)eloop_init()) == NULL) {
+    if ((context->eloop = (struct eloop_data *)edge_eloop_init()) == NULL) {
       log_error("Failed to initialize event loop");
       goto run_engine_fail;
     }
@@ -549,7 +549,7 @@ int run_ctl(struct app_config *app_config, struct eloop_data *eloop) {
   log_info("Running event loop");
   log_info("++++++++++++++++++");
 
-  eloop_run(context->eloop);
+  edge_eloop_run(context->eloop);
   log_info("Exit event loop");
 
   if (context->exec_capture) {
@@ -582,7 +582,7 @@ int run_ctl(struct app_config *app_config, struct eloop_data *eloop) {
 #endif
   iface_free_context(context->iface_ctx);
   utarray_free(context->config_ifinfo_array);
-  eloop_free(context->eloop);
+  edge_eloop_free(context->eloop);
   os_free(context);
 
   return 0;
@@ -608,7 +608,7 @@ run_engine_fail:
   if (context->config_ifinfo_array != NULL) {
     utarray_free(context->config_ifinfo_array);
   }
-  eloop_free(context->eloop);
+  edge_eloop_free(context->eloop);
   os_free(context);
   return -1;
 }

--- a/src/supervisor/network_commands.c
+++ b/src/supervisor/network_commands.c
@@ -436,10 +436,10 @@ uint8_t *register_ticket_cmd(struct supervisor_context *context,
     return NULL;
   }
 
-  if (eloop_register_timeout(context->eloop, TICKET_TIMEOUT, 0,
+  if (edge_eloop_register_timeout(context->eloop, TICKET_TIMEOUT, 0,
                              eloop_ticket_timeout_handler, NULL,
                              (void *)context) < 0) {
-    log_error("eloop_register_timeout fail");
+    log_error("edge_eloop_register_timeout fail");
     os_free(context->ticket);
     return NULL;
   }

--- a/src/supervisor/network_commands.c
+++ b/src/supervisor/network_commands.c
@@ -437,8 +437,8 @@ uint8_t *register_ticket_cmd(struct supervisor_context *context,
   }
 
   if (edge_eloop_register_timeout(context->eloop, TICKET_TIMEOUT, 0,
-                             eloop_ticket_timeout_handler, NULL,
-                             (void *)context) < 0) {
+                                  eloop_ticket_timeout_handler, NULL,
+                                  (void *)context) < 0) {
     log_error("edge_eloop_register_timeout fail");
     os_free(context->ticket);
     return NULL;

--- a/src/supervisor/supervisor.c
+++ b/src/supervisor/supervisor.c
@@ -364,16 +364,16 @@ int run_supervisor(char *server_path, unsigned int port,
   }
 
   if (edge_eloop_register_read_sock(context->eloop, context->domain_sock,
-                               eloop_read_domain_handler, NULL,
-                               (void *)context) == -1) {
+                                    eloop_read_domain_handler, NULL,
+                                    (void *)context) == -1) {
     log_error("edge_eloop_register_read_sock fail");
     close_supervisor(context);
     return -1;
   }
 
   if (edge_eloop_register_read_sock(context->eloop, context->udp_sock,
-                               eloop_read_udp_handler, NULL,
-                               (void *)context) == -1) {
+                                    eloop_read_udp_handler, NULL,
+                                    (void *)context) == -1) {
     log_error("edge_eloop_register_read_sock fail");
     close_supervisor(context);
     return -1;

--- a/src/supervisor/supervisor.c
+++ b/src/supervisor/supervisor.c
@@ -363,18 +363,18 @@ int run_supervisor(char *server_path, unsigned int port,
     return -1;
   }
 
-  if (eloop_register_read_sock(context->eloop, context->domain_sock,
+  if (edge_eloop_register_read_sock(context->eloop, context->domain_sock,
                                eloop_read_domain_handler, NULL,
                                (void *)context) == -1) {
-    log_error("eloop_register_read_sock fail");
+    log_error("edge_eloop_register_read_sock fail");
     close_supervisor(context);
     return -1;
   }
 
-  if (eloop_register_read_sock(context->eloop, context->udp_sock,
+  if (edge_eloop_register_read_sock(context->eloop, context->udp_sock,
                                eloop_read_udp_handler, NULL,
                                (void *)context) == -1) {
-    log_error("eloop_register_read_sock fail");
+    log_error("edge_eloop_register_read_sock fail");
     close_supervisor(context);
     return -1;
   }

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -59,7 +59,7 @@ add_cmocka_test(test_runctl
 )
 
 target_link_options(test_runctl PRIVATE
-  "LINKER:--wrap=get_vlan_mapper,--wrap=eloop_run,--wrap=get_commands_paths,--wrap=hmap_str_keychar_get"
+  "LINKER:--wrap=get_vlan_mapper,--wrap=edge_eloop_run,--wrap=get_commands_paths,--wrap=hmap_str_keychar_get"
   "LINKER:--wrap=fw_init_context,--wrap=fw_set_ip_forward"
 )
 

--- a/tests/ap/CMakeLists.txt
+++ b/tests/ap/CMakeLists.txt
@@ -21,5 +21,5 @@ add_cmocka_test(test_ap_service
 )
 target_link_options(test_ap_service
   PRIVATE
-  "LINKER:--wrap=close,--wrap=generate_vlan_conf,--wrap=run_ap_process,--wrap=generate_hostapd_conf,--wrap=signal_ap_process,--wrap=create_domain_client,--wrap=eloop_register_read_sock,--wrap=write_domain_data_s,--wrap=writeread_domain_data_str"
+  "LINKER:--wrap=close,--wrap=generate_vlan_conf,--wrap=run_ap_process,--wrap=generate_hostapd_conf,--wrap=signal_ap_process,--wrap=create_domain_client,--wrap=edge_eloop_register_read_sock,--wrap=write_domain_data_s,--wrap=writeread_domain_data_str"
 )

--- a/tests/ap/test_ap_service.c
+++ b/tests/ap/test_ap_service.c
@@ -59,7 +59,7 @@ int __wrap_create_domain_client(char *addr) {
 }
 
 int __wrap_edge_eloop_register_read_sock(int sock, eloop_sock_handler handler,
-                                    void *eloop_data, void *user_data) {
+                                         void *eloop_data, void *user_data) {
   (void)sock;
   (void)handler;
   (void)eloop_data;

--- a/tests/ap/test_ap_service.c
+++ b/tests/ap/test_ap_service.c
@@ -58,7 +58,7 @@ int __wrap_create_domain_client(char *addr) {
   return 0;
 }
 
-int __wrap_eloop_register_read_sock(int sock, eloop_sock_handler handler,
+int __wrap_edge_eloop_register_read_sock(int sock, eloop_sock_handler handler,
                                     void *eloop_data, void *user_data) {
   (void)sock;
   (void)handler;

--- a/tests/capture/CMakeLists.txt
+++ b/tests/capture/CMakeLists.txt
@@ -10,5 +10,5 @@ add_cmocka_test(test_capture_service
 )
 target_link_options(test_capture_service
   PRIVATE
-  "LINKER:--wrap=open_sqlite_header_db,--wrap=open_sqlite_pcap_db,--wrap=free_sqlite_header_db,--wrap=free_sqlite_pcap_db,--wrap=run_pcap,--wrap=close_pcap,--wrap=eloop_init,--wrap=eloop_register_read_sock,--wrap=eloop_register_timeout,--wrap=eloop_run,--wrap=eloop_free,--wrap=run_register_db,--wrap=extract_packets,--wrap=push_packet_queue,--wrap=push_pcap_queue"
+  "LINKER:--wrap=open_sqlite_header_db,--wrap=open_sqlite_pcap_db,--wrap=free_sqlite_header_db,--wrap=free_sqlite_pcap_db,--wrap=run_pcap,--wrap=close_pcap,--wrap=edge_eloop_init,--wrap=edge_eloop_register_read_sock,--wrap=edge_eloop_register_timeout,--wrap=edge_eloop_run,--wrap=edge_eloop_free,--wrap=run_register_db,--wrap=extract_packets,--wrap=push_packet_queue,--wrap=push_pcap_queue"
 )

--- a/tests/capture/test_capture_service.c
+++ b/tests/capture/test_capture_service.c
@@ -64,8 +64,8 @@ struct eloop_data *__wrap_edge_eloop_init(void) {
 }
 
 int __wrap_edge_eloop_register_read_sock(struct eloop_data *eloop, int sock,
-                                    eloop_sock_handler handler,
-                                    void *eloop_data, void *user_data) {
+                                         eloop_sock_handler handler,
+                                         void *eloop_data, void *user_data) {
   (void)eloop;
   (void)sock;
   (void)handler;
@@ -75,10 +75,10 @@ int __wrap_edge_eloop_register_read_sock(struct eloop_data *eloop, int sock,
   return 0;
 }
 
-int __wrap_edge_eloop_register_timeout(struct eloop_data *eloop, unsigned long secs,
-                                  unsigned long usecs,
-                                  eloop_timeout_handler handler,
-                                  void *eloop_data, void *user_data) {
+int __wrap_edge_eloop_register_timeout(struct eloop_data *eloop,
+                                       unsigned long secs, unsigned long usecs,
+                                       eloop_timeout_handler handler,
+                                       void *eloop_data, void *user_data) {
   (void)eloop;
   (void)secs;
   (void)usecs;

--- a/tests/capture/test_capture_service.c
+++ b/tests/capture/test_capture_service.c
@@ -59,11 +59,11 @@ void __wrap_close_pcap(struct pcap_context *ctx) {
     os_free(ctx);
 }
 
-struct eloop_data *__wrap_eloop_init(void) {
+struct eloop_data *__wrap_edge_eloop_init(void) {
   return (struct eloop_data *)&test_eloop;
 }
 
-int __wrap_eloop_register_read_sock(struct eloop_data *eloop, int sock,
+int __wrap_edge_eloop_register_read_sock(struct eloop_data *eloop, int sock,
                                     eloop_sock_handler handler,
                                     void *eloop_data, void *user_data) {
   (void)eloop;
@@ -75,7 +75,7 @@ int __wrap_eloop_register_read_sock(struct eloop_data *eloop, int sock,
   return 0;
 }
 
-int __wrap_eloop_register_timeout(struct eloop_data *eloop, unsigned long secs,
+int __wrap_edge_eloop_register_timeout(struct eloop_data *eloop, unsigned long secs,
                                   unsigned long usecs,
                                   eloop_timeout_handler handler,
                                   void *eloop_data, void *user_data) {
@@ -89,9 +89,9 @@ int __wrap_eloop_register_timeout(struct eloop_data *eloop, unsigned long secs,
   return 0;
 }
 
-void __wrap_eloop_run(struct eloop_data *eloop) { (void)eloop; }
+void __wrap_edge_eloop_run(struct eloop_data *eloop) { (void)eloop; }
 
-void __wrap_eloop_free(struct eloop_data *eloop) { (void)eloop; }
+void __wrap_edge_eloop_free(struct eloop_data *eloop) { (void)eloop; }
 
 uint32_t __wrap_run_register_db(char *address, char *name) {
   (void)address;

--- a/tests/dns/CMakeLists.txt
+++ b/tests/dns/CMakeLists.txt
@@ -29,6 +29,6 @@ if (USE_MDNS_SERVICE AND USE_CAPTURE_SERVICE)
   )
   target_link_options(test_mdns_service
     PRIVATE
-    "LINKER:--wrap=run_pcap,--wrap=eloop_register_read_sock,--wrap=eloop_init,--wrap=eloop_run,--wrap=eloop_free"
+    "LINKER:--wrap=run_pcap,--wrap=edge_eloop_register_read_sock,--wrap=edge_eloop_init,--wrap=edge_eloop_run,--wrap=edge_eloop_free"
   )
 endif ()

--- a/tests/dns/test_mdns_service.c
+++ b/tests/dns/test_mdns_service.c
@@ -37,7 +37,7 @@ int __wrap_run_pcap(char *interface, bool immediate, bool promiscuous,
   return 0;
 }
 
-int __wrap_eloop_register_read_sock(struct eloop_data *eloop, int sock,
+int __wrap_edge_eloop_register_read_sock(struct eloop_data *eloop, int sock,
                                     eloop_sock_handler handler,
                                     void *eloop_data, void *user_data) {
   (void)eloop;
@@ -49,13 +49,13 @@ int __wrap_eloop_register_read_sock(struct eloop_data *eloop, int sock,
   return 0;
 }
 
-struct eloop_data *__wrap_eloop_init(void) {
+struct eloop_data *__wrap_edge_eloop_init(void) {
   return mock_ptr_type(struct eloop_data *);
 }
 
-void __wrap_eloop_free(struct eloop_data *eloop) { os_free(eloop); }
+void __wrap_edge_eloop_free(struct eloop_data *eloop) { os_free(eloop); }
 
-void __wrap_eloop_run(struct eloop_data *eloop) { (void)eloop; }
+void __wrap_edge_eloop_run(struct eloop_data *eloop) { (void)eloop; }
 
 static void test_run_mdns(void **state) {
   (void)state;
@@ -63,7 +63,7 @@ static void test_run_mdns(void **state) {
   struct mdns_context context;
   struct eloop_data *eloop = os_zalloc(sizeof(struct eloop_data));
 
-  will_return(__wrap_eloop_init, eloop);
+  will_return(__wrap_edge_eloop_init, eloop);
   assert_int_equal(run_mdns(&context), 0);
   close_mdns(&context);
 }
@@ -73,7 +73,7 @@ static void test_close_mdns(void **state) {
 
   struct mdns_context context;
   struct eloop_data *eloop = os_zalloc(sizeof(struct eloop_data));
-  will_return(__wrap_eloop_init, eloop);
+  will_return(__wrap_edge_eloop_init, eloop);
   run_mdns(&context);
   assert_int_equal(close_mdns(&context), 0);
 }

--- a/tests/dns/test_mdns_service.c
+++ b/tests/dns/test_mdns_service.c
@@ -38,8 +38,8 @@ int __wrap_run_pcap(char *interface, bool immediate, bool promiscuous,
 }
 
 int __wrap_edge_eloop_register_read_sock(struct eloop_data *eloop, int sock,
-                                    eloop_sock_handler handler,
-                                    void *eloop_data, void *user_data) {
+                                         eloop_sock_handler handler,
+                                         void *eloop_data, void *user_data) {
   (void)eloop;
   (void)sock;
   (void)handler;

--- a/tests/radius/radius_client.c
+++ b/tests/radius/radius_client.c
@@ -555,7 +555,7 @@ static void radius_client_timer(void *eloop_ctx, void *timeout_ctx) {
       first = now.sec;
     edge_eloop_cancel_timeout(radius->eloop, radius_client_timer, radius, NULL);
     edge_eloop_register_timeout(radius->eloop, first - now.sec, 0,
-                           radius_client_timer, radius, NULL);
+                                radius_client_timer, radius, NULL);
     log_trace("Next RADIUS client retransmit in %ld seconds",
               (long int)(first - now.sec));
   }
@@ -628,8 +628,8 @@ static void radius_client_update_timeout(struct radius_client_data *radius) {
   os_get_reltime(&now);
   if (first < now.sec)
     first = now.sec;
-  edge_eloop_register_timeout(radius->eloop, first - now.sec, 0, radius_client_timer,
-                         radius, NULL);
+  edge_eloop_register_timeout(radius->eloop, first - now.sec, 0,
+                              radius_client_timer, radius, NULL);
   log_trace("Next RADIUS client retransmit in %ld seconds",
             (long int)(first - now.sec));
 }
@@ -1056,7 +1056,7 @@ static int radius_change_server(struct radius_client_data *radius,
   if (radius->msgs) {
     edge_eloop_cancel_timeout(radius->eloop, radius_client_timer, radius, NULL);
     edge_eloop_register_timeout(radius->eloop, RADIUS_CLIENT_FIRST_WAIT, 0,
-                           radius_client_timer, radius, NULL);
+                                radius_client_timer, radius, NULL);
   }
 
   switch (nserv->addr.af) {
@@ -1197,7 +1197,7 @@ static void radius_retry_primary_timer(void *eloop_ctx, void *timeout_ctx) {
 
   if (conf->retry_primary_interval)
     edge_eloop_register_timeout(radius->eloop, conf->retry_primary_interval, 0,
-                           radius_retry_primary_timer, radius, NULL);
+                                radius_retry_primary_timer, radius, NULL);
 }
 
 static int radius_client_disable_pmtu_discovery(int s) {
@@ -1279,8 +1279,8 @@ static int radius_client_init_auth(struct radius_client_data *radius) {
 
   if (radius->auth_serv_sock >= 0 &&
       edge_eloop_register_read_sock(radius->eloop, radius->auth_serv_sock,
-                               radius_client_receive, radius,
-                               (void *)RADIUS_AUTH)) {
+                                    radius_client_receive, radius,
+                                    (void *)RADIUS_AUTH)) {
     log_trace(
         "RADIUS: Could not register read socket for authentication server");
     radius_close_auth_sockets(radius);
@@ -1289,8 +1289,9 @@ static int radius_client_init_auth(struct radius_client_data *radius) {
 
 #ifdef CONFIG_IPV6
   if (radius->auth_serv_sock6 >= 0 &&
-      edge_eloop_register_read_sock(radius->auth_serv_sock6, radius_client_receive,
-                               radius, (void *)RADIUS_AUTH)) {
+      edge_eloop_register_read_sock(radius->auth_serv_sock6,
+                                    radius_client_receive, radius,
+                                    (void *)RADIUS_AUTH)) {
     wpa_printf(
         MSG_INFO,
         "RADIUS: Could not register read socket for authentication server");
@@ -1333,8 +1334,8 @@ static int radius_client_init_acct(struct radius_client_data *radius) {
 
   if (radius->acct_serv_sock >= 0 &&
       edge_eloop_register_read_sock(radius->eloop, radius->acct_serv_sock,
-                               radius_client_receive, radius,
-                               (void *)RADIUS_ACCT)) {
+                                    radius_client_receive, radius,
+                                    (void *)RADIUS_ACCT)) {
     log_trace("RADIUS: Could not register read socket for accounting server");
     radius_close_acct_sockets(radius);
     return -1;
@@ -1342,8 +1343,9 @@ static int radius_client_init_acct(struct radius_client_data *radius) {
 
 #ifdef CONFIG_IPV6
   if (radius->acct_serv_sock6 >= 0 &&
-      edge_eloop_register_read_sock(radius->acct_serv_sock6, radius_client_receive,
-                               radius, (void *)RADIUS_ACCT)) {
+      edge_eloop_register_read_sock(radius->acct_serv_sock6,
+                                    radius_client_receive, radius,
+                                    (void *)RADIUS_ACCT)) {
     wpa_printf(MSG_INFO,
                "RADIUS: Could not register read socket for accounting server");
     radius_close_acct_sockets(radius);
@@ -1398,7 +1400,7 @@ radius_client_init(struct eloop_data *eloop, void *ctx,
 
   if (conf->retry_primary_interval)
     edge_eloop_register_timeout(radius->eloop, conf->retry_primary_interval, 0,
-                           radius_retry_primary_timer, radius, NULL);
+                                radius_retry_primary_timer, radius, NULL);
 
   return radius;
 }
@@ -1415,7 +1417,8 @@ void radius_client_deinit(struct radius_client_data *radius) {
   radius_close_auth_sockets(radius);
   radius_close_acct_sockets(radius);
 
-  edge_eloop_cancel_timeout(radius->eloop, radius_retry_primary_timer, radius, NULL);
+  edge_eloop_cancel_timeout(radius->eloop, radius_retry_primary_timer, radius,
+                            NULL);
 
   radius_client_flush(radius, 0);
   os_free(radius->auth_handlers);

--- a/tests/radius/radius_client.c
+++ b/tests/radius/radius_client.c
@@ -553,8 +553,8 @@ static void radius_client_timer(void *eloop_ctx, void *timeout_ctx) {
   if (radius->msgs) {
     if (first < now.sec)
       first = now.sec;
-    eloop_cancel_timeout(radius->eloop, radius_client_timer, radius, NULL);
-    eloop_register_timeout(radius->eloop, first - now.sec, 0,
+    edge_eloop_cancel_timeout(radius->eloop, radius_client_timer, radius, NULL);
+    edge_eloop_register_timeout(radius->eloop, first - now.sec, 0,
                            radius_client_timer, radius, NULL);
     log_trace("Next RADIUS client retransmit in %ld seconds",
               (long int)(first - now.sec));
@@ -613,7 +613,7 @@ static void radius_client_update_timeout(struct radius_client_data *radius) {
   os_time_t first;
   struct radius_msg_list *entry;
 
-  eloop_cancel_timeout(radius->eloop, radius_client_timer, radius, NULL);
+  edge_eloop_cancel_timeout(radius->eloop, radius_client_timer, radius, NULL);
 
   if (radius->msgs == NULL) {
     return;
@@ -628,7 +628,7 @@ static void radius_client_update_timeout(struct radius_client_data *radius) {
   os_get_reltime(&now);
   if (first < now.sec)
     first = now.sec;
-  eloop_register_timeout(radius->eloop, first - now.sec, 0, radius_client_timer,
+  edge_eloop_register_timeout(radius->eloop, first - now.sec, 0, radius_client_timer,
                          radius, NULL);
   log_trace("Next RADIUS client retransmit in %ld seconds",
             (long int)(first - now.sec));
@@ -641,7 +641,7 @@ static void radius_client_list_add(struct radius_client_data *radius,
                                    const uint8_t *addr) {
   struct radius_msg_list *entry, *prev;
 
-  if (eloop_terminated(radius->eloop)) {
+  if (edge_eloop_terminated(radius->eloop)) {
     /* No point in adding entries to retransmit queue since event
      * loop has already been terminated. */
     radius_msg_free(msg);
@@ -977,7 +977,7 @@ void radius_client_flush(struct radius_client_data *radius, int only_auth) {
   }
 
   if (radius->msgs == NULL)
-    eloop_cancel_timeout(radius->eloop, radius_client_timer, radius, NULL);
+    edge_eloop_cancel_timeout(radius->eloop, radius_client_timer, radius, NULL);
 }
 
 static void radius_client_update_acct_msgs(struct radius_client_data *radius,
@@ -1054,8 +1054,8 @@ static int radius_change_server(struct radius_client_data *radius,
   }
 
   if (radius->msgs) {
-    eloop_cancel_timeout(radius->eloop, radius_client_timer, radius, NULL);
-    eloop_register_timeout(radius->eloop, RADIUS_CLIENT_FIRST_WAIT, 0,
+    edge_eloop_cancel_timeout(radius->eloop, radius_client_timer, radius, NULL);
+    edge_eloop_register_timeout(radius->eloop, RADIUS_CLIENT_FIRST_WAIT, 0,
                            radius_client_timer, radius, NULL);
   }
 
@@ -1196,7 +1196,7 @@ static void radius_retry_primary_timer(void *eloop_ctx, void *timeout_ctx) {
   }
 
   if (conf->retry_primary_interval)
-    eloop_register_timeout(radius->eloop, conf->retry_primary_interval, 0,
+    edge_eloop_register_timeout(radius->eloop, conf->retry_primary_interval, 0,
                            radius_retry_primary_timer, radius, NULL);
 }
 
@@ -1218,13 +1218,13 @@ static void radius_close_auth_sockets(struct radius_client_data *radius) {
   radius->auth_sock = -1;
 
   if (radius->auth_serv_sock >= 0) {
-    eloop_unregister_read_sock(radius->eloop, radius->auth_serv_sock);
+    edge_eloop_unregister_read_sock(radius->eloop, radius->auth_serv_sock);
     close(radius->auth_serv_sock);
     radius->auth_serv_sock = -1;
   }
 #ifdef CONFIG_IPV6
   if (radius->auth_serv_sock6 >= 0) {
-    eloop_unregister_read_sock(radius->auth_serv_sock6);
+    edge_eloop_unregister_read_sock(radius->auth_serv_sock6);
     close(radius->auth_serv_sock6);
     radius->auth_serv_sock6 = -1;
   }
@@ -1235,13 +1235,13 @@ static void radius_close_acct_sockets(struct radius_client_data *radius) {
   radius->acct_sock = -1;
 
   if (radius->acct_serv_sock >= 0) {
-    eloop_unregister_read_sock(radius->eloop, radius->acct_serv_sock);
+    edge_eloop_unregister_read_sock(radius->eloop, radius->acct_serv_sock);
     close(radius->acct_serv_sock);
     radius->acct_serv_sock = -1;
   }
 #ifdef CONFIG_IPV6
   if (radius->acct_serv_sock6 >= 0) {
-    eloop_unregister_read_sock(radius->acct_serv_sock6);
+    edge_eloop_unregister_read_sock(radius->acct_serv_sock6);
     close(radius->acct_serv_sock6);
     radius->acct_serv_sock6 = -1;
   }
@@ -1278,7 +1278,7 @@ static int radius_client_init_auth(struct radius_client_data *radius) {
                        radius->auth_serv_sock6, 1);
 
   if (radius->auth_serv_sock >= 0 &&
-      eloop_register_read_sock(radius->eloop, radius->auth_serv_sock,
+      edge_eloop_register_read_sock(radius->eloop, radius->auth_serv_sock,
                                radius_client_receive, radius,
                                (void *)RADIUS_AUTH)) {
     log_trace(
@@ -1289,7 +1289,7 @@ static int radius_client_init_auth(struct radius_client_data *radius) {
 
 #ifdef CONFIG_IPV6
   if (radius->auth_serv_sock6 >= 0 &&
-      eloop_register_read_sock(radius->auth_serv_sock6, radius_client_receive,
+      edge_eloop_register_read_sock(radius->auth_serv_sock6, radius_client_receive,
                                radius, (void *)RADIUS_AUTH)) {
     wpa_printf(
         MSG_INFO,
@@ -1332,7 +1332,7 @@ static int radius_client_init_acct(struct radius_client_data *radius) {
                        radius->acct_serv_sock6, 0);
 
   if (radius->acct_serv_sock >= 0 &&
-      eloop_register_read_sock(radius->eloop, radius->acct_serv_sock,
+      edge_eloop_register_read_sock(radius->eloop, radius->acct_serv_sock,
                                radius_client_receive, radius,
                                (void *)RADIUS_ACCT)) {
     log_trace("RADIUS: Could not register read socket for accounting server");
@@ -1342,7 +1342,7 @@ static int radius_client_init_acct(struct radius_client_data *radius) {
 
 #ifdef CONFIG_IPV6
   if (radius->acct_serv_sock6 >= 0 &&
-      eloop_register_read_sock(radius->acct_serv_sock6, radius_client_receive,
+      edge_eloop_register_read_sock(radius->acct_serv_sock6, radius_client_receive,
                                radius, (void *)RADIUS_ACCT)) {
     wpa_printf(MSG_INFO,
                "RADIUS: Could not register read socket for accounting server");
@@ -1397,7 +1397,7 @@ radius_client_init(struct eloop_data *eloop, void *ctx,
   }
 
   if (conf->retry_primary_interval)
-    eloop_register_timeout(radius->eloop, conf->retry_primary_interval, 0,
+    edge_eloop_register_timeout(radius->eloop, conf->retry_primary_interval, 0,
                            radius_retry_primary_timer, radius, NULL);
 
   return radius;
@@ -1415,7 +1415,7 @@ void radius_client_deinit(struct radius_client_data *radius) {
   radius_close_auth_sockets(radius);
   radius_close_acct_sockets(radius);
 
-  eloop_cancel_timeout(radius->eloop, radius_retry_primary_timer, radius, NULL);
+  edge_eloop_cancel_timeout(radius->eloop, radius_retry_primary_timer, radius, NULL);
 
   radius_client_flush(radius, 0);
   os_free(radius->auth_handlers);

--- a/tests/radius/test_radius_server.c
+++ b/tests/radius/test_radius_server.c
@@ -69,7 +69,7 @@ static RadiusRxResult receive_auth(struct radius_msg *msg,
             radius_msg_get_hdr(msg)->code);
 
   /* We're done for this example, so request eloop to terminate. */
-  eloop_terminate(eloop);
+  edge_eloop_terminate(eloop);
 
   return RADIUS_RX_PROCESSED;
 }
@@ -151,7 +151,7 @@ static void test_radius_server_init(void **state) {
 
   inet_aton(conf.radius_client_ip, &ctx.own_ip_addr);
 
-  eloop = eloop_init();
+  eloop = edge_eloop_init();
   assert_non_null(eloop);
 
   srv = os_zalloc(sizeof(*srv));
@@ -178,9 +178,9 @@ static void test_radius_server_init(void **state) {
   radius_srv = radius_server_init(eloop, srv->port, client);
   assert_non_null(radius_srv);
 
-  eloop_register_timeout(eloop, 0, 0, start_test, &ctx, NULL);
+  edge_eloop_register_timeout(eloop, 0, 0, start_test, &ctx, NULL);
 
-  eloop_run(eloop);
+  edge_eloop_run(eloop);
 
   int cmp = memcmp(&saved_addr[0], &addr[0], 6);
   assert_int_equal(cmp, 0);
@@ -190,7 +190,7 @@ static void test_radius_server_init(void **state) {
   os_free(srv->shared_secret);
   os_free(srv);
 
-  eloop_free(eloop);
+  edge_eloop_free(eloop);
 }
 
 int main(int argc, char *argv[]) {

--- a/tests/test_edgesec.c
+++ b/tests/test_edgesec.c
@@ -72,9 +72,9 @@ void *ap_server_thread(void *arg) {
   assert_int_not_equal(fd, -1);
 
   assert_int_not_equal(
-      eloop_register_read_sock(eloop, fd, ap_eloop, (void *)eloop, NULL), -1);
+      edge_eloop_register_read_sock(eloop, fd, ap_eloop, (void *)eloop, NULL), -1);
 
-  eloop_run(eloop);
+  edge_eloop_run(eloop);
   log_trace("AP server thread end");
   assert_int_equal(close_domain_socket(fd), 0);
   return NULL;
@@ -94,7 +94,7 @@ static RadiusRxResult receive_auth(struct radius_msg *msg,
             radius_msg_get_hdr(msg)->code);
 
   /* We're done for this example, so request eloop to terminate. */
-  eloop_terminate(eloop);
+  edge_eloop_terminate(eloop);
 
   return RADIUS_RX_PROCESSED;
 }
@@ -146,7 +146,7 @@ void *supervisor_client_thread(void *arg) {
                                            .num_auth_servers = 1,
                                            .msg_dumps = 1};
 
-  struct eloop_data *eloop = eloop_init();
+  struct eloop_data *eloop = edge_eloop_init();
   struct radius_client_data *radius =
       radius_client_init(eloop, /*ctx*/ eloop, &servers);
   assert_non_null(radius);
@@ -183,8 +183,8 @@ void *supervisor_client_thread(void *arg) {
 
   assert_int_not_equal(radius_client_send(radius, msg, RADIUS_AUTH, addr), -1);
 
-  eloop_run(eloop);
-  eloop_free(eloop);
+  edge_eloop_run(eloop);
+  edge_eloop_free(eloop);
 
   char command[128];
   snprintf(command, 128, "%s 00:01:02:03:04:05", CMD_GET_MAP);
@@ -196,7 +196,7 @@ void *supervisor_client_thread(void *arg) {
     os_free(reply);
   }
 
-  eloop_terminate(main_eloop);
+  edge_eloop_terminate(main_eloop);
 
   // Send a PING command to terminate the eloop
   writeread_domain_data_str(socket_path, CMD_PING, &reply);
@@ -223,10 +223,10 @@ static void test_edgesec(void **state) {
 
   os_init_random_seed();
 
-  struct eloop_data *main_eloop = eloop_init();
+  struct eloop_data *main_eloop = edge_eloop_init();
 
   pthread_t ap_id = 0;
-  struct eloop_data *ap_eloop = eloop_init();
+  struct eloop_data *ap_eloop = edge_eloop_init();
   assert_int_equal(
       pthread_create(&ap_id, NULL, ap_server_thread, (void *)ap_eloop), 0);
 
@@ -237,9 +237,9 @@ static void test_edgesec(void **state) {
 
   assert_int_equal(run_ctl(&config, main_eloop), 0);
 
-  eloop_terminate(ap_eloop);
+  edge_eloop_terminate(ap_eloop);
 
-  eloop_free(ap_eloop);
+  edge_eloop_free(ap_eloop);
   free_app_config(&config);
   pthread_mutex_destroy(&log_lock);
 }

--- a/tests/test_edgesec.c
+++ b/tests/test_edgesec.c
@@ -72,7 +72,8 @@ void *ap_server_thread(void *arg) {
   assert_int_not_equal(fd, -1);
 
   assert_int_not_equal(
-      edge_eloop_register_read_sock(eloop, fd, ap_eloop, (void *)eloop, NULL), -1);
+      edge_eloop_register_read_sock(eloop, fd, ap_eloop, (void *)eloop, NULL),
+      -1);
 
   edge_eloop_run(eloop);
   log_trace("AP server thread end");

--- a/tests/test_runctl.c
+++ b/tests/test_runctl.c
@@ -34,7 +34,7 @@ int __wrap_get_vlan_mapper(hmap_vlan_conn **hmap, int vlanid,
   return (int)mock();
 }
 
-void __wrap_eloop_run(struct eloop_data *eloop) { (void)eloop; }
+void __wrap_edge_eloop_run(struct eloop_data *eloop) { (void)eloop; }
 
 int __wrap_get_commands_paths(char *commands[], UT_array *bin_path_arr,
                               hmap_str_keychar **hmap_bin_paths) {

--- a/tests/utils/test_eloop.c
+++ b/tests/utils/test_eloop.c
@@ -102,17 +102,17 @@ static void test_eloop_timeout(void **state) {
 
   // check if timeout is registered
   assert_false(edge_eloop_is_timeout_registered(test_state->eloop,
-                                           eloop_timeout_handler_function,
-                                           eloop_data, user_data));
+                                                eloop_timeout_handler_function,
+                                                eloop_data, user_data));
   expect_string(eloop_timeout_handler_function, eloop_ctx, eloop_data);
   expect_string(eloop_timeout_handler_function, user_ctx, user_data);
   assert_return_code(edge_eloop_register_timeout(test_state->eloop, 0, 1,
-                                            eloop_timeout_handler_function,
-                                            eloop_data, user_data),
+                                                 eloop_timeout_handler_function,
+                                                 eloop_data, user_data),
                      0);
   assert_true(edge_eloop_is_timeout_registered(test_state->eloop,
-                                          eloop_timeout_handler_function,
-                                          eloop_data, user_data));
+                                               eloop_timeout_handler_function,
+                                               eloop_data, user_data));
 
   // basic test
   char eloop_data1[] = "this is eloop data: run 1";
@@ -120,34 +120,34 @@ static void test_eloop_timeout(void **state) {
   expect_string(eloop_timeout_handler_function, eloop_ctx, eloop_data1);
   expect_string(eloop_timeout_handler_function, user_ctx, user_data1);
   assert_return_code(edge_eloop_register_timeout(test_state->eloop, 0, 100,
-                                            eloop_timeout_handler_function,
-                                            eloop_data1, user_data1),
+                                                 eloop_timeout_handler_function,
+                                                 eloop_data1, user_data1),
                      0);
 
   // test cancelling timeouts
   char eloop_data2[] = "this is eloop data: run 2";
   char user_data2[] = "this is user data: run 2";
   assert_return_code(edge_eloop_register_timeout(test_state->eloop, 0, 200,
-                                            eloop_timeout_handler_function,
-                                            eloop_data2, user_data2),
+                                                 eloop_timeout_handler_function,
+                                                 eloop_data2, user_data2),
                      0);
-  assert_int_equal(
-      edge_eloop_cancel_timeout(test_state->eloop, eloop_timeout_handler_function,
-                           eloop_data2, user_data2),
-      1 // should cancel only all = one timeout
+  assert_int_equal(edge_eloop_cancel_timeout(test_state->eloop,
+                                             eloop_timeout_handler_function,
+                                             eloop_data2, user_data2),
+                   1 // should cancel only all = one timeout
   );
 
   assert_return_code(edge_eloop_register_timeout(test_state->eloop, 1, 0,
-                                            eloop_timeout_handler_function,
-                                            eloop_data2, user_data2),
+                                                 eloop_timeout_handler_function,
+                                                 eloop_data2, user_data2),
                      0);
   assert_return_code(edge_eloop_register_timeout(test_state->eloop, 2, 0,
-                                            eloop_timeout_handler_function,
-                                            eloop_data2, user_data2),
+                                                 eloop_timeout_handler_function,
+                                                 eloop_data2, user_data2),
                      0);
   assert_return_code(edge_eloop_register_timeout(test_state->eloop, 3, 0,
-                                            eloop_timeout_handler_function,
-                                            eloop_data2, user_data2),
+                                                 eloop_timeout_handler_function,
+                                                 eloop_data2, user_data2),
                      0);
 
   struct os_reltime remaining = {0};
@@ -156,10 +156,10 @@ static void test_eloop_timeout(void **state) {
                        eloop_data2, user_data2, &remaining),
                    1 // should cancel only one timeout
   );
-  assert_int_equal(
-      edge_eloop_cancel_timeout(test_state->eloop, eloop_timeout_handler_function,
-                           eloop_data2, user_data2),
-      2 // should cancel all = two timeouts
+  assert_int_equal(edge_eloop_cancel_timeout(test_state->eloop,
+                                             eloop_timeout_handler_function,
+                                             eloop_data2, user_data2),
+                   2 // should cancel all = two timeouts
   );
 
   char eloop_data3[] = "this is eloop data: run 3";
@@ -167,8 +167,8 @@ static void test_eloop_timeout(void **state) {
   expect_string(eloop_timeout_handler_function, eloop_ctx, eloop_data3);
   expect_string(eloop_timeout_handler_function, user_ctx, user_data3);
   assert_return_code(edge_eloop_register_timeout(test_state->eloop, 0, 300,
-                                            eloop_timeout_handler_function,
-                                            eloop_data3, user_data3),
+                                                 eloop_timeout_handler_function,
+                                                 eloop_data3, user_data3),
                      0);
 
   // test depleting (shortening) timeouts
@@ -176,21 +176,21 @@ static void test_eloop_timeout(void **state) {
   expect_string(eloop_timeout_handler_function, eloop_ctx, eloop_data4);
   expect_string(eloop_timeout_handler_function, user_ctx, user_data);
   assert_return_code(edge_eloop_register_timeout(test_state->eloop, 120,
-                                            0, // super long time
-                                            eloop_timeout_handler_function,
-                                            eloop_data4, user_data),
+                                                 0, // super long time
+                                                 eloop_timeout_handler_function,
+                                                 eloop_data4, user_data),
                      0);
   assert_int_equal(edge_eloop_deplete_timeout(
                        test_state->eloop, 100000, 0, // longer, so no change
                        eloop_timeout_handler_function, eloop_data4, user_data),
                    0);
-  assert_int_equal(edge_eloop_deplete_timeout(test_state->eloop, 1, 0,
-                                         eloop_timeout_handler_function,
-                                         "this data does not exist", user_data),
+  assert_int_equal(edge_eloop_deplete_timeout(
+                       test_state->eloop, 1, 0, eloop_timeout_handler_function,
+                       "this data does not exist", user_data),
                    -1);
   assert_int_equal(edge_eloop_deplete_timeout(test_state->eloop, 0, 400,
-                                         eloop_timeout_handler_function,
-                                         eloop_data4, user_data),
+                                              eloop_timeout_handler_function,
+                                              eloop_data4, user_data),
                    1);
 
   // test replenishing (lengthening) timeouts
@@ -198,22 +198,22 @@ static void test_eloop_timeout(void **state) {
   expect_string(eloop_timeout_handler_function, eloop_ctx, eloop_data5);
   expect_string(eloop_timeout_handler_function, user_ctx, user_data);
   assert_return_code(edge_eloop_register_timeout(test_state->eloop, 0,
-                                            2, // super short time
-                                            eloop_timeout_handler_function,
-                                            eloop_data5, user_data),
+                                                 2, // super short time
+                                                 eloop_timeout_handler_function,
+                                                 eloop_data5, user_data),
                      0);
   assert_int_equal(edge_eloop_replenish_timeout(
                        test_state->eloop, 0, 1, // no change, should return 0
                        eloop_timeout_handler_function, eloop_data5, user_data),
                    0);
   assert_int_equal(edge_eloop_replenish_timeout(test_state->eloop, 100000, 0,
-                                           eloop_timeout_handler_function,
-                                           "this data does not exist",
-                                           user_data),
+                                                eloop_timeout_handler_function,
+                                                "this data does not exist",
+                                                user_data),
                    -1);
   assert_int_equal(edge_eloop_replenish_timeout(test_state->eloop, 0, 500,
-                                           eloop_timeout_handler_function,
-                                           eloop_data5, user_data),
+                                                eloop_timeout_handler_function,
+                                                eloop_data5, user_data),
                    1);
 
   log_debug("Starting eloop");
@@ -241,8 +241,9 @@ static void test_edge_eloop_register_read_sock(void **state) {
   int cs = create_domain_client(NULL);
   assert_int_not_equal(cs, -1);
 
-  int eret = edge_eloop_register_read_sock(eloop, ss, test_eloop_sock_handler_read,
-                                      (void *)eloop, (void *)eloop_param);
+  int eret =
+      edge_eloop_register_read_sock(eloop, ss, test_eloop_sock_handler_read,
+                                    (void *)eloop, (void *)eloop_param);
   assert_int_not_equal(eret, -1);
 
   memset(&svaddr, 0, sizeof(struct sockaddr_un));
@@ -273,8 +274,8 @@ static void test_edge_eloop_unregister_read_sock(void **state) {
 
   assert_int_not_equal(ss, -1);
 
-  int ret = edge_eloop_register_read_sock(eloop, ss, test_eloop_sock_handler_unreg,
-                                     NULL, NULL);
+  int ret = edge_eloop_register_read_sock(
+      eloop, ss, test_eloop_sock_handler_unreg, NULL, NULL);
   assert_int_not_equal(ret, -1);
 
   edge_eloop_unregister_read_sock(eloop, ss);
@@ -292,7 +293,7 @@ static void test_edge_eloop_register_timeout(void **state) {
   char buf[100] = {0};
   struct eloop_data *eloop = edge_eloop_init();
   int ret = edge_eloop_register_timeout(eloop, 0, 0, test_eloop_timeout_handler,
-                                   eloop, (void *)buf);
+                                        eloop, (void *)buf);
 
   assert_int_not_equal(ret, -1);
   edge_eloop_run(eloop);
@@ -306,12 +307,12 @@ static void test_edge_eloop_cancel_timeout(void **state) {
   char buf[100] = {0};
   struct eloop_data *eloop = edge_eloop_init();
   int ret = edge_eloop_register_timeout(eloop, 0, 0, test_eloop_timeout_handler,
-                                   eloop, (void *)buf);
+                                        eloop, (void *)buf);
 
   assert_int_not_equal(ret, -1);
 
   ret = edge_eloop_cancel_timeout(eloop, test_eloop_timeout_handler, eloop,
-                             (void *)buf);
+                                  (void *)buf);
   edge_eloop_run(eloop);
   assert_string_equal(buf, "");
   edge_eloop_free(eloop);

--- a/tests/utils/test_eloop.c
+++ b/tests/utils/test_eloop.c
@@ -32,7 +32,7 @@ void test_eloop_sock_handler_read(int sock, void *eloop_ctx, void *sock_ctx) {
   read_socket_data(sock, read_buf, sizeof(read_buf), &addr, 0);
   assert_string_equal(read_buf, TEST_SEND_BUF_DATA);
 
-  eloop_terminate(eloop);
+  edge_eloop_terminate(eloop);
 }
 
 void test_eloop_sock_handler_unreg(int sock, void *eloop_ctx, void *sock_ctx) {
@@ -54,14 +54,14 @@ void test_eloop_timeout_handler(void *eloop_ctx, void *user_ctx) {
   strcpy(user_ctx_data, TEST_ELOOP_PARAM);
 }
 
-static void test_eloop_init(void **state) {
+static void test_edge_eloop_init(void **state) {
   (void)state; /* unused */
 
-  struct eloop_data *eloop = eloop_init();
+  struct eloop_data *eloop = edge_eloop_init();
 
   assert_non_null(eloop);
 
-  eloop_free(eloop);
+  edge_eloop_free(eloop);
 }
 
 struct test_state_t {
@@ -70,7 +70,7 @@ struct test_state_t {
 
 int setup(void **state) {
   struct test_state_t *test_state = calloc(1, sizeof(struct test_state_t));
-  test_state->eloop = eloop_init();
+  test_state->eloop = edge_eloop_init();
   assert_non_null(test_state->eloop);
   *state = test_state;
   return 0;
@@ -78,7 +78,7 @@ int setup(void **state) {
 
 int teardown(void **state) {
   struct test_state_t *test_state = *state;
-  eloop_free(test_state->eloop);
+  edge_eloop_free(test_state->eloop);
   free(test_state);
   return 0;
 }
@@ -101,16 +101,16 @@ static void test_eloop_timeout(void **state) {
   char user_data[] = "user data";
 
   // check if timeout is registered
-  assert_false(eloop_is_timeout_registered(test_state->eloop,
+  assert_false(edge_eloop_is_timeout_registered(test_state->eloop,
                                            eloop_timeout_handler_function,
                                            eloop_data, user_data));
   expect_string(eloop_timeout_handler_function, eloop_ctx, eloop_data);
   expect_string(eloop_timeout_handler_function, user_ctx, user_data);
-  assert_return_code(eloop_register_timeout(test_state->eloop, 0, 1,
+  assert_return_code(edge_eloop_register_timeout(test_state->eloop, 0, 1,
                                             eloop_timeout_handler_function,
                                             eloop_data, user_data),
                      0);
-  assert_true(eloop_is_timeout_registered(test_state->eloop,
+  assert_true(edge_eloop_is_timeout_registered(test_state->eloop,
                                           eloop_timeout_handler_function,
                                           eloop_data, user_data));
 
@@ -119,7 +119,7 @@ static void test_eloop_timeout(void **state) {
   char user_data1[] = "this is user data: run 1";
   expect_string(eloop_timeout_handler_function, eloop_ctx, eloop_data1);
   expect_string(eloop_timeout_handler_function, user_ctx, user_data1);
-  assert_return_code(eloop_register_timeout(test_state->eloop, 0, 100,
+  assert_return_code(edge_eloop_register_timeout(test_state->eloop, 0, 100,
                                             eloop_timeout_handler_function,
                                             eloop_data1, user_data1),
                      0);
@@ -127,37 +127,37 @@ static void test_eloop_timeout(void **state) {
   // test cancelling timeouts
   char eloop_data2[] = "this is eloop data: run 2";
   char user_data2[] = "this is user data: run 2";
-  assert_return_code(eloop_register_timeout(test_state->eloop, 0, 200,
+  assert_return_code(edge_eloop_register_timeout(test_state->eloop, 0, 200,
                                             eloop_timeout_handler_function,
                                             eloop_data2, user_data2),
                      0);
   assert_int_equal(
-      eloop_cancel_timeout(test_state->eloop, eloop_timeout_handler_function,
+      edge_eloop_cancel_timeout(test_state->eloop, eloop_timeout_handler_function,
                            eloop_data2, user_data2),
       1 // should cancel only all = one timeout
   );
 
-  assert_return_code(eloop_register_timeout(test_state->eloop, 1, 0,
+  assert_return_code(edge_eloop_register_timeout(test_state->eloop, 1, 0,
                                             eloop_timeout_handler_function,
                                             eloop_data2, user_data2),
                      0);
-  assert_return_code(eloop_register_timeout(test_state->eloop, 2, 0,
+  assert_return_code(edge_eloop_register_timeout(test_state->eloop, 2, 0,
                                             eloop_timeout_handler_function,
                                             eloop_data2, user_data2),
                      0);
-  assert_return_code(eloop_register_timeout(test_state->eloop, 3, 0,
+  assert_return_code(edge_eloop_register_timeout(test_state->eloop, 3, 0,
                                             eloop_timeout_handler_function,
                                             eloop_data2, user_data2),
                      0);
 
   struct os_reltime remaining = {0};
-  assert_int_equal(eloop_cancel_timeout_one(
+  assert_int_equal(edge_eloop_cancel_timeout_one(
                        test_state->eloop, eloop_timeout_handler_function,
                        eloop_data2, user_data2, &remaining),
                    1 // should cancel only one timeout
   );
   assert_int_equal(
-      eloop_cancel_timeout(test_state->eloop, eloop_timeout_handler_function,
+      edge_eloop_cancel_timeout(test_state->eloop, eloop_timeout_handler_function,
                            eloop_data2, user_data2),
       2 // should cancel all = two timeouts
   );
@@ -166,7 +166,7 @@ static void test_eloop_timeout(void **state) {
   char user_data3[] = "this is user data: run 3";
   expect_string(eloop_timeout_handler_function, eloop_ctx, eloop_data3);
   expect_string(eloop_timeout_handler_function, user_ctx, user_data3);
-  assert_return_code(eloop_register_timeout(test_state->eloop, 0, 300,
+  assert_return_code(edge_eloop_register_timeout(test_state->eloop, 0, 300,
                                             eloop_timeout_handler_function,
                                             eloop_data3, user_data3),
                      0);
@@ -175,20 +175,20 @@ static void test_eloop_timeout(void **state) {
   char eloop_data4[] = "this is eloop data: run 4";
   expect_string(eloop_timeout_handler_function, eloop_ctx, eloop_data4);
   expect_string(eloop_timeout_handler_function, user_ctx, user_data);
-  assert_return_code(eloop_register_timeout(test_state->eloop, 120,
+  assert_return_code(edge_eloop_register_timeout(test_state->eloop, 120,
                                             0, // super long time
                                             eloop_timeout_handler_function,
                                             eloop_data4, user_data),
                      0);
-  assert_int_equal(eloop_deplete_timeout(
+  assert_int_equal(edge_eloop_deplete_timeout(
                        test_state->eloop, 100000, 0, // longer, so no change
                        eloop_timeout_handler_function, eloop_data4, user_data),
                    0);
-  assert_int_equal(eloop_deplete_timeout(test_state->eloop, 1, 0,
+  assert_int_equal(edge_eloop_deplete_timeout(test_state->eloop, 1, 0,
                                          eloop_timeout_handler_function,
                                          "this data does not exist", user_data),
                    -1);
-  assert_int_equal(eloop_deplete_timeout(test_state->eloop, 0, 400,
+  assert_int_equal(edge_eloop_deplete_timeout(test_state->eloop, 0, 400,
                                          eloop_timeout_handler_function,
                                          eloop_data4, user_data),
                    1);
@@ -197,31 +197,31 @@ static void test_eloop_timeout(void **state) {
   char eloop_data5[] = "this is eloop data: run 5";
   expect_string(eloop_timeout_handler_function, eloop_ctx, eloop_data5);
   expect_string(eloop_timeout_handler_function, user_ctx, user_data);
-  assert_return_code(eloop_register_timeout(test_state->eloop, 0,
+  assert_return_code(edge_eloop_register_timeout(test_state->eloop, 0,
                                             2, // super short time
                                             eloop_timeout_handler_function,
                                             eloop_data5, user_data),
                      0);
-  assert_int_equal(eloop_replenish_timeout(
+  assert_int_equal(edge_eloop_replenish_timeout(
                        test_state->eloop, 0, 1, // no change, should return 0
                        eloop_timeout_handler_function, eloop_data5, user_data),
                    0);
-  assert_int_equal(eloop_replenish_timeout(test_state->eloop, 100000, 0,
+  assert_int_equal(edge_eloop_replenish_timeout(test_state->eloop, 100000, 0,
                                            eloop_timeout_handler_function,
                                            "this data does not exist",
                                            user_data),
                    -1);
-  assert_int_equal(eloop_replenish_timeout(test_state->eloop, 0, 500,
+  assert_int_equal(edge_eloop_replenish_timeout(test_state->eloop, 0, 500,
                                            eloop_timeout_handler_function,
                                            eloop_data5, user_data),
                    1);
 
   log_debug("Starting eloop");
-  eloop_run(test_state->eloop);
+  edge_eloop_run(test_state->eloop);
   log_debug("Finished eloop");
 }
 
-static void test_eloop_register_read_sock(void **state) {
+static void test_edge_eloop_register_read_sock(void **state) {
   struct tmpdir *tmpdir = *state;
   char *send_buf = TEST_SEND_BUF_DATA;
   char *eloop_param = TEST_ELOOP_PARAM;
@@ -230,9 +230,9 @@ static void test_eloop_register_read_sock(void **state) {
   char server_file_path[PATH_MAX];
   server_file_path[PATH_MAX - 1] = '\0';
   snprintf(server_file_path, PATH_MAX - 1, "%s/%s", tmpdir->tmpdir,
-           "test_eloop_register_read_sock.sock");
+           "test_edge_eloop_register_read_sock.sock");
 
-  struct eloop_data *eloop = eloop_init();
+  struct eloop_data *eloop = edge_eloop_init();
 
   int ss = create_domain_server(server_file_path);
 
@@ -241,7 +241,7 @@ static void test_eloop_register_read_sock(void **state) {
   int cs = create_domain_client(NULL);
   assert_int_not_equal(cs, -1);
 
-  int eret = eloop_register_read_sock(eloop, ss, test_eloop_sock_handler_read,
+  int eret = edge_eloop_register_read_sock(eloop, ss, test_eloop_sock_handler_read,
                                       (void *)eloop, (void *)eloop_param);
   assert_int_not_equal(eret, -1);
 
@@ -253,68 +253,68 @@ static void test_eloop_register_read_sock(void **state) {
                        sizeof(struct sockaddr_un));
   assert_int_equal(ret, buf_len);
 
-  eloop_run(eloop);
+  edge_eloop_run(eloop);
 
   close(ss);
   close(cs);
   assert_return_code(remove(server_file_path), /** errno */ 0);
-  eloop_free(eloop);
+  edge_eloop_free(eloop);
 }
 
-static void test_eloop_unregister_read_sock(void **state) {
+static void test_edge_eloop_unregister_read_sock(void **state) {
   struct tmpdir *tmpdir = *state;
   char server_file_path[PATH_MAX];
   server_file_path[PATH_MAX - 1] = '\0';
   snprintf(server_file_path, PATH_MAX - 1, "%s/%s", tmpdir->tmpdir,
-           "test_eloop_unregister_read_sock.sock");
+           "test_edge_eloop_unregister_read_sock.sock");
 
-  struct eloop_data *eloop = eloop_init();
+  struct eloop_data *eloop = edge_eloop_init();
   int ss = create_domain_server(server_file_path);
 
   assert_int_not_equal(ss, -1);
 
-  int ret = eloop_register_read_sock(eloop, ss, test_eloop_sock_handler_unreg,
+  int ret = edge_eloop_register_read_sock(eloop, ss, test_eloop_sock_handler_unreg,
                                      NULL, NULL);
   assert_int_not_equal(ret, -1);
 
-  eloop_unregister_read_sock(eloop, ss);
+  edge_eloop_unregister_read_sock(eloop, ss);
 
-  eloop_run(eloop);
+  edge_eloop_run(eloop);
 
   close(ss);
-  eloop_free(eloop);
+  edge_eloop_free(eloop);
   assert_return_code(remove(server_file_path), /** errno */ 0);
 }
 
-static void test_eloop_register_timeout(void **state) {
+static void test_edge_eloop_register_timeout(void **state) {
   (void)state; /* unused */
 
   char buf[100] = {0};
-  struct eloop_data *eloop = eloop_init();
-  int ret = eloop_register_timeout(eloop, 0, 0, test_eloop_timeout_handler,
+  struct eloop_data *eloop = edge_eloop_init();
+  int ret = edge_eloop_register_timeout(eloop, 0, 0, test_eloop_timeout_handler,
                                    eloop, (void *)buf);
 
   assert_int_not_equal(ret, -1);
-  eloop_run(eloop);
+  edge_eloop_run(eloop);
   assert_string_equal(buf, TEST_ELOOP_PARAM);
-  eloop_free(eloop);
+  edge_eloop_free(eloop);
 }
 
-static void test_eloop_cancel_timeout(void **state) {
+static void test_edge_eloop_cancel_timeout(void **state) {
   (void)state; /* unused */
 
   char buf[100] = {0};
-  struct eloop_data *eloop = eloop_init();
-  int ret = eloop_register_timeout(eloop, 0, 0, test_eloop_timeout_handler,
+  struct eloop_data *eloop = edge_eloop_init();
+  int ret = edge_eloop_register_timeout(eloop, 0, 0, test_eloop_timeout_handler,
                                    eloop, (void *)buf);
 
   assert_int_not_equal(ret, -1);
 
-  ret = eloop_cancel_timeout(eloop, test_eloop_timeout_handler, eloop,
+  ret = edge_eloop_cancel_timeout(eloop, test_eloop_timeout_handler, eloop,
                              (void *)buf);
-  eloop_run(eloop);
+  edge_eloop_run(eloop);
   assert_string_equal(buf, "");
-  eloop_free(eloop);
+  edge_eloop_free(eloop);
 }
 
 int main(int argc, char *argv[]) {
@@ -324,13 +324,13 @@ int main(int argc, char *argv[]) {
   log_set_quiet(false);
 
   const struct CMUnitTest tests[] = {
-      cmocka_unit_test(test_eloop_init),
-      cmocka_unit_test_setup_teardown(test_eloop_register_read_sock,
+      cmocka_unit_test(test_edge_eloop_init),
+      cmocka_unit_test_setup_teardown(test_edge_eloop_register_read_sock,
                                       setup_tmpdir, teardown_tmpdir),
-      cmocka_unit_test_setup_teardown(test_eloop_unregister_read_sock,
+      cmocka_unit_test_setup_teardown(test_edge_eloop_unregister_read_sock,
                                       setup_tmpdir, teardown_tmpdir),
-      cmocka_unit_test(test_eloop_register_timeout),
-      cmocka_unit_test(test_eloop_cancel_timeout),
+      cmocka_unit_test(test_edge_eloop_register_timeout),
+      cmocka_unit_test(test_edge_eloop_cancel_timeout),
       cmocka_unit_test_setup_teardown(test_eloop_timeout, setup, teardown)};
 
   return cmocka_run_group_tests(tests, NULL, NULL);

--- a/tests/utils/test_eloop_handles_null.c
+++ b/tests/utils/test_eloop_handles_null.c
@@ -25,14 +25,14 @@
  * Macros](https://www.drdobbs.com/the-new-c-x-macros/184401387)
  */
 #define TEST_HANDLE_ELOOP_NULL_FUNCTIONS                                       \
-  X(eloop_register_read_sock, (NULL, 0, NULL, NULL, NULL))                     \
-  X(eloop_register_sock, (NULL, 0, EVENT_TYPE_READ, NULL, NULL, NULL))         \
-  X(eloop_register_timeout, (NULL, 0, 0, NULL, NULL, NULL))                    \
-  X(eloop_cancel_timeout, (NULL, NULL, NULL, NULL))                            \
-  X(eloop_cancel_timeout_one, (NULL, NULL, NULL, NULL, NULL))                  \
-  X(eloop_is_timeout_registered, (NULL, NULL, NULL, NULL))                     \
-  X(eloop_deplete_timeout, (NULL, 0, 0, NULL, NULL, NULL))                     \
-  X(eloop_replenish_timeout, (NULL, 0, 0, NULL, NULL, NULL))
+  X(edge_eloop_register_read_sock, (NULL, 0, NULL, NULL, NULL))                     \
+  X(edge_eloop_register_sock, (NULL, 0, EVENT_TYPE_READ, NULL, NULL, NULL))         \
+  X(edge_eloop_register_timeout, (NULL, 0, 0, NULL, NULL, NULL))                    \
+  X(edge_eloop_cancel_timeout, (NULL, NULL, NULL, NULL))                            \
+  X(edge_eloop_cancel_timeout_one, (NULL, NULL, NULL, NULL, NULL))                  \
+  X(edge_eloop_is_timeout_registered, (NULL, NULL, NULL, NULL))                     \
+  X(edge_eloop_deplete_timeout, (NULL, 0, 0, NULL, NULL, NULL))                     \
+  X(edge_eloop_replenish_timeout, (NULL, 0, 0, NULL, NULL, NULL))
 
 // Creates all the test functions defined in TEST_HANDLE_ELOOP_NULL_FUNCTIONS
 #define X(function, args)                                                      \

--- a/tests/utils/test_eloop_handles_null.c
+++ b/tests/utils/test_eloop_handles_null.c
@@ -25,13 +25,13 @@
  * Macros](https://www.drdobbs.com/the-new-c-x-macros/184401387)
  */
 #define TEST_HANDLE_ELOOP_NULL_FUNCTIONS                                       \
-  X(edge_eloop_register_read_sock, (NULL, 0, NULL, NULL, NULL))                     \
-  X(edge_eloop_register_sock, (NULL, 0, EVENT_TYPE_READ, NULL, NULL, NULL))         \
-  X(edge_eloop_register_timeout, (NULL, 0, 0, NULL, NULL, NULL))                    \
-  X(edge_eloop_cancel_timeout, (NULL, NULL, NULL, NULL))                            \
-  X(edge_eloop_cancel_timeout_one, (NULL, NULL, NULL, NULL, NULL))                  \
-  X(edge_eloop_is_timeout_registered, (NULL, NULL, NULL, NULL))                     \
-  X(edge_eloop_deplete_timeout, (NULL, 0, 0, NULL, NULL, NULL))                     \
+  X(edge_eloop_register_read_sock, (NULL, 0, NULL, NULL, NULL))                \
+  X(edge_eloop_register_sock, (NULL, 0, EVENT_TYPE_READ, NULL, NULL, NULL))    \
+  X(edge_eloop_register_timeout, (NULL, 0, 0, NULL, NULL, NULL))               \
+  X(edge_eloop_cancel_timeout, (NULL, NULL, NULL, NULL))                       \
+  X(edge_eloop_cancel_timeout_one, (NULL, NULL, NULL, NULL, NULL))             \
+  X(edge_eloop_is_timeout_registered, (NULL, NULL, NULL, NULL))                \
+  X(edge_eloop_deplete_timeout, (NULL, 0, 0, NULL, NULL, NULL))                \
   X(edge_eloop_replenish_timeout, (NULL, 0, 0, NULL, NULL, NULL))
 
 // Creates all the test functions defined in TEST_HANDLE_ELOOP_NULL_FUNCTIONS

--- a/tests/utils/test_eloop_threaded.c
+++ b/tests/utils/test_eloop_threaded.c
@@ -31,7 +31,7 @@ struct test_state_t {
 
 int setup(void **state) {
   struct test_state_t *test_state = calloc(1, sizeof(struct test_state_t));
-  test_state->eloop = eloop_init();
+  test_state->eloop = edge_eloop_init();
   assert_non_null(test_state->eloop);
   *state = test_state;
   return 0;
@@ -39,17 +39,17 @@ int setup(void **state) {
 
 int teardown(void **state) {
   struct test_state_t *test_state = *state;
-  eloop_free(test_state->eloop);
+  edge_eloop_free(test_state->eloop);
   free(test_state);
   return 0;
 }
 
 static void test_basic_eloop(void **state) {
   struct test_state_t *test_state = *state;
-  eloop_run(test_state->eloop);
+  edge_eloop_run(test_state->eloop);
 
-  eloop_terminate(test_state->eloop);
-  assert_true(eloop_terminated(test_state->eloop));
+  edge_eloop_terminate(test_state->eloop);
+  assert_true(edge_eloop_terminated(test_state->eloop));
 }
 
 struct test_eloop_sock_ctx {
@@ -116,7 +116,7 @@ static void eloop_sock_handler_function(int sock, void *eloop_ctx,
   utarray_push_back(sock_handler_recieved_data, &pointer_to_buffer);
 
   if (strcmp(buf, "STOP") == 0) {
-    eloop_terminate(eloop);
+    edge_eloop_terminate(eloop);
   }
 }
 
@@ -140,7 +140,7 @@ struct eloop_sock_handler_args {
 static int eloop_sock_handler_thread(void *thread_ctx) {
   struct eloop_sock_handler_args *args = thread_ctx;
 
-  struct eloop_data *eloop = eloop_init();
+  struct eloop_data *eloop = edge_eloop_init();
   assert_non_null(
       eloop); // might crash, since CMocka doesn't support multithreading
 
@@ -152,18 +152,18 @@ static int eloop_sock_handler_thread(void *thread_ctx) {
   assert_non_null(args->sock_handler_recieved_data);
 
   int server_socket = create_udp_server(args->udp_port);
-  assert_return_code(eloop_register_read_sock(
+  assert_return_code(edge_eloop_register_read_sock(
                          eloop, server_socket, eloop_sock_handler_function,
                          eloop, args->sock_handler_recieved_data),
                      0);
 
   log_debug("Starting server UDP eloop");
-  eloop_run(eloop);
+  edge_eloop_run(eloop);
   log_debug("Stopping server UDP eloop");
   log_debug("Recieved %d packets of data on port %d",
             utarray_len(args->sock_handler_recieved_data), args->udp_port);
 
-  eloop_free(eloop);
+  edge_eloop_free(eloop);
   close(server_socket);
   return 0;
 }
@@ -171,7 +171,7 @@ static int eloop_sock_handler_thread(void *thread_ctx) {
 /**
  * @brief eloop socket tests.
  *
- * Creates a background UDP thread that uses eloop_register_read_sock()
+ * Creates a background UDP thread that uses edge_eloop_register_read_sock()
  * to listen for UDP packets.
  *
  * The foreground client thread sends packets to the server, then sends `STOP`
@@ -213,25 +213,25 @@ static void test_eloop_sock(void **state) {
   make_struct_test_eloop_sock_user_ctx(test1, "Hello World!");
   utarray_push_back(sent_data, &test1.data);
   assert_return_code(
-      eloop_register_timeout(test_state->eloop, 0, initial_delay_useconds,
+      edge_eloop_register_timeout(test_state->eloop, 0, initial_delay_useconds,
                              send_data_to_sock, &eloop_ctx, &test1),
       0);
   utarray_push_back(sent_data, &test1.data);
   assert_return_code(
-      eloop_register_timeout(test_state->eloop, 0, initial_delay_useconds + 1,
+      edge_eloop_register_timeout(test_state->eloop, 0, initial_delay_useconds + 1,
                              send_data_to_sock, &eloop_ctx, &test1),
       0);
 
   make_struct_test_eloop_sock_user_ctx(test2, "Foo bar!");
   utarray_push_back(sent_data, &test2.data);
   assert_return_code(
-      eloop_register_timeout(test_state->eloop, 0, initial_delay_useconds + 2,
+      edge_eloop_register_timeout(test_state->eloop, 0, initial_delay_useconds + 2,
                              send_data_to_sock, &eloop_ctx, &test2),
       0);
 
   make_struct_test_eloop_sock_user_ctx(stop_packet, "STOP");
   utarray_push_back(sent_data, &stop_packet.data);
-  assert_return_code(eloop_register_timeout(test_state->eloop, 1, 0,
+  assert_return_code(edge_eloop_register_timeout(test_state->eloop, 1, 0,
                                             send_data_to_sock, &eloop_ctx,
                                             &stop_packet),
                      0);
@@ -246,7 +246,7 @@ static void test_eloop_sock(void **state) {
                    thrd_success);
 
   log_debug("Starting eloop");
-  eloop_run(test_state->eloop);
+  edge_eloop_run(test_state->eloop);
   log_debug("Finished eloop");
 
   assert_return_code(close(client_socket), 0);

--- a/tests/utils/test_eloop_threaded.c
+++ b/tests/utils/test_eloop_threaded.c
@@ -214,26 +214,26 @@ static void test_eloop_sock(void **state) {
   utarray_push_back(sent_data, &test1.data);
   assert_return_code(
       edge_eloop_register_timeout(test_state->eloop, 0, initial_delay_useconds,
-                             send_data_to_sock, &eloop_ctx, &test1),
+                                  send_data_to_sock, &eloop_ctx, &test1),
       0);
   utarray_push_back(sent_data, &test1.data);
-  assert_return_code(
-      edge_eloop_register_timeout(test_state->eloop, 0, initial_delay_useconds + 1,
-                             send_data_to_sock, &eloop_ctx, &test1),
-      0);
+  assert_return_code(edge_eloop_register_timeout(
+                         test_state->eloop, 0, initial_delay_useconds + 1,
+                         send_data_to_sock, &eloop_ctx, &test1),
+                     0);
 
   make_struct_test_eloop_sock_user_ctx(test2, "Foo bar!");
   utarray_push_back(sent_data, &test2.data);
-  assert_return_code(
-      edge_eloop_register_timeout(test_state->eloop, 0, initial_delay_useconds + 2,
-                             send_data_to_sock, &eloop_ctx, &test2),
-      0);
+  assert_return_code(edge_eloop_register_timeout(
+                         test_state->eloop, 0, initial_delay_useconds + 2,
+                         send_data_to_sock, &eloop_ctx, &test2),
+                     0);
 
   make_struct_test_eloop_sock_user_ctx(stop_packet, "STOP");
   utarray_push_back(sent_data, &stop_packet.data);
   assert_return_code(edge_eloop_register_timeout(test_state->eloop, 1, 0,
-                                            send_data_to_sock, &eloop_ctx,
-                                            &stop_packet),
+                                                 send_data_to_sock, &eloop_ctx,
+                                                 &stop_packet),
                      0);
 
   struct eloop_sock_handler_args eloop_sock_handler_args = {


### PR DESCRIPTION
Add the `edgesec_` namespace prefix to all eloop functions.

We're having difficulties with using the libeap library, because it also uses eloop, but a different version of eloop. This is causing linking errors.

Unfortunately, we're not using C++, so we can't just wrap everything in a namespace, so we have to manually namespace the functions by adding our own custom prefix.

---

Before merging this PR, do you want to test this locally with `libeap` to see if it works?

By the way, @mereacre, if you prefer to see the `.patch` in GitHub's viewer, see https://github.com/nqminds/hostap/commit/38b00e51cb253b0955a10ff3a0e0cc9d12b8409c (I've made a private fork of `hostap` in our @nqminds organization)

To be honest, instead of dealing with `.patch` files in this repo, we could just download from own forked version of `hostap` at https://github.com/nqminds/hostap/commit/38b00e51cb253b0955a10ff3a0e0cc9d12b8409c, but :shrug:, I don't know if it's worth the effort in changing the system we have now (plus, then we'd have to make https://github.com/nqminds/hostap public).