### PR TITLE
build(uci): download uci archive, not `git`

### DIFF
--- a/lib/uci.cmake
+++ b/lib/uci.cmake
@@ -9,11 +9,16 @@ if (USE_UCI_SERVICE AND NOT (BUILD_ONLY_DOCS))
     set(LIBUBOX_INCLUDE_PATH ${LIBUBOX_INSTALL_DIR}/include)
     set(LIBUBOX_LIB_DIR "${LIBUBOX_INSTALL_DIR}/lib")
 
+    set(libubox_git_tag f2d6752901f2f2d8612fb43e10061570c9198af1) # master as of 2022-02-10
     ExternalProject_Add(
       libubox
-      GIT_REPOSITORY https://git.openwrt.org/project/libubox.git
-      GIT_TAG f2d6752901f2f2d8612fb43e10061570c9198af1 # master as of 2022-02-10
-      GIT_PROGRESS true
+      #GIT_REPOSITORY https://git.openwrt.org/project/libubox.git
+      #GIT_TAG "${libubox_git_tag}"
+      # Escape semicolons in gitweb URL with `\\\;`
+      URL "https://git.openwrt.org/?p=project/libubox.git\\\;a=snapshot\\\;h=${libubox_git_tag}\\\;sf=tgz"
+      # this hash will change when OpenWRT's git server updates to v2.38.0+
+      URL_HASH SHA3_256=2189a3dbe55095e1a53c20aeb48d0d40b4fe8ea6f85a85653899bae63209cd5c
+      DOWNLOAD_NAME "libubox-${libubox_git_tag}.tar.gz"
       DOWNLOAD_DIR "${EP_DOWNLOAD_DIR}" # if empty string, uses default download dir
       INSTALL_DIR "${LIBUBOX_INSTALL_DIR}"
       CMAKE_ARGS
@@ -33,11 +38,16 @@ if (USE_UCI_SERVICE AND NOT (BUILD_ONLY_DOCS))
     set(LIBUCI_INCLUDE_PATH ${LIBUCI_INSTALL_DIR}/include)
     set(LIBUCI_LIB_DIR "${LIBUCI_INSTALL_DIR}/lib")
 
+    set(libuci_git_tag f84f49f00fb70364f58b4cce72f1796a7190d370) # master as of 2021-10-22
     ExternalProject_Add(
       libuci
-      GIT_REPOSITORY https://git.openwrt.org/project/uci.git
-      GIT_TAG f84f49f00fb70364f58b4cce72f1796a7190d370 # master as of 2021-10-22
-      GIT_PROGRESS true
+      #GIT_REPOSITORY https://git.openwrt.org/project/uci.git
+      #GIT_TAG "${libuci_git_tag}"
+      # Escape semicolons in gitweb URL with `\\\;`
+      URL "https://git.openwrt.org/?p=project/uci.git\\\;a=snapshot\\\;h=${libuci_git_tag}\\\;sf=tgz"
+      # this hash will change when OpenWRT's git server updates to v2.38.0+
+      URL_HASH SHA3_256=4524e6d408204e9a3f3e5a3531888d4e45fdf617a3aceb1a2e271e262f0fd3bd
+      DOWNLOAD_NAME "uci-${libuci_git_tag}.tar.gz"
       DOWNLOAD_DIR "${EP_DOWNLOAD_DIR}" # if empty string, uses default download dir
       INSTALL_DIR "${LIBUCI_INSTALL_DIR}"
       CMAKE_ARGS


### PR DESCRIPTION
Download `uci` (and `libubox`) as a tarball, instead of using a `git clone`.

Both `uci` and `libubox` are hosted on the [OpenWRT git server][1], which isn't very fast.

Downloading a tarball is quite a bit faster. Additionally, it means that we can easily store it in a custom `DOWNLOAD_DIR` and easily cache it, to prevent mutliple re-downloads.

Finally, doing `rm -r` on a git repo fails (you need `-f` to force delete it). Deleting an uncompressed tarball is much easier.

A few issues:
  - In CMake v3.22.1, `;` is a list seperator character. Because GitWeb uses `;` in the URLs, we need to escape them in CMake using `\\\;` (double-escaped because CMake has some [interesting list unescaping issues][2]).

    We also can't use [`$<SEMICOLON>`][3], because the URL parameter of `ExternalProject_Add()` doesn't yet support generator expressions.
  - `git.openwrt.org` is currently running git v2.30.2. When it updates to git v2.38.0+, the default gzip compression algorithm will change, which may cause the hash to change, see [git/git@4f4be00d302bc52d0d9d5a3d4738bb525066c710][4]

[1]: https://git.openwrt.org/
[2]: https://gitlab.kitware.com/cmake/cmake/-/issues/20317
[3]: https://cmake.org/cmake/help/v3.22/manual/cmake-generator-expressions.7.html#escaped-characters
[4]: https://github.com/git/git/commit/4f4be00d302bc52d0d9d5a3d4738bb525066c710