### PR TITLE
refactor(os): rename os_get_time with edge_ prefix

### DIFF
--- a/src/utils/os.c
+++ b/src/utils/os.c
@@ -145,7 +145,7 @@ int8_t hex2num(char c) {
   return -1;
 }
 
-int os_get_time(struct os_time *t) {
+int edge_os_get_time(struct os_time *t) {
   int res;
   struct timeval tv;
   res = gettimeofday(&tv, NULL);

--- a/src/utils/os.h
+++ b/src/utils/os.h
@@ -87,13 +87,15 @@ struct os_reltime {
  */
 int become_daemon(int flags);
 
+#define os_get_time(t) edge_os_get_time(t)
+
 /**
  * @brief Get current time (sec, usec)
  *
  * @param t Pointer to buffer for the time
  * @return int 0 on success, -1 on failure
  */
-int os_get_time(struct os_time *t);
+int edge_os_get_time(struct os_time *t);
 
 /**
  * @brief Get relative time (sec, usec)


### PR DESCRIPTION
Rename `os_get_time` to `edge_os_get_time` to avoid linking conflits with libeap (it has it's own os_get_time too).

I've added a `#define os_get_time(t) edge_os_get_time(t)` macro so we don't need to change where we use it.

---

Adapted from https://github.com/nqminds/edgesec/commit/a082eff6ab7d131917dd980124b03637e79590e1, which renamed `os_get_time` to `sys_get_time`, and didn't create a macro for `os_get_time`, so it had to be renamed in a bunch of places.