### PR TITLE
build(cmocka): use upstream cmocka

### DIFF
--- a/lib/cmocka.cmake
+++ b/lib/cmocka.cmake
@@ -23,7 +23,7 @@ if (BUILD_ONLY_DOCS OR NOT (CMAKE_PROJECT_NAME STREQUAL PROJECT_NAME AND BUILD_T
 elseif (BUILD_CMOCKA_LIB)
   include(FetchContent)
 
-  set(CMOCKA_GIT_SHA "55c444ee6ab77f27b188b09b1a32792d3a02d2f1")
+  set(CMOCKA_GIT_SHA "018bd67ad4791c8cdbfdc85b6191fced2a6f06c0")
   FetchContent_Declare(
     cmocka
     # Use upstream in development cmocka version to fix some bugs
@@ -33,8 +33,8 @@ elseif (BUILD_CMOCKA_LIB)
     # - CHERI PureCap fixes
     #   - Use `__builtin_align_down` to align pointers https://gitlab.com/cmocka/cmocka/-/merge_requests/55
     #   - Remove casts from `uintptr_t` to `uintmax_t` https://gitlab.com/cmocka/cmocka/-/merge_requests/56
-    URL "https://gitlab.com/api/v4/projects/aloisklink%2Fcmocka/repository/archive.tar.bz2?sha=${CMOCKA_GIT_SHA}"
-    URL_HASH SHA256=496c8628a7e9fd000a59540fab97d21fdd3721a8e8b7930c55bdef78acf301f7
+    URL "https://gitlab.com/api/v4/projects/cmocka%2Fcmocka/repository/archive.tar.bz2?sha=${CMOCKA_GIT_SHA}"
+    URL_HASH SHA256=e6e71936c0c2049564b2775536888d577c44f3b21ffa387af1d18a5f0621c65b
     DOWNLOAD_NAME "cmocka-${CMOCKA_GIT_SHA}.tar.bz2"
     DOWNLOAD_DIR "${EP_DOWNLOAD_DIR}" # if empty string, uses default dir
   )


### PR DESCRIPTION
Use commit https://gitlab.com/cmocka/cmocka/-/commit/018bd67ad4791c8cdbfdc85b6191fced2a6f06c0 of CMocka, as the CheriBSD and Morello Purecap patches we need have now been upstreamed into the offical CMocka library. 🎉🎉🥳🥳

For a full list of what has changed, as well as the merge requests I submitted, please see commit https://github.com/nqminds/edgesec/commit/ed2b5f98d59523e29dd9864a0c7b25d66f95a7e6, which was submitted to EDGESec in https://github.com/nqminds/edgesec/pull/378
