### PR TITLE
refactor(os): inline hex2byte and remove from os.h

### DIFF
--- a/src/utils/os.c
+++ b/src/utils/os.c
@@ -163,7 +163,17 @@ int os_get_reltime(struct os_reltime *t) {
   return res;
 }
 
-int16_t hex2byte(const char hex[static 2]) {
+/**
+ * @brief ASCII hex character pair to byte
+ * @code{.c}
+ * // returns 0x91 aka 145 aka '\x91'
+ * hex2byte("91")
+ * @endcode
+ *
+ * @param hex Two char string
+ * @return Converted byte, or `-1` on error.
+ */
+static inline int16_t hex2byte(const char hex[static 2]) {
   int_fast8_t a = hex2num(*hex++);
   if (a < 0)
     return -1;

--- a/src/utils/os.h
+++ b/src/utils/os.h
@@ -182,20 +182,11 @@ void os_init_random_seed(void);
 int os_get_random_number_s(unsigned char *buf, size_t len);
 
 /**
- * @brief ASCII hex character to number
- *
- * @param hex Two char string
- * @return converted number from 0-255, or `-1` on error.
- */
-int16_t hex2byte(const char hex[static 2]);
-
-/**
  * @brief Hex char to number
  * @code{.c}
  * // returns 0x9 aka 9 aka '\x09'
  * hex2num('9')
  * @endcode
- *
  * @param[in] c Hex char
  * @return Converted byte from 0-15, or `-1` on error.
  */


### PR DESCRIPTION
Inline the `hex2byte` function, and remove it from `src/utils/os.h`

We never call it outside of this file, but it may cause linking errors with libeap.

---

Adapted from https://github.com/nqminds/edgesec/commit/b273cce7c0e4a3fb234b655d2a49603b78db7e3a

The main difference is that instead of renaming the function, if we just inline it, this avoids linker issues (there were also some merge conflicts to fix).