### PR TITLE
refactor: inline os_zalloc for internal linkage

### DIFF
--- a/src/utils/allocs.c
+++ b/src/utils/allocs.c
@@ -18,8 +18,6 @@
 
 #include "allocs.h"
 
-void *os_zalloc(size_t size) { return os_calloc(size, 1); }
-
 void *os_memdup(const void *src, size_t len) {
   void *r = os_malloc(len);
 

--- a/src/utils/allocs.h
+++ b/src/utils/allocs.h
@@ -27,7 +27,7 @@
  * @param size Number of bytes to allocate
  * @return void* Pointer to allocated and zeroed memory or %NULL on failure
  */
-void *os_zalloc(size_t size);
+static inline void *os_zalloc(size_t size) { return calloc(size, 1); }
 
 // void *os_malloc(size_t size);
 // void os_free(void* ptr);


### PR DESCRIPTION
Change `os_zalloc` to use `static inline` so that it uses internal linkage.

The libeap library also has it's own `os_zalloc`, which is causing linking errors. We can easily avoid this by inlining the edgesec version of `os_zalloc`. The function is literally just one-line of code, so inlining it should basically change nothing.

---

I made this commit to replace https://github.com/nqminds/edgesec/pull/380/commits/93d8c8a827c243cde9ffd4df20e5d6f1a77a02aa, since there's no need to rename `os_zalloc` to `sys_zalloc` if we can just inline the function.