### PR TITLE
refactor(os): rename os_memcpy_const with `edge_`

### DIFF
--- a/src/utils/os.c
+++ b/src/utils/os.c
@@ -201,7 +201,7 @@ size_t os_strlcpy(char *restrict dest, const char *restrict src, size_t siz) {
   }
 }
 
-int os_memcmp_const(const void *a, const void *b, size_t len) {
+int edge_os_memcmp_const(const void *a, const void *b, size_t len) {
   const uint8_t *aa = a;
   const uint8_t *bb = b;
   size_t i;

--- a/src/utils/os.h
+++ b/src/utils/os.h
@@ -242,15 +242,17 @@ size_t os_strlcpy(char *restrict dest, const char *restrict src, size_t siz);
  */
 size_t os_strnlen_s(char *str, size_t max_len);
 
+#define os_memcmp_const(a, b, len) edge_os_memcmp_const((a), (b), (len))
+
 /**
  * @brief Constant time memory comparison
  *
  * This function is meant for comparing passwords or hash values where
  * difference in execution time could provide external observer information
  * about the location of the difference in the memory buffers. The return value
- * does not behave like os_memcmp(), i.e., os_memcmp_const() cannot be used to
- * sort items into a defined order. Unlike os_memcmp(), execution time of
- * os_memcmp_const() does not depend on the contents of the compared memory
+ * does not behave like os_memcmp(), i.e., edge_os_memcmp_const() cannot be used
+ * to sort items into a defined order. Unlike os_memcmp(), execution time of
+ * edge_os_memcmp_const() does not depend on the contents of the compared memory
  * buffers, but only on the total compared length.
  *
  * @param a First buffer to compare
@@ -258,7 +260,7 @@ size_t os_strnlen_s(char *str, size_t max_len);
  * @param len Number of octets to compare
  * @return int 0 if buffers are equal, non-zero if not
  */
-int os_memcmp_const(const void *a, const void *b, size_t len);
+int edge_os_memcmp_const(const void *a, const void *b, size_t len);
 
 /*
  * gcc 4.4 ends up generating strict-aliasing warnings about some very common


### PR DESCRIPTION
Rename `os_memcpy_const` to `edge_os_memcpy_const` to avoid linking conflicts with libeap.

I've also added a `#define os_memcmp_const edge_os_memcmp_const` macro, so we don't need to rename anything.

---

Adapted from https://github.com/nqminds/edgesec/commit/8268ac37b092cbd994afcdaf4f880d89b9cb05f5, which renamed `os_memcpy_const` to `sys_memcpy_const`, and didn't create a macro for `os_memcpy_const`, so it had to be renamed in a bunch of places.