### PR TITLE
build(CMakePresets): hide `default` configure preset

### DIFF
--- a/CMakePresets.json
+++ b/CMakePresets.json
@@ -9,7 +9,8 @@
     {
       "name": "default",
       "displayName": "Default Config",
-      "description": "Default build",
+      "hidden": true,
+      "description": "Default build (won't compile without enabling one of `USE_*_SERVICE`)",
       "binaryDir": "${sourceDir}/build/${presetName}",
       "cacheVariables": {
         "CMAKE_BUILD_TYPE": {


### PR DESCRIPTION
The `default` build preset no longer works, because you must enable one of the `USE_*_SERVICE` flags in order to compile `edgesec`.

We still use it for inheritance, however, so it's useful to keep. Hiding it means it won't show up in `cmake --list-presets`.