### PR TITLE
refactor(md5_internal): rename `md5_vector` with `edge_` prefix

### DIFF
--- a/src/radius/md5_internal.c
+++ b/src/radius/md5_internal.c
@@ -25,14 +25,6 @@ static void MD5Transform(uint32_t buf[4], uint32_t const in[16]);
 
 typedef struct MD5Context MD5_CTX;
 
-/**
- * md5_vector - MD5 hash for data vector
- * @num_elem: Number of elements in the data vector
- * @addr: Pointers to the data areas
- * @len: Lengths of the data blocks
- * @mac: Buffer for the hash
- * Returns: 0 on success, -1 of failure
- */
 int edge_md5_vector(size_t num_elem, const uint8_t *addr[], const size_t *len,
                     uint8_t *mac) {
   MD5_CTX ctx;

--- a/src/radius/md5_internal.c
+++ b/src/radius/md5_internal.c
@@ -33,8 +33,8 @@ typedef struct MD5Context MD5_CTX;
  * @mac: Buffer for the hash
  * Returns: 0 on success, -1 of failure
  */
-int md5_vector(size_t num_elem, const uint8_t *addr[], const size_t *len,
-               uint8_t *mac) {
+int edge_md5_vector(size_t num_elem, const uint8_t *addr[], const size_t *len,
+                    uint8_t *mac) {
   MD5_CTX ctx;
   size_t i;
 

--- a/src/radius/md5_internal.h
+++ b/src/radius/md5_internal.h
@@ -28,6 +28,16 @@ struct MD5Context {
 #define md5_vector(num_elem, addr, len, mac)                                   \
   edge_md5_vector((num_elem), (addr), (len), (mac))
 
+/**
+ * MD5 hash for data vector
+ *
+ * @param num_elem Number of elements in the data vector
+ * @param addr Pointers to the data areas
+ * @param len Lengths of the data blocks
+ * @param[out] mac Buffer for the hash
+ * @retval  0 on success
+ * @retval -1 on failure
+ */
 int edge_md5_vector(size_t num_elem, const uint8_t *addr[], const size_t *len,
                     uint8_t *mac);
 

--- a/src/radius/md5_internal.h
+++ b/src/radius/md5_internal.h
@@ -37,6 +37,15 @@ struct MD5Context {
  * @param[out] mac Buffer for the hash
  * @retval  0 on success
  * @retval -1 on failure
+ *
+ * @author Jouni Malinen <j@w1.fi>
+ * @date 2009
+ * @copyright SPDX-License-Identifier: BSD-3-Clause
+ * @remarks
+ * The source of this code was adapted from `md5_internal()` in commit
+ * 0a5d68aba50c385e316a30d834d5b6174a4041d2 in `src/crypto/md5-internal.c`
+ * of the hostap project, see
+ * https://w1.fi/cgit/hostap/tree/src/crypto/md5-internal.c?id=0a5d68aba50c385e316a30d834d5b6174a4041d2#n34
  */
 int edge_md5_vector(size_t num_elem, const uint8_t *addr[], const size_t *len,
                     uint8_t *mac);

--- a/src/radius/md5_internal.h
+++ b/src/radius/md5_internal.h
@@ -25,8 +25,11 @@ struct MD5Context {
   uint8_t in[64];
 };
 
-int md5_vector(size_t num_elem, const uint8_t *addr[], const size_t *len,
-               uint8_t *mac);
+#define md5_vector(num_elem, addr, len, mac)                                   \
+  edge_md5_vector((num_elem), (addr), (len), (mac))
+
+int edge_md5_vector(size_t num_elem, const uint8_t *addr[], const size_t *len,
+                    uint8_t *mac);
 
 void MD5Init(struct MD5Context *context);
 void MD5Update(struct MD5Context *context, unsigned char const *buf,


### PR DESCRIPTION
Rename `md5_vector()` to `edge_md5_vector()` to avoid linking conflicts with libeap.

I've added a `#define md5_vector edge_md5_vector`, so that we don't need to change any usages of this function.

---

Adapted from https://github.com/nqminds/edgesec/commit/31bfdfd489ea6fb182509393fc35cb00e37f8ee0, which renamed `md5_vector` to `md5_vector_base`, and didn't create a macro for `md5_vector`, so it had to be renamed in a bunch of places.

(also, that commit has a bunch of other RADIUS junk in it).