### PR TITLE
test(ap_service): fix return for generate_*_conf()

### DIFF
--- a/tests/ap/test_ap_service.c
+++ b/tests/ap/test_ap_service.c
@@ -25,11 +25,11 @@
 #include "utils/log.h"
 #include "utils/os.h"
 
-bool __wrap_generate_vlan_conf(char *vlan_file, char *interface) {
+int __wrap_generate_vlan_conf(char *vlan_file, char *interface) {
   (void)vlan_file;
   (void)interface;
 
-  return true;
+  return 0;
 }
 
 int __wrap_run_ap_process(struct apconf *hconf) {
@@ -38,12 +38,12 @@ int __wrap_run_ap_process(struct apconf *hconf) {
   return 0;
 }
 
-bool __wrap_generate_hostapd_conf(struct apconf *hconf,
-                                  struct radius_conf *rconf) {
+int __wrap_generate_hostapd_conf(struct apconf *hconf,
+                                 struct radius_conf *rconf) {
   (void)hconf;
   (void)rconf;
 
-  return true;
+  return 0;
 }
 
 int __wrap_signal_ap_process(struct apconf *hconf) {


### PR DESCRIPTION
The `generate_*_conf()` functions previously returned a `bool`, with `true` for success and `false` for failure.

However, 3196584bfea28817259dba98f4853609f5051f8a changed this behaviour, and made those functions use a return code, where `0` is success, and `-1` is for failures.

See:
https://github.com/nqminds/edgesec/blob/9854c1b57af0814fde321f12cd42a11e80192248/src/ap/hostapd.h#L25-L32 

https://github.com/nqminds/edgesec/blob/9854c1b57af0814fde321f12cd42a11e80192248/src/ap/hostapd.h#L34-L41

The C compiler didn't throw any issues, because the compiler doesn't check the signature for `__wrap_*` functions. Instead, it's only the linker that checks for these issues, and on most platforms, I believe returning a `bool` and `int` have the same ABI, since both use the same  register for return values.

Fixes: 3196584bfea28817259dba98f4853609f5051f8a