### PR TITLE
Use apt `mirrors.txt` file to bypass apt server failures

### DIFF
--- a/.github/workflows/create-debs.yml
+++ b/.github/workflows/create-debs.yml
@@ -31,6 +31,14 @@ jobs:
     steps:
       - name: Checkout code
         uses: actions/checkout@v3
+      - name: Set apt mirror
+        # GitHub Actions apt proxy is super unstable
+        # see https://github.com/actions/runner-images/issues/7048
+        run: |
+          # make sure there is a `\t` between URL and `priority:*` attributes
+          printf 'http://azure.archive.ubuntu.com/ubuntu	priority:1\n' | sudo tee /etc/apt/mirrors.txt
+          curl http://mirrors.ubuntu.com/mirrors.txt | sudo tee --append /etc/apt/mirrors.txt
+          sudo sed -i 's/http:\/\/azure.archive.ubuntu.com\/ubuntu\//mirror+file:\/etc\/apt\/mirrors.txt/' /etc/apt/sources.list
       - name: Install Dependencies
         shell: bash # we're using bash arrays here
         run: |
@@ -113,6 +121,14 @@ jobs:
       - name: Checkout code
         # not sure if needed, maybe the codecov action uses it
         uses: actions/checkout@v3
+      - name: Set apt mirror
+        # GitHub Actions apt proxy is super unstable
+        # see https://github.com/actions/runner-images/issues/7048
+        run: |
+          # make sure there is a `\t` between URL and `priority:*` attributes
+          printf 'http://azure.archive.ubuntu.com/ubuntu	priority:1\n' | sudo tee /etc/apt/mirrors.txt
+          curl http://mirrors.ubuntu.com/mirrors.txt | sudo tee --append /etc/apt/mirrors.txt
+          sudo sed -i 's/http:\/\/azure.archive.ubuntu.com\/ubuntu\//mirror+file:\/etc\/apt\/mirrors.txt/' /etc/apt/sources.list
       - name: Install Coverage Tools
         run: |
           sudo apt-get install lcov -y || ( sudo apt-get update && sudo apt-get install lcov -y )
@@ -146,6 +162,14 @@ jobs:
     steps:
       - name: Checkout code
         uses: actions/checkout@v3
+      - name: Set apt mirror
+        # GitHub Actions apt proxy is super unstable
+        # see https://github.com/actions/runner-images/issues/7048
+        run: |
+          # make sure there is a `\t` between URL and `priority:*` attributes
+          printf 'http://azure.archive.ubuntu.com/ubuntu	priority:1\n' | sudo tee /etc/apt/mirrors.txt
+          curl http://mirrors.ubuntu.com/mirrors.txt | sudo tee --append /etc/apt/mirrors.txt
+          sudo sed -i 's/http:\/\/azure.archive.ubuntu.com\/ubuntu\//mirror+file:\/etc\/apt\/mirrors.txt/' /etc/apt/sources.list
       - name: Install Dependencies
         run: |
           sudo apt-get update
@@ -231,6 +255,14 @@ jobs:
         # Sometimes the cache step just freezes forever
         # so put a limit on it so that we can restart it earlier on failure
         timeout-minutes: 10
+      - name: Set apt mirror
+        # GitHub Actions apt proxy is super unstable
+        # see https://github.com/actions/runner-images/issues/7048
+        run: |
+          # make sure there is a `\t` between URL and `priority:*` attributes
+          printf 'http://azure.archive.ubuntu.com/ubuntu	priority:1\n' | sudo tee /etc/apt/mirrors.txt
+          curl http://mirrors.ubuntu.com/mirrors.txt | sudo tee --append /etc/apt/mirrors.txt
+          sudo sed -i 's/http:\/\/azure.archive.ubuntu.com\/ubuntu\//mirror+file:\/etc\/apt\/mirrors.txt/' /etc/apt/sources.list
       - name: Install dependencies
         run: |
           sudo apt-get update && sudo apt-get install pbuilder debhelper -y

--- a/.github/workflows/pages.yml
+++ b/.github/workflows/pages.yml
@@ -15,6 +15,14 @@ jobs:
     # Checks-out your repository under $GITHUB_WORKSPACE, so your job can access it
     # warning! This is a shallow clone, and has no git history for docs!
     - uses: actions/checkout@v2
+    - name: Set apt mirror
+      # GitHub Actions apt proxy is super unstable
+      # see https://github.com/actions/runner-images/issues/7048
+      run: |
+        # make sure there is a `\t` between URL and `priority:*` attributes
+        printf 'http://azure.archive.ubuntu.com/ubuntu	priority:1\n' | sudo tee /etc/apt/mirrors.txt
+        curl http://mirrors.ubuntu.com/mirrors.txt | sudo tee --append /etc/apt/mirrors.txt
+        sudo sed -i 's/http:\/\/azure.archive.ubuntu.com\/ubuntu\//mirror+file:\/etc\/apt\/mirrors.txt/' /etc/apt/sources.list
     - name: Install Dependencies
       run: sudo apt-get update && sudo apt-get install doxygen graphviz texinfo -y
     - name: Configure


### PR DESCRIPTION
GitHub Actions runs on Azure by default.

The Microsoft Azure apt mirror is constantly failing (see https://github.com/actions/runner-images/issues/7048), but we can setup a custom mirror file to automatically bypass the Azure apt server if it's failing.

We're essentially using the `mirrors.txt` file from http://mirrors.ubuntu.com/mirrors.txt (auto-generated based on location), but we append `http://azure.archive.ubuntu.com/ubuntu	priority:1\n` so that apt always tries the faster `http://azure.archive.ubuntu.com/ubuntu` mirror first, and only falls back to the other entries in `mirrors.txt` on failure.

See [*apt-transport-mirror(1)* man-page](https://manpages.ubuntu.com/manpages/jammy/en/man5/sources.list.5.html) for details.

The mirrors in `http://mirrors.ubuntu.com/mirrors.txt` are a lot slower than the azure archive, but at least it means most of our CI actions still work.