### PR TITLE
feat(os): add `os_strncmp` definition

### DIFF
--- a/src/utils/os.h
+++ b/src/utils/os.h
@@ -61,6 +61,10 @@
 #define os_strlen(s) strlen((s))
 #endif
 
+#ifndef os_strncmp
+#define os_strncmp(s1, s2, n) strncmp((s1), (s2), (n))
+#endif
+
 struct find_dir_type {
   int proc_running;
   char *proc_name;


### PR DESCRIPTION
Source-code taken from the hostap project expects a `os_strncmp` call that points to [`strncmp`](https://en.cppreference.com/w/c/string/byte/strncmp).

---

Adapted from commit https://github.com/nqminds/edgesec/commits/12d15b2405aa6f2ab39a31d880499f8fc6f84c02, which instead names this macro `sys_strncmp`.

https://github.com/nqminds/edgesec/blob/12d15b2405aa6f2ab39a31d880499f8fc6f84c02/src/utils/os.h#L67-L69

Using `os_strncmp` is a lot easier, since then we can avoid changing any of the hostap code.