### PR TITLE
ci: remove deprecated `set-output` commands

### DIFF
--- a/.github/workflows/create-debs.yml
+++ b/.github/workflows/create-debs.yml
@@ -60,9 +60,9 @@ jobs:
         run: |
           if ctest --list-presets | grep -s "${{ matrix.cmake-preset }}"; then
             # ctest --preset "${{ matrix.cmake-preset }}" --output-on-failure
-            echo "::set-output name=tested::true"
+            echo "tested=true" >> $GITHUB_OUTPUT
           else
-            echo "::set-output name=tested::false"
+            echo "tested=false" >> $GITHUB_OUTPUT
           fi
       - name: Code Coverage
         # code coverage only works if ctest works
@@ -91,7 +91,7 @@ jobs:
           preset='${{ matrix.cmake-preset }}'
           # replace `/` with `-`
           escaped_preset="${preset////-}"
-          echo "::set-output name=ESCAPED_CMAKE_PRESET::${escaped_preset}"
+          echo "ESCAPED_CMAKE_PRESET=${escaped_preset}" >> $GITHUB_OUTPUT
       - name: Archive Install Output
         uses: actions/upload-artifact@v2
         with:
@@ -257,9 +257,9 @@ jobs:
           OLD_DEB_PATH="$(ls -rt '${{ runner.temp }}/pbuilder/result'/edgesec*.deb | head -1)"
           NEW_DEB_PATH="$(echo "$OLD_DEB_PATH" | sed -E 's/_(([[:digit:]]\.){0,2}[[:digit:]](-[A-Za-z0-9+.~]+)*)_/_\1_${{ matrix.distribution }}_/')"
           mv "$OLD_DEB_PATH" "$NEW_DEB_PATH"
-          echo " ::set-output name=old-deb-path::${OLD_DEB_PATH}"
-          echo " ::set-output name=deb-path::${NEW_DEB_PATH}"
-          echo " ::set-output name=deb-name::$(basename "${NEW_DEB_PATH}")"
+          echo "old-deb-path=${OLD_DEB_PATH}" >> $GITHUB_OUTPUT
+          echo "deb-path=${NEW_DEB_PATH}" >> $GITHUB_OUTPUT
+          echo "deb-name=$(basename "${NEW_DEB_PATH}")" >> $GITHUB_OUTPUT
       - name: Archive built debs
         uses: actions/upload-artifact@v2
         with:


### PR DESCRIPTION
[GitHub Actions has deprecated the `set-output` command.][1]

They expect to disable the command fully in May 2023.

Migrating is pretty easy, all we need to do is replace the `echo "::set-output name={name}::{value}"` syntax with the new `echo "{name}={value}" >> $GITHUB_OUTPUT` syntax.

[1]: https://github.blog/changelog/2022-10-11-github-actions-deprecating-save-state-and-set-output-commands/

### Notes to reviewers

@AshleySetter, don't worry, despite being in the `edgesec` repo, this isn't C code :wink:

I'm guessing you also program in GitHub Actions' YAML DSL (YAML is an amazing programming language), so you might be interested in this change, if you haven't heard about it already.