### PR TITLE
Move and inline `os_memdup` into `src/radius/common.h`

### DIFF
--- a/src/radius/common.h
+++ b/src/radius/common.h
@@ -15,6 +15,7 @@
 
 #include <stddef.h>
 
+#include "utils/allocs.h"
 #include "utils/log.h"
 
 typedef uint64_t u64;
@@ -146,6 +147,24 @@ static inline u32 WPA_GET_BE32(const u8 *a) {
 
 static inline u32 WPA_GET_BE24(const u8 *a) {
   return (a[0] << 16) | (a[1] << 8) | a[2];
+}
+
+/**
+ * @brief Allocate duplicate of passed memory chunk
+ *
+ * This function allocates a memory block like os_malloc() would, and
+ * copies the given source buffer into it.
+ *
+ * @param src Source buffer to duplicate
+ * @param len Length of source buffer
+ * @return void* %NULL if allocation failed, copy of src buffer otherwise
+ */
+static inline void *os_memdup(const void *src, size_t len) {
+  void *r = os_malloc(len);
+
+  if (r && src)
+    os_memcpy(r, src, len);
+  return r;
 }
 
 #define wpa_printf(level, ...)                                                 \

--- a/src/utils/allocs.c
+++ b/src/utils/allocs.c
@@ -18,14 +18,6 @@
 
 #include "allocs.h"
 
-void *os_memdup(const void *src, size_t len) {
-  void *r = os_malloc(len);
-
-  if (r && src)
-    os_memcpy(r, src, len);
-  return r;
-}
-
 char *os_strdup(const char *s) {
   char *dest = NULL;
   size_t len = strlen(s) + 1;

--- a/src/utils/allocs.h
+++ b/src/utils/allocs.h
@@ -54,6 +54,10 @@ static inline void *os_realloc_array(void *ptr, size_t nmemb, size_t size) {
   return os_realloc(ptr, nmemb * size);
 }
 
+#ifndef os_memcpy
+#define os_memcpy(d, s, n) memcpy((d), (s), (n))
+#endif
+
 /**
  * @brief Allocate duplicate of passed memory chunk
  *
@@ -64,11 +68,14 @@ static inline void *os_realloc_array(void *ptr, size_t nmemb, size_t size) {
  * @param len Length of source buffer
  * @return void* %NULL if allocation failed, copy of src buffer otherwise
  */
-void *os_memdup(const void *src, size_t len);
+static inline void *os_memdup(const void *src, size_t len) {
+  void *r = os_malloc(len);
 
-#ifndef os_memcpy
-#define os_memcpy(d, s, n) memcpy((d), (s), (n))
-#endif
+  if (r && src)
+    os_memcpy(r, src, len);
+  return r;
+}
+
 #ifndef os_memmove
 #define os_memmove(d, s, n) memmove((d), (s), (n))
 #endif
@@ -80,7 +87,6 @@ void *os_memdup(const void *src, size_t len);
 #endif
 
 /**
- * @brief Returns a pointer to a new string which is a duplicate of the string s
  *
  * @param s The input string
  * @return char* The dublicate string pointer, NULL on error

--- a/src/utils/allocs.h
+++ b/src/utils/allocs.h
@@ -57,25 +57,6 @@ static inline void *os_realloc_array(void *ptr, size_t nmemb, size_t size) {
 #ifndef os_memcpy
 #define os_memcpy(d, s, n) memcpy((d), (s), (n))
 #endif
-
-/**
- * @brief Allocate duplicate of passed memory chunk
- *
- * This function allocates a memory block like os_malloc() would, and
- * copies the given source buffer into it.
- *
- * @param src Source buffer to duplicate
- * @param len Length of source buffer
- * @return void* %NULL if allocation failed, copy of src buffer otherwise
- */
-static inline void *os_memdup(const void *src, size_t len) {
-  void *r = os_malloc(len);
-
-  if (r && src)
-    os_memcpy(r, src, len);
-  return r;
-}
-
 #ifndef os_memmove
 #define os_memmove(d, s, n) memmove((d), (s), (n))
 #endif


### PR DESCRIPTION
Change `os_memdup` to use `static inline` so that it uses internal linkage, to avoid conflicts with the `os_memdup` function defined in libeap.

I've also moved it from `src/utils/allocs` to `src/utils/common`.

---

Adapted from https://github.com/nqminds/edgesec/commit/e604195e077a58e5ac97a430310d54b2ae141b6c, except with a different commit message and fixed merge conflicts.