### PR TITLE
refactor(os): rename os_get_random with `edge_`

### DIFF
--- a/src/utils/os.c
+++ b/src/utils/os.c
@@ -213,7 +213,7 @@ int os_memcmp_const(const void *a, const void *b, size_t len) {
   return res;
 }
 
-int os_get_random(unsigned char *buf, size_t len) {
+int edge_os_get_random(unsigned char *buf, size_t len) {
   FILE *f;
   size_t rc;
 

--- a/src/utils/os.h
+++ b/src/utils/os.h
@@ -148,6 +148,8 @@ int os_get_timestamp(uint64_t *timestamp);
  */
 void os_to_timestamp(struct timeval ts, uint64_t *timestamp);
 
+#define os_get_random(buf, len) edge_os_get_random((buf), (len))
+
 /**
  * @brief Get cryptographically strong pseudo random data
  *
@@ -155,7 +157,7 @@ void os_to_timestamp(struct timeval ts, uint64_t *timestamp);
  * @param len Length of the buffer.
  * @return int 0 on success, -1 on failure
  */
-int os_get_random(unsigned char *buf, size_t len);
+int edge_os_get_random(unsigned char *buf, size_t len);
 
 /**
  * @brief Return a random int from a give range


### PR DESCRIPTION
Rename `os_get_random()` to `edge_os_get_random()` to avoid linking conflicts with libeap.

I've added a `#define os_get_random edge_os_get_random` macro so that we don't need to change references in the code.

---

Adapted from https://github.com/nqminds/edgesec/commit/d178bacc7469ddba0563182f214f564987b82727, which renamed `os_get_random` to `get_random`, and didn't create a macro for `os_get_random`, so it had to be renamed in a bunch of places.