### PR TITLE
doc(common): document `wpa_trace_show` definition

### DIFF
--- a/src/radius/common.h
+++ b/src/radius/common.h
@@ -209,8 +209,18 @@ static inline void printf_encode(char *txt, size_t maxlen, const uint8_t *data,
 }
 
 #ifndef wpa_trace_show
+/**
+ * Dummy implementation of hostap's wpa_trace_show()
+ *
+ * @see https://w1.fi/cgit/hostap/tree/src/utils/trace.h?h=hostap_2_10#n33
+ *
+ * @note
+ * In the future, we could use something like GCC's backtrace_symbols()
+ * to implement this,
+ * https://www.gnu.org/software/libc/manual/html_node/Backtraces.html
+ */
 #define wpa_trace_show(s) log_trace("%s", s)
-#endif
+#endif /* wpa_trace_show */
 
 #define TEST_FAIL() 0
 #endif


### PR DESCRIPTION
Document dummy `wpa_trace_show()` function for code taken from hostap.

In the hostap source-code, this function is supposed to print a backtrace to help debugging (see https://w1.fi/cgit/hostap/tree/src/utils/trace.h?h=hostap_2_10#n33), but we don't have backtrace tools in edgesec

In the future, we could use something like GCC's [backtrace_symbols()](https://www.gnu.org/software/libc/manual/html_node/Backtraces.html) to easily implement this.