### PR TITLE
refactor(os): rename hexstr2bin with edge_ prefix

### DIFF
--- a/src/radius/wpabuf.c
+++ b/src/radius/wpabuf.c
@@ -302,7 +302,7 @@ struct wpabuf *wpabuf_parse_bin(const char *buf) {
   if (ret == NULL)
     return NULL;
 
-  if (hexstr2bin(buf, wpabuf_put(ret, len), len)) {
+  if (edge_hexstr2bin(buf, wpabuf_put(ret, len), len)) {
     wpabuf_free(ret);
     return NULL;
   }

--- a/src/utils/os.c
+++ b/src/utils/os.c
@@ -173,7 +173,7 @@ int16_t hex2byte(const char hex[static 2]) {
   return (a << 4) | b;
 }
 
-int hexstr2bin(const char *hex, uint8_t *buf, size_t len) {
+int edge_hexstr2bin(const char *hex, uint8_t *buf, size_t len) {
   const char *ipos = hex;
   uint8_t *opos = buf;
 

--- a/src/utils/os.h
+++ b/src/utils/os.h
@@ -210,7 +210,7 @@ int8_t hex2num(char c);
  * double this size
  * @return int 0 on success, -1 on failure (invalid hex string)
  */
-int hexstr2bin(const char *hex, uint8_t *buf, size_t len);
+int edge_hexstr2bin(const char *hex, uint8_t *buf, size_t len);
 
 /**
  * @brief Check if a string is a number

--- a/tests/utils/test_os.c
+++ b/tests/utils/test_os.c
@@ -665,31 +665,31 @@ static void test_hexstr2bin(void **state) {
 
   uint8_t buffer[256] = {0};
   {
-    assert_return_code(hexstr2bin("01", buffer, 1), errno);
+    assert_return_code(edge_hexstr2bin("01", buffer, 1), errno);
     uint8_t expected_data[] = {0x01};
     assert_memory_equal(expected_data, buffer, sizeof(expected_data));
   }
 
   {
-    assert_return_code(
-        hexstr2bin("0123456789abcdef", buffer, sizeof("0123456789abcdef") / 2),
-        errno);
+    assert_return_code(edge_hexstr2bin("0123456789abcdef", buffer,
+                                       sizeof("0123456789abcdef") / 2),
+                       errno);
     uint8_t expected_data[] = {0x01, 0x23, 0x45, 0x67, 0x89, 0xab, 0xcd, 0xef};
     assert_memory_equal(expected_data, buffer, sizeof(expected_data));
   }
 
   { // should handle capital and lower-case letters
-    assert_return_code(
-        hexstr2bin("0123456789ABCDEF", buffer, sizeof("0123456789ABCDEF") / 2),
-        errno);
+    assert_return_code(edge_hexstr2bin("0123456789ABCDEF", buffer,
+                                       sizeof("0123456789ABCDEF") / 2),
+                       errno);
     uint8_t expected_data[] = {0x01, 0x23, 0x45, 0x67, 0x89, 0xAB, 0xCD, 0xEF};
     assert_memory_equal(expected_data, buffer, sizeof(expected_data));
   }
 
   // should return `-1` for invalid chars
-  assert_int_equal(hexstr2bin("0g", buffer, 1), -1);
-  assert_int_equal(hexstr2bin("ꙮ", buffer, 1), -1);
-  assert_int_equal(hexstr2bin("0", buffer, 1), -1);
+  assert_int_equal(edge_hexstr2bin("0g", buffer, 1), -1);
+  assert_int_equal(edge_hexstr2bin("ꙮ", buffer, 1), -1);
+  assert_int_equal(edge_hexstr2bin("0", buffer, 1), -1);
 }
 
 static void test_signal_process(void **state) {


### PR DESCRIPTION
Renames `hexstr2bin` to use the `edge_` prefix, so that it's called `edge_hexstr2bin`.

---

Adapted from https://github.com/nqminds/edgesec/commit/e53cebe3ffe81a39f184a7f2f4b54eba4e46ecd8

Differences:
  - Instead of naming it `convert_hexstr2bin`, I've called if `edge_hexstr2bin`, since it makes more sense to have every function in edgesec share a common namespace prefix, and we've decided on `edge_` in https://github.com/nqminds/edgesec/pull/393#issuecomment-1406510314.