### PR TITLE
feat(os): add `os_strstr` definition

### DIFF
--- a/src/utils/os.h
+++ b/src/utils/os.h
@@ -61,6 +61,10 @@
 #define os_strlen(s) strlen((s))
 #endif
 
+#ifndef os_strncmp
+#define os_strncmp(s1, s2, n) strncmp((s1), (s2), (n))
+#endif
+
 struct find_dir_type {
   int proc_running;
   char *proc_name;

--- a/src/utils/os.h
+++ b/src/utils/os.h
@@ -65,6 +65,15 @@
 #define os_strncmp(s1, s2, n) strncmp((s1), (s2), (n))
 #endif
 
+#ifndef os_strstr
+/**
+ * @brief Macro to strstr() for code taken from hostap.
+ * @remarks strstr() is a type-generic function in C23 and might not return a
+ * a `char *`.
+ */
+#define os_strstr(s1, s2) strstr((s1), (s2))
+#endif
+
 struct find_dir_type {
   int proc_running;
   char *proc_name;


### PR DESCRIPTION
Source-code taken from the hostap project expects a `os_strstr` function/macro that points to `strstr`.

I've added a doc-string since [`strstr` is a type-generic function in C23][1], so it's has some unusual behaviour.

[1]: https://en.cppreference.com/w/c/string/byte/strstr

---

Adapted from commit https://github.com/nqminds/edgesec/commit/12d15b2405aa6f2ab39a31d880499f8fc6f84c02, which instead uses `sys_strstr`, and instead of macro, it just declares a function called `sys_strstr`, but never defines it anywhere:

https://github.com/nqminds/edgesec/blob/12d15b2405aa6f2ab39a31d880499f8fc6f84c02/src/utils/os.h#L88-L94

It also has a nice doc-string, but since [`strstr`][1] is a built-in ISO C function, it's probably not too important to have a doc-string (I think Doxygen should auto-link it to cppreference.com anyway).

---

**Blocked/draft until the following PR is merged:**
  - https://github.com/nqminds/edgesec/pull/430
