### PR TITLE
refactor(net): rename `hwaddr_aton2` with `edge_ `

### DIFF
--- a/src/utils/net.c
+++ b/src/utils/net.c
@@ -199,7 +199,7 @@ int disable_pmtu_discovery(int sock) {
   return 0;
 }
 
-int hwaddr_aton2(const char *txt, uint8_t *addr) {
+int edge_hwaddr_aton2(const char *txt, uint8_t *addr) {
   int i;
   const char *pos = txt;
 

--- a/src/utils/net.c
+++ b/src/utils/net.c
@@ -206,8 +206,9 @@ int edge_hwaddr_aton2(const char *txt, uint8_t *addr) {
   for (i = 0; i < 6; i++) {
     int a, b;
 
-    while (*pos == ':' || *pos == '.' || *pos == '-')
+    while (*pos == ':' || *pos == '.' || *pos == '-') {
       pos++;
+    }
 
     a = hex2num(*pos++);
     if (a < 0)

--- a/src/utils/net.h
+++ b/src/utils/net.h
@@ -152,6 +152,8 @@ int disable_pmtu_discovery(int sock);
  * @param[out] addr Buffer for the MAC address (ETHER_ADDR_LEN = 6 bytes)
  * @return int Characters used (> 0) on success, -1 on failure
  */
-int hwaddr_aton2(const char *txt, uint8_t *addr);
+int edge_hwaddr_aton2(const char *txt, uint8_t *addr);
+
+#define hwaddr_aton2(txt, addr) edge_hwaddr_aton2((txt), (addr))
 
 #endif


### PR DESCRIPTION
Rename `hwaddr_aton2` to `edge_hwaddr_aton2` to avoid potential linking errors with libeap.

I've added a `#define hwaddr_aton2(t) edge_hwaddr_aton2(t)` macro so we don't need to change where we use it.

---

Adapted from https://github.com/nqminds/edgesec/commit/5c5a32c3c891c5e269224a03656eae5abd2fe765, which renamed `hwaddr_aton2` to `convert_ascii2mac`.

Commit https://github.com/nqminds/edgesec/commit/17cf5d7772357233b5218b8c12315b6610feff0d also added curly-braces around the `while (*pos == ':' || *pos == '.' || *pos == '-')` loop in `hwaddr_aton2()`, so I extracted that into its own commit.