### PR TITLE
refactor(log): use C99 bool as `printf_hex` param

### DIFF
--- a/src/radius/common.h
+++ b/src/radius/common.h
@@ -153,7 +153,7 @@ static inline u32 WPA_GET_BE24(const u8 *a) {
 #define wpa_printf(level, ...)                                                 \
   log_levels(LOGC_TRACE, __FILENAME__, __LINE__, __VA_ARGS__)
 #define wpa_snprintf_hex(buf, buf_size, data, len)                             \
-  printf_hex(buf, buf_size, data, len, 0)
+  printf_hex(buf, buf_size, data, len, false)
 
 static inline void printf_encode(char *txt, size_t maxlen, const uint8_t *data,
                                  size_t len) {

--- a/src/utils/log.c
+++ b/src/utils/log.c
@@ -312,7 +312,7 @@ void log_error_exit_proc(uint8_t level, const char *file, uint32_t line,
 }
 
 size_t printf_hex(char *buf, size_t buf_size, const uint8_t *data, size_t len,
-                  int uppercase) {
+                  bool uppercase) {
   size_t i;
   char *pos = buf, *end = buf + buf_size;
   int ret;

--- a/src/utils/log.h
+++ b/src/utils/log.h
@@ -87,6 +87,29 @@ void log_error_exit(uint8_t level, const char *file, uint32_t line,
 void log_error_exit_proc(uint8_t level, const char *file, uint32_t line,
                          const char *format, ...);
 
+/**
+ * @brief Prints the data in @c data to @c buf as hex.
+ *
+ * Prints the data in @c data to @c buf as hex.
+ *
+ * @param[out] buf The output string buffer.
+ * @param buf_size The size of the output buffer, @c buf.
+ * As this will NUL terminated, make sure that this is an odd number,
+ * otherwise you may cut a hex-byte in half.
+ * @param[in] data The input data to print to @c buf.
+ * @param len The length of @c data.
+ * @param uppercase If `0`, print hex in lowercase. If `>0`, print hex in
+ * uppercase.
+ * @return The number of hex characters that have been written to `buf` without
+ * truncation. This excludes the `NUL`-terminator.
+ *
+ * @author Jouni Malinen <j@w1.fi>
+ * @copyright SPDX-License-Identifier: BSD-3-clause
+ * @author Alexandru Mereacre
+ * @remark Adapted from hostap's `src/utils/common.c`, see
+ * https://w1.fi/cgit/hostap/tree/src/utils/common.c?h=hostap_2_10#n317,
+ * except with additional NULL pointer checking.
+ */
 size_t printf_hex(char *buf, size_t buf_size, const uint8_t *data, size_t len,
                   int uppercase);
 #endif

--- a/src/utils/log.h
+++ b/src/utils/log.h
@@ -98,7 +98,7 @@ void log_error_exit_proc(uint8_t level, const char *file, uint32_t line,
  * otherwise you may cut a hex-byte in half.
  * @param[in] data The input data to print to @c buf.
  * @param len The length of @c data.
- * @param uppercase If `0`, print hex in lowercase. If `>0`, print hex in
+ * @param uppercase If `false`, print hex in lowercase. If `true`, print hex in
  * uppercase.
  * @return The number of hex characters that have been written to `buf` without
  * truncation. This excludes the `NUL`-terminator.
@@ -111,5 +111,5 @@ void log_error_exit_proc(uint8_t level, const char *file, uint32_t line,
  * except with additional NULL pointer checking.
  */
 size_t printf_hex(char *buf, size_t buf_size, const uint8_t *data, size_t len,
-                  int uppercase);
+                  bool uppercase);
 #endif


### PR DESCRIPTION
Instead of using an `int` that is either `0` or `1` for the param `uppercase` in the function `printf_hex()`, we can instead use an ISO C99 `bool` that is `true` or `false`.

---

While I was at it, I also documented what the `printf_hex` function does, because the return code is a bit intuitive.

I've also documented that the code is taken from hostap at https://w1.fi/cgit/hostap/tree/src/utils/common.c?h=hostap_2_10#n317 and is covered by the `BSD-3-Clause` license.
