### PR TITLE
refactor(attributes): fix `STRUCT_PACKED` in clang

### DIFF
--- a/src/utils/attributes.h
+++ b/src/utils/attributes.h
@@ -34,6 +34,16 @@
 
 #if defined __has_attribute
 #if __has_attribute(packed)
+/**
+ * Use as little memory as possible for the attributed `enum`, `struct`, or
+ * `union`.
+ *
+ * @remarks Please be aware that this packing algorithm is platform specific.
+ * Even using GCC on Windows has different results:
+ * see https://gcc.gnu.org/onlinedocs/gcc/x86-Variable-Attributes.html
+ *
+ * @see https://clang.llvm.org/docs/AttributeReference.html#packed
+ */
 #define STRUCT_PACKED __attribute__((packed))
 #else
 #define STRUCT_PACKED

--- a/src/utils/attributes.h
+++ b/src/utils/attributes.h
@@ -32,10 +32,14 @@
 #endif /* defined __has_attribute */
 #endif /* __maybe_unused */
 
-#ifdef __GNUC__
+#if defined __has_attribute
+#if __has_attribute(packed)
 #define STRUCT_PACKED __attribute__((packed))
 #else
 #define STRUCT_PACKED
-#endif
+#endif /* __has_attribute(packed) */
+#else
+#define STRUCT_PACKED
+#endif /* defined __has_attribute */
 
 #endif /* ATTRIBUTES_H */


### PR DESCRIPTION
Use the [`__has_attribute`][1] macro to check for compiler support for `__attribute__((packed))`, so that `STRUCT_PACKED` also works on the Clang compiler.

(`__has_attribute` is supported by GCC, Clang, IBM compiler, and even the Oracle® Solaris Studio C compiler).

[1]: https://clang.llvm.org/docs/LanguageExtensions.html#has-attribute

