### PR TITLE
fix(os): error signal_process() if passed "."

### DIFF
--- a/src/utils/os.c
+++ b/src/utils/os.c
@@ -890,6 +890,12 @@ bool signal_process(char *proc_name, int sig) {
     return false;
   }
 
+  if (strcmp(proc_name, ".") == 0) {
+    // may be caused by somebody calling basename(proc_name);
+    log_error("proc_name is .");
+    return false;
+  }
+
   if (!os_strnlen_s(proc_name, MAX_OS_PATH_LEN)) {
     log_error("proc_name is empty");
     return false;

--- a/tests/utils/test_os.c
+++ b/tests/utils/test_os.c
@@ -14,6 +14,8 @@
 #include <sys/types.h>
 #include <unistd.h>
 
+#include <signal.h>
+
 #include <limits.h>
 
 #include "utils/allocs.h"
@@ -690,6 +692,16 @@ static void test_hexstr2bin(void **state) {
   assert_int_equal(hexstr2bin("0", buffer, 1), -1);
 }
 
+static void test_signal_process(void **state) {
+  (void)state; /* unused */
+
+  log_debug("should error if passing `.`");
+  assert_false(signal_process(
+      ".",
+      SIGURG /* use SIGURG since it's ignored by default on most processes */
+      ));
+}
+
 int main(int argc, char *argv[]) {
   (void)argc;
   (void)argv;
@@ -712,7 +724,8 @@ int main(int argc, char *argv[]) {
                                       teardown_tmpdir),
       cmocka_unit_test_setup_teardown(test_os_strlcpy, setup_os_strlcpy_test,
                                       teardown_os_strlcpy_test),
-      cmocka_unit_test(test_hexstr2bin)};
+      cmocka_unit_test(test_hexstr2bin),
+      cmocka_unit_test(test_signal_process)};
 
   return cmocka_run_group_tests(tests, NULL, NULL);
 }


### PR DESCRIPTION
Passing `signal_process(".", ...)` sends the signal to pretty much every running process, meaning pretty much everything on your computer gets killed.

This can occur, since under the [`basename` POSIX specification][1]:

> If string is a null string, it is unspecified whether the resulting
> string is '.' or a null string. In either case, skip steps 2 through 6.

Since we often call `signal_process(basename(some_str), ...`, this can often happen to us.

(guess how I found out 🤦)

This commit makes `signal_process(".", ` log and return an error. I've also added a test case for this scenario.

[1]: https://pubs.opengroup.org/onlinepubs/9699919799/utilities/basename.html