### PR TITLE
refactor(os): rename os_get_reltime with `edge_`

### DIFF
--- a/src/utils/os.c
+++ b/src/utils/os.c
@@ -154,7 +154,7 @@ int os_get_time(struct os_time *t) {
   return res;
 }
 
-int os_get_reltime(struct os_reltime *t) {
+int edge_os_get_reltime(struct os_reltime *t) {
   int res;
   struct timeval tv;
   res = gettimeofday(&tv, NULL);

--- a/src/utils/os.h
+++ b/src/utils/os.h
@@ -101,7 +101,11 @@ int os_get_time(struct os_time *t);
  * @param t Pointer to buffer for the time
  * @return int 0 on success, -1 on failure
  */
-int os_get_reltime(struct os_reltime *t);
+int edge_os_get_reltime(struct os_reltime *t);
+
+#ifndef os_get_reltime
+#define os_get_reltime(t) edge_os_get_reltime((t))
+#endif
 
 /**
  * @brief Compares the seconds value of two time params


### PR DESCRIPTION
Rename `os_get_reltime` to `edge_os_get_reltime` to avoid linking conflicts with the `os_get_reltime` from libeap.

Use a `#define os_get_reltime edge_os_get_reltime` instead of renaming the function everywhere in our source code.

---

Adapted from https://github.com/nqminds/edgesec/commit/a873368103caf92e3351bf17a9117225f8965366, which renamed `os_get_reltime` to `get_reltime`, and didn't create a macro for `os_get_reltime`, so it had to be renamed in a bunch of places.