### PR TITLE
test(eloop): test if 1mil µs overflows to 1s

### DIFF
--- a/tests/utils/test_eloop_threaded.c
+++ b/tests/utils/test_eloop_threaded.c
@@ -229,9 +229,18 @@ static void test_eloop_sock(void **state) {
                          send_data_to_sock, &eloop_ctx, &test2),
                      0);
 
+  // one million microseconds should rollover to 1 second
+  make_struct_test_eloop_sock_user_ctx(
+      test1Second, "CↈↃµs (one million in ancient roman numerals)");
+  utarray_push_back(sent_data, &test1Second.data);
+  assert_return_code(edge_eloop_register_timeout(test_state->eloop, 0, 1000000,
+                                                 send_data_to_sock, &eloop_ctx,
+                                                 &test1Second),
+                     0);
+
   make_struct_test_eloop_sock_user_ctx(stop_packet, "STOP");
   utarray_push_back(sent_data, &stop_packet.data);
-  assert_return_code(edge_eloop_register_timeout(test_state->eloop, 1, 0,
+  assert_return_code(edge_eloop_register_timeout(test_state->eloop, 1, 1,
                                                  send_data_to_sock, &eloop_ctx,
                                                  &stop_packet),
                      0);


### PR DESCRIPTION
Test whether 1 million microseconds overflows to 1 second when running `edge_eloop_register_timeout()`.

This was causing code-coverage issues, because this path was occasionally not run in the current tests.

![image](https://user-images.githubusercontent.com/19716675/220184058-e169eebe-8d2b-44c7-b820-fb07ec515eef.png)

(source-code available at https://w1.fi/cgit/hostap/tree/src/utils/eloop.c?h=hostap_2_10#n791)
