### PR TITLE
build(cmake): hide FreeBSD ctest preset on Linux

### DIFF
--- a/CMakePresets.json
+++ b/CMakePresets.json
@@ -340,7 +340,12 @@
     },
     {
       "name": "freebsd",
-      "configurePreset": "freebsd"
+      "configurePreset": "freebsd",
+      "condition": {
+        "type": "equals",
+        "lhs": "${hostSystemName}",
+        "rhs": "FreeBSD"
+      }
     },
     {
       "name": "openwrt",


### PR DESCRIPTION
Hide the FreeBSD ctest preset on Linux and other non-FreeBSD operating systems.

Although building for FreeBSD might make sense on Linux, (e.g. for cross-compiling), testing FreeBSD on Linux should never work, so it's safe to remove it.

### Notes to reviewers

Please only merge this PR once the FreeBSD tests pass.