### PR TITLE
feat(os): add `os_snprintf` definition

### DIFF
--- a/src/utils/os.h
+++ b/src/utils/os.h
@@ -55,6 +55,10 @@
 #define os_strlen(s) strlen((s))
 #endif
 
+#ifndef os_snprintf
+#define os_snprintf(s, maxlen, ...) snprintf((s), (maxlen), __VA_ARGS__)
+#endif
+
 #ifndef os_strncmp
 #define os_strncmp(s1, s2, n) strncmp((s1), (s2), (n))
 #endif


### PR DESCRIPTION
Source-code taken from the hostap project expects a `os_snprintf` function/macro that points to the ISO C99 `snprintf`.

---

Adapted from commit https://github.com/nqminds/edgesec/commit/dff384c0c21e41af7da63a45bfb3574322a6f9c8.

I've instead given it some arguments to make it clear that it's a function.

