### PR TITLE
refactor(md5): avoid linker naming conflicts in `hmac_md5*` functions

### DIFF
--- a/src/radius/md5.c
+++ b/src/radius/md5.c
@@ -30,8 +30,9 @@
  * @mac: Buffer for the hash (16 bytes)
  * Returns: 0 on success, -1 on failure
  */
-int hmac_md5_vector(const uint8_t *key, size_t key_len, size_t num_elem,
-                    const uint8_t *addr[], const size_t *len, uint8_t *mac) {
+static inline int hmac_md5_vector(const uint8_t *key, size_t key_len,
+                                  size_t num_elem, const uint8_t *addr[],
+                                  const size_t *len, uint8_t *mac) {
   uint8_t k_pad[64]; /* padding - key XORd with ipad/opad */
   uint8_t tk[16];
   const uint8_t *_addr[6];

--- a/src/radius/md5.c
+++ b/src/radius/md5.c
@@ -100,7 +100,7 @@ static inline int hmac_md5_vector(const uint8_t *key, size_t key_len,
 }
 
 /**
- * hmac_md5 - HMAC-MD5 over data buffer (RFC 2104)
+ * edge_hmac_md5 - HMAC-MD5 over data buffer (RFC 2104)
  * @key: Key for HMAC operations
  * @key_len: Length of the key in bytes
  * @data: Pointers to the data area
@@ -108,7 +108,7 @@ static inline int hmac_md5_vector(const uint8_t *key, size_t key_len,
  * @mac: Buffer for the hash (16 bytes)
  * Returns: 0 on success, -1 on failure
  */
-int hmac_md5(const uint8_t *key, size_t key_len, const uint8_t *data,
-             size_t data_len, uint8_t *mac) {
+int edge_hmac_md5(const uint8_t *key, size_t key_len, const uint8_t *data,
+                  size_t data_len, uint8_t *mac) {
   return hmac_md5_vector(key, key_len, 1, &data, &data_len, mac);
 }

--- a/src/radius/md5.c
+++ b/src/radius/md5.c
@@ -99,15 +99,6 @@ static inline int hmac_md5_vector(const uint8_t *key, size_t key_len,
   return res;
 }
 
-/**
- * edge_hmac_md5 - HMAC-MD5 over data buffer (RFC 2104)
- * @key: Key for HMAC operations
- * @key_len: Length of the key in bytes
- * @data: Pointers to the data area
- * @data_len: Length of the data area
- * @mac: Buffer for the hash (16 bytes)
- * Returns: 0 on success, -1 on failure
- */
 int edge_hmac_md5(const uint8_t *key, size_t key_len, const uint8_t *data,
                   size_t data_len, uint8_t *mac) {
   return hmac_md5_vector(key, key_len, 1, &data, &data_len, mac);

--- a/src/radius/md5.h
+++ b/src/radius/md5.h
@@ -34,6 +34,15 @@
  * @param[out] mac Buffer for the hash (16 bytes)
  * @retval  0 on success
  * @retval -1 on failure
+ *
+ * @author Jouni Malinen <j@w1.fi>
+ * @date 2003-2009
+ * @copyright SPDX-License-Identifier: BSD-3-Clause
+ * @remarks
+ * The source of this code was adapted from `hmac_md5()` in commit
+ * 0a5d68aba50c385e316a30d834d5b6174a4041d2 in `src/crypto/md5.c`
+ * of the hostap project, see
+ * https://w1.fi/cgit/hostap/tree/src/crypto/md5.c?id=0a5d68aba50c385e316a30d834d5b6174a4041d2#n98
  */
 int edge_hmac_md5(const uint8_t *key, size_t key_len, const uint8_t *data,
                   size_t data_len, uint8_t *mac);

--- a/src/radius/md5.h
+++ b/src/radius/md5.h
@@ -24,6 +24,15 @@
 #define hmac_md5(key, key_len, data, data_len, mac)                            \
   edge_hmac_md5((key), (key_len), (data), (data_len), (mac))
 
+/**
+ * edge_hmac_md5 - HMAC-MD5 over data buffer (RFC 2104)
+ * @key: Key for HMAC operations
+ * @key_len: Length of the key in bytes
+ * @data: Pointers to the data area
+ * @data_len: Length of the data area
+ * @mac: Buffer for the hash (16 bytes)
+ * Returns: 0 on success, -1 on failure
+ */
 int edge_hmac_md5(const uint8_t *key, size_t key_len, const uint8_t *data,
                   size_t data_len, uint8_t *mac);
 

--- a/src/radius/md5.h
+++ b/src/radius/md5.h
@@ -21,8 +21,6 @@
 
 #define MD5_MAC_LEN 16
 
-int hmac_md5_vector(const uint8_t *key, size_t key_len, size_t num_elem,
-                    const uint8_t *addr[], const size_t *len, uint8_t *mac);
 int hmac_md5(const uint8_t *key, size_t key_len, const uint8_t *data,
              size_t data_len, uint8_t *mac);
 

--- a/src/radius/md5.h
+++ b/src/radius/md5.h
@@ -21,7 +21,10 @@
 
 #define MD5_MAC_LEN 16
 
-int hmac_md5(const uint8_t *key, size_t key_len, const uint8_t *data,
-             size_t data_len, uint8_t *mac);
+#define hmac_md5(key, key_len, data, data_len, mac)                            \
+  edge_hmac_md5((key), (key_len), (data), (data_len), (mac))
+
+int edge_hmac_md5(const uint8_t *key, size_t key_len, const uint8_t *data,
+                  size_t data_len, uint8_t *mac);
 
 #endif /* MD5_H */

--- a/src/radius/md5.h
+++ b/src/radius/md5.h
@@ -25,13 +25,15 @@
   edge_hmac_md5((key), (key_len), (data), (data_len), (mac))
 
 /**
- * edge_hmac_md5 - HMAC-MD5 over data buffer (RFC 2104)
- * @key: Key for HMAC operations
- * @key_len: Length of the key in bytes
- * @data: Pointers to the data area
- * @data_len: Length of the data area
- * @mac: Buffer for the hash (16 bytes)
- * Returns: 0 on success, -1 on failure
+ * HMAC-MD5 over data buffer (RFC 2104)
+ *
+ * @param key Key for HMAC operations
+ * @param key_len Length of the key in bytes
+ * @param data Pointers to the data area
+ * @param data_len Length of the data area
+ * @param[out] mac Buffer for the hash (16 bytes)
+ * @retval  0 on success
+ * @retval -1 on failure
  */
 int edge_hmac_md5(const uint8_t *key, size_t key_len, const uint8_t *data,
                   size_t data_len, uint8_t *mac);


### PR DESCRIPTION
Rename/inline functions in `src/radius/md5.c` to avoid linker naming conflicts with libeap.

**[refactor(md5): rename `hmac_md5` with `edge_` prefix](https://github.com/nqminds/edgesec/commit/7d518e32354357512a621b967fe81c1be00924f4)** 

Rename `hmac_md5` to `edge_hmac_md5` to avoid a linker conflict when linking with libeap.

I've added a `#define hmac_md5 edge_hmac_md5`, so that we don't need to change any usage of this function.

**[refactor(md5): inline `hmac_md5_vector` in `md5.c`](https://github.com/nqminds/edgesec/commit/b470ebeacf3c7c81706734f34dbfd1f9cfbadefb)** 

We never use the `hmac_md5_vector()` function anywhere except in `md5.c`, so we might as well inline it. This also helps avoid linker conflicts when linking libeap, which also has a `hmac_md5_vector`.

---

Adapted from https://github.com/nqminds/edgesec/commit/a71d948501e1b1252577720172ffc8405b814a3b, which renamed `hmac_md5` to `hmac_md5_base` and renamed `hmac_md5_vector` to `hmac_md5_vector_base`.