### PR TITLE
refactor(allocs): add `__must_check` compiler attribute

### DIFF
--- a/src/utils/CMakeLists.txt
+++ b/src/utils/CMakeLists.txt
@@ -3,6 +3,7 @@ add_library(log log.c)
 set_target_properties(log PROPERTIES C_EXTENSIONS ON POSITION_INDEPENDENT_CODE ON)
 
 add_library(allocs allocs.c)
+target_link_libraries(allocs PUBLIC attributes)
 
 add_library(attributes INTERFACE) # #define's for compiler attributes
 set_target_properties(attributes PROPERTIES PUBLIC_HEADER "attributes.h")

--- a/src/utils/allocs.h
+++ b/src/utils/allocs.h
@@ -19,24 +19,7 @@
 #include <sys/types.h>
 #include <unistd.h>
 
-#ifndef __must_check
-#if defined __has_attribute
-#if __has_attribute(__warn_unused_result__)
-/**
- * If used before a function, tells compilers that the result of the function
- * should be used and not ignored.
- *
- * @see
- * https://clang.llvm.org/docs/AttributeReference.html#nodiscard-warn-unused-result
- */
-#define __must_check __attribute__((__warn_unused_result__))
-#else
-#define __must_check
-#endif /* __has_attribute(__warn_unused_result__) */
-#else
-#define __must_check
-#endif /* defined __has_attribute */
-#endif /* __has_attribute */
+#include "./attributes.h"
 
 /**
  * @brief Allocate and zero memory

--- a/src/utils/allocs.h
+++ b/src/utils/allocs.h
@@ -46,7 +46,9 @@
  * @param size Number of bytes to allocate
  * @return void* Pointer to allocated and zeroed memory or %NULL on failure
  */
-static inline void *os_zalloc(size_t size) { return calloc(size, 1); }
+__must_check static inline void *os_zalloc(size_t size) {
+  return calloc(size, 1);
+}
 
 // void *os_malloc(size_t size);
 // void os_free(void* ptr);
@@ -67,7 +69,8 @@ static inline void *os_zalloc(size_t size) { return calloc(size, 1); }
 #define os_free(p) free((p))
 #endif
 
-static inline void *os_realloc_array(void *ptr, size_t nmemb, size_t size) {
+__must_check static inline void *os_realloc_array(void *ptr, size_t nmemb,
+                                                  size_t size) {
   if (size && nmemb > (~(size_t)0) / size)
     return NULL;
   return os_realloc(ptr, nmemb * size);
@@ -103,7 +106,7 @@ static inline void *os_realloc_array(void *ptr, size_t nmemb, size_t size) {
  * see
  * https://w1.fi/cgit/hostap/commit/?id=dbdda355d0add3f7d96e3279321d3a63abfc4b32
  */
-static inline void *os_memdup(const void *src, size_t len) {
+__must_check static inline void *os_memdup(const void *src, size_t len) {
   void *r = os_malloc(len);
 
   if (r && src)
@@ -116,5 +119,5 @@ static inline void *os_memdup(const void *src, size_t len) {
  * @param s The input string
  * @return char* The dublicate string pointer, NULL on error
  */
-char *os_strdup(const char *s);
+__must_check char *os_strdup(const char *s);
 #endif

--- a/src/utils/allocs.h
+++ b/src/utils/allocs.h
@@ -19,6 +19,25 @@
 #include <sys/types.h>
 #include <unistd.h>
 
+#ifndef __must_check
+#if defined __has_attribute
+#if __has_attribute(__warn_unused_result__)
+/**
+ * If used before a function, tells compilers that the result of the function
+ * should be used and not ignored.
+ *
+ * @see
+ * https://clang.llvm.org/docs/AttributeReference.html#nodiscard-warn-unused-result
+ */
+#define __must_check __attribute__((__warn_unused_result__))
+#else
+#define __must_check
+#endif /* __has_attribute(__warn_unused_result__) */
+#else
+#define __must_check
+#endif /* defined __has_attribute */
+#endif /* __has_attribute */
+
 /**
  * @brief Allocate and zero memory
  *

--- a/src/utils/attributes.h
+++ b/src/utils/attributes.h
@@ -13,6 +13,25 @@
 #ifndef ATTRIBUTES_H
 #define ATTRIBUTES_H
 
+#ifndef __must_check
+#if defined __has_attribute
+#if __has_attribute(__warn_unused_result__)
+/**
+ * If used before a function, tells compilers that the result of the function
+ * should be used and not ignored.
+ *
+ * @see
+ * https://clang.llvm.org/docs/AttributeReference.html#nodiscard-warn-unused-result
+ */
+#define __must_check __attribute__((__warn_unused_result__))
+#else
+#define __must_check
+#endif /* __has_attribute(__warn_unused_result__) */
+#else
+#define __must_check
+#endif /* defined __has_attribute */
+#endif /* __has_attribute */
+
 #ifndef __maybe_unused
 #if defined __has_attribute
 #if __has_attribute(unused)


### PR DESCRIPTION
Add a `__must_check` attribute to that tells Clang/GCC that the return code for a function must be used.

This attribute may be used by code taken from the `hostap` project.

The original implementation from `hostap` was GCC specific, so I modified it to work with Clang as well.

---

Adapted from commit https://github.com/nqminds/edgesec/commit/dff384c0c21e41af7da63a45bfb3574322a6f9c8, although that was in `src/utils/common.h` and only worked for GCC, not Clang.

---

Since we've added it, I've also set `__must_check` on a bunch of functions that returns a pointer that must be free-d, such as:
  - `os_zalloc`
  - `os_memdup`
  - `os_realloc_array`
  - `os_strdup`

The return values of all these functions must be `free()`-ed, so it's a bug if we don't check their return codes.