### PR TITLE
feat(common): add wpa_hexdump_ascii function

### DIFF
--- a/src/radius/common.h
+++ b/src/radius/common.h
@@ -155,6 +155,27 @@ static inline u32 WPA_GET_BE24(const u8 *a) {
 #define wpa_snprintf_hex(buf, buf_size, data, len)                             \
   printf_hex(buf, buf_size, data, len, 0)
 
+/**
+ * Prints the first 15-bytes of the given buffer with the given title.
+ *
+ * @param level priority level of the message
+ * @param title of for the message
+ * @param data buffer to be dumped
+ * @param length of the buf
+ *
+ * @remarks Designed to have the same API as hostap's wpa_hexdump_ascii(),
+ * see https://w1.fi/cgit/hostap/tree/src/utils/wpa_debug.h?h=hostap_2_10#n118
+ * However, it prints every byte as hex, and never prints bytes as ASCII.
+ */
+static inline void
+wpa_hexdump_ascii(__maybe_unused int level, // used by hostap, but our
+                                            // implementation doesn't use it
+                  const char *title, const void *buf, size_t len) {
+  char hex_buf[32];
+  printf_hex(hex_buf, 32, buf, len, false);
+  log_trace("%s - hexdump(len=%lu):%s", title, len, hex_buf);
+}
+
 static inline void printf_encode(char *txt, size_t maxlen, const uint8_t *data,
                                  size_t len) {
   char *end = txt + maxlen;

--- a/src/radius/common.h
+++ b/src/radius/common.h
@@ -156,7 +156,7 @@ static inline u32 WPA_GET_BE24(const u8 *a) {
   printf_hex(buf, buf_size, data, len, 0)
 
 /**
- * Prints the first 15-bytes of the given buffer with the given title.
+ * Prints the first 16-bytes of the given buffer with the given title.
  *
  * @param level priority level of the message
  * @param title of for the message
@@ -171,8 +171,8 @@ static inline void
 wpa_hexdump_ascii(__maybe_unused int level, // used by hostap, but our
                                             // implementation doesn't use it
                   const char *title, const void *buf, size_t len) {
-  char hex_buf[32];
-  printf_hex(hex_buf, 32, buf, len, false);
+  char hex_buf[33];
+  printf_hex(hex_buf, sizeof(hex_buf), buf, len, false);
   log_trace("%s - hexdump(len=%lu):%s", title, len, hex_buf);
 }
 


### PR DESCRIPTION
Add `wpa_hexdump_ascii` to match the API of `wpa_hexdump_ascii()` from hostap.

Please note that this function acts differently from the hostap version of the function:
  - It only prints the first 16 bytes.
  - It prints all bytes as hex, never as ASCII.

---

Adapted from commit https://github.com/nqminds/edgesec/commit/dff384c0c21e41af7da63a45bfb3574322a6f9c8.

My changes compared to https://github.com/nqminds/edgesec/commit/dff384c0c21e41af7da63a45bfb3574322a6f9c8:
  - Added documentation
  - Use `__maybe_unused` (from https://github.com/nqminds/edgesec/commit/5a3a8bf22e4976c8fe9ff37daa1e221fd299da01) to mark the unused `level` param.
  - I've changed the number of bytes in the buffer to 33 instead of 32. This is because we need a byte for the `NUL`-terminator too (see https://github.com/nqminds/edgesec/pull/439/commits/24fe4cbd56740bc828bc2016652dad59b6b67c24 for more information), otherwise `printf_hex` causes a mid-byte truncation issue.
