### PR TITLE
feat(common): add `os_snprintf_error()`

### DIFF
--- a/src/radius/common.h
+++ b/src/radius/common.h
@@ -150,6 +150,23 @@ static inline u32 WPA_GET_BE24(const u8 *a) {
   return (a[0] << 16) | (a[1] << 8) | a[2];
 }
 
+/**
+ * Returns `true` if `snprintf` was truncated.
+ *
+ * @param size - Size of snprintf() output buffer.
+ * @param res - Return code from snprintf()
+ * @retval 0 if snprintf() was successful
+ * @retval 1 if snprintf() failed
+ *
+ * @author Jouni Malinen <j@w1.fi>
+ * @remarks Taken from commit 0047306bc9ab7d46e8cc22ff9a3e876c47626473 of
+ * hostap, see
+ * https://w1.fi/cgit/hostap/commit/?id=0047306bc9ab7d46e8cc22ff9a3e876c47626473
+ */
+static inline int os_snprintf_error(size_t size, int res) {
+  return res < 0 || (unsigned int)res >= size;
+}
+
 #define wpa_printf(level, ...)                                                 \
   log_levels(LOGC_TRACE, __FILENAME__, __LINE__, __VA_ARGS__)
 #define wpa_snprintf_hex(buf, buf_size, data, len)                             \


### PR DESCRIPTION
Add `os_snprintf_error()` function from commit [0047306bc9ab7d46e8cc22ff9a3e876c47626473][1] from the hostap project.

It is used by source-code taken from hostap.

(side-note, we should probably be using it in our own code too!)

[1]: https://w1.fi/cgit/hostap/commit/?id=0047306bc9ab7d46e8cc22ff9a3e876c47626473

---

Adapted from commit https://github.com/nqminds/edgesec/commit/dff384c0c21e41af7da63a45bfb3574322a6f9c8.

I've also given the function a doc-string, and documented where the function came from.