### PR TITLE
ci(build-debs): run CI action on Ubuntu 22.04

### DIFF
--- a/.github/workflows/create-debs.yml
+++ b/.github/workflows/create-debs.yml
@@ -201,7 +201,7 @@ jobs:
   build-deb:
     name: Build Debian Package
     # building a deb is super slow, but we're a public repo now, so it's free!!
-    runs-on: [ubuntu-20.04]
+    runs-on: [ubuntu-22.04]
     strategy:
       matrix:
         architecture: [arm64, amd64]


### PR DESCRIPTION
~This may hopefully fix some of the `apt` issues we're having.~

Looks like the Ubuntu Apt issues have been fixed, but it's probably still worth merging this anyway.