### PR TITLE
refactor: move printf_encode into radius/common.h

### DIFF
--- a/src/radius/common.h
+++ b/src/radius/common.h
@@ -153,6 +153,59 @@ static inline u32 WPA_GET_BE24(const u8 *a) {
 #define wpa_snprintf_hex(buf, buf_size, data, len)                             \
   printf_hex(buf, buf_size, data, len, 0)
 
+static inline void printf_encode(char *txt, size_t maxlen, const uint8_t *data,
+                                 size_t len) {
+  char *end = txt + maxlen;
+  size_t i;
+
+  for (i = 0; i < len; i++) {
+    if (txt + 4 >= end)
+      break;
+
+    switch (data[i]) {
+      case '\"':
+        *txt++ = '\\';
+        *txt++ = '\"';
+        break;
+      case '\\':
+        *txt++ = '\\';
+        *txt++ = '\\';
+        break;
+      case '\033':
+        *txt++ = '\\';
+        *txt++ = 'e';
+        break;
+      case '\n':
+        *txt++ = '\\';
+        *txt++ = 'n';
+        break;
+      case '\r':
+        *txt++ = '\\';
+        *txt++ = 'r';
+        break;
+      case '\t':
+        *txt++ = '\\';
+        *txt++ = 't';
+        break;
+      default:
+        // check if value is a valid printable ASCII char
+        // this also confirms that we can safely cast unsigned data to signed
+        // char
+        if (data[i] >= 32 && data[i] <= 126) {
+          *txt++ = (char)data[i];
+        } else {
+          // guaranteed to be positive and to have 4 chars left, as otherwise
+          // loop will break
+          size_t max_chars_to_print = (size_t)(end - txt);
+          txt += snprintf(txt, max_chars_to_print, "\\x%02x", data[i]);
+        }
+        break;
+    }
+  }
+
+  *txt = '\0';
+}
+
 #ifndef wpa_trace_show
 #define wpa_trace_show(s) log_trace("%s", s)
 #endif

--- a/src/utils/log.c
+++ b/src/utils/log.c
@@ -311,58 +311,6 @@ void log_error_exit_proc(uint8_t level, const char *file, uint32_t line,
   terminate(false);
 }
 
-void printf_encode(char *txt, size_t maxlen, const uint8_t *data, size_t len) {
-  char *end = txt + maxlen;
-  size_t i;
-
-  for (i = 0; i < len; i++) {
-    if (txt + 4 >= end)
-      break;
-
-    switch (data[i]) {
-      case '\"':
-        *txt++ = '\\';
-        *txt++ = '\"';
-        break;
-      case '\\':
-        *txt++ = '\\';
-        *txt++ = '\\';
-        break;
-      case '\033':
-        *txt++ = '\\';
-        *txt++ = 'e';
-        break;
-      case '\n':
-        *txt++ = '\\';
-        *txt++ = 'n';
-        break;
-      case '\r':
-        *txt++ = '\\';
-        *txt++ = 'r';
-        break;
-      case '\t':
-        *txt++ = '\\';
-        *txt++ = 't';
-        break;
-      default:
-        // check if value is a valid printable ASCII char
-        // this also confirms that we can safely cast unsigned data to signed
-        // char
-        if (data[i] >= 32 && data[i] <= 126) {
-          *txt++ = (char)data[i];
-        } else {
-          // guaranteed to be positive and to have 4 chars left, as otherwise
-          // loop will break
-          size_t max_chars_to_print = (size_t)(end - txt);
-          txt += snprintf(txt, max_chars_to_print, "\\x%02x", data[i]);
-        }
-        break;
-    }
-  }
-
-  *txt = '\0';
-}
-
 size_t printf_hex(char *buf, size_t buf_size, const uint8_t *data, size_t len,
                   int uppercase) {
   size_t i;

--- a/src/utils/log.h
+++ b/src/utils/log.h
@@ -87,7 +87,6 @@ void log_error_exit(uint8_t level, const char *file, uint32_t line,
 void log_error_exit_proc(uint8_t level, const char *file, uint32_t line,
                          const char *format, ...);
 
-void printf_encode(char *txt, size_t maxlen, const uint8_t *data, size_t len);
 size_t printf_hex(char *buf, size_t buf_size, const uint8_t *data, size_t len,
                   int uppercase);
 #endif


### PR DESCRIPTION
Move the `printf_encode()` function into `radius/common.h` and inline it to avoid linking conflicts with the `printf_encode()` function in libeap.

---

This is the same commit as https://github.com/nqminds/edgesec/commit/c25c8fdccc7b98315affd664dc5fe7c77c1e976f, I just changed the description.