### PR TITLE
doc(common): document `TEST_FAIL()` definition

### DIFF
--- a/src/radius/common.h
+++ b/src/radius/common.h
@@ -212,5 +212,12 @@ static inline void printf_encode(char *txt, size_t maxlen, const uint8_t *data,
 #define wpa_trace_show(s) log_trace("%s", s)
 #endif
 
+/**
+ * Used in hostap source code to test failures.
+ *
+ * @see
+ * https://w1.fi/cgit/hostap/commit/?h=hostap_2_10&id=2da525651d9aa49854bff51f7e4faf9273f68868
+ */
 #define TEST_FAIL() 0
-#endif
+
+#endif /* COMMON_H */


### PR DESCRIPTION
The `TEST_FAIL()` macro is used in hostap's source-code to test handling failing functions, see [commit 2da525651d9aa49854bff51f7e4faf9273f68868 of hostap][1]

It can be set to `0` to be ignored in production code.

[1]: https://w1.fi/cgit/hostap/commit/?id=2da525651d9aa49854bff51f7e4faf9273f68868