### PR TITLE
Remove external linkage from some `md5_internal.c` functions

### DIFF
--- a/src/radius/md5_internal.c
+++ b/src/radius/md5_internal.c
@@ -22,6 +22,8 @@
 #include "md5_internal.h"
 
 static void MD5Init(struct MD5Context *ctx);
+static void MD5Update(struct MD5Context *ctx, unsigned char const *buf,
+                      unsigned len);
 static void MD5Transform(uint32_t buf[4], uint32_t const in[16]);
 
 typedef struct MD5Context MD5_CTX;
@@ -91,7 +93,8 @@ static void MD5Init(struct MD5Context *ctx) {
  * Update context to reflect the concatenation of another buffer full
  * of bytes.
  */
-void MD5Update(struct MD5Context *ctx, unsigned char const *buf, unsigned len) {
+static void MD5Update(struct MD5Context *ctx, unsigned char const *buf,
+                      unsigned len) {
   uint32_t t;
 
   /* Update bitcount */

--- a/src/radius/md5_internal.c
+++ b/src/radius/md5_internal.c
@@ -21,6 +21,7 @@
 
 #include "md5_internal.h"
 
+static void MD5Init(struct MD5Context *ctx);
 static void MD5Transform(uint32_t buf[4], uint32_t const in[16]);
 
 typedef struct MD5Context MD5_CTX;
@@ -76,7 +77,7 @@ static void byteReverse(unsigned char *buf, unsigned longs) {
  * Start MD5 accumulation.  Set bit count to 0 and buffer to mysterious
  * initialization constants.
  */
-void MD5Init(struct MD5Context *ctx) {
+static void MD5Init(struct MD5Context *ctx) {
   ctx->buf[0] = 0x67452301;
   ctx->buf[1] = 0xefcdab89;
   ctx->buf[2] = 0x98badcfe;

--- a/src/radius/md5_internal.c
+++ b/src/radius/md5_internal.c
@@ -24,6 +24,7 @@
 static void MD5Init(struct MD5Context *ctx);
 static void MD5Update(struct MD5Context *ctx, unsigned char const *buf,
                       unsigned len);
+static void MD5Final(unsigned char digest[16], struct MD5Context *ctx);
 static void MD5Transform(uint32_t buf[4], uint32_t const in[16]);
 
 typedef struct MD5Context MD5_CTX;
@@ -141,7 +142,7 @@ static void MD5Update(struct MD5Context *ctx, unsigned char const *buf,
  * Final wrapup - pad to 64-byte boundary with the bit pattern
  * 1 0* (64-bit count of bits processed, MSB-first)
  */
-void MD5Final(unsigned char digest[16], struct MD5Context *ctx) {
+static void MD5Final(unsigned char digest[16], struct MD5Context *ctx) {
   unsigned count;
   unsigned char *p;
 

--- a/src/radius/md5_internal.h
+++ b/src/radius/md5_internal.h
@@ -50,6 +50,4 @@ struct MD5Context {
 int edge_md5_vector(size_t num_elem, const uint8_t *addr[], const size_t *len,
                     uint8_t *mac);
 
-void MD5Final(unsigned char digest[16], struct MD5Context *context);
-
 #endif /* MD5_INTERNAL_H */

--- a/src/radius/md5_internal.h
+++ b/src/radius/md5_internal.h
@@ -50,8 +50,6 @@ struct MD5Context {
 int edge_md5_vector(size_t num_elem, const uint8_t *addr[], const size_t *len,
                     uint8_t *mac);
 
-void MD5Update(struct MD5Context *context, unsigned char const *buf,
-               unsigned len);
 void MD5Final(unsigned char digest[16], struct MD5Context *context);
 
 #endif /* MD5_INTERNAL_H */

--- a/src/radius/md5_internal.h
+++ b/src/radius/md5_internal.h
@@ -50,7 +50,6 @@ struct MD5Context {
 int edge_md5_vector(size_t num_elem, const uint8_t *addr[], const size_t *len,
                     uint8_t *mac);
 
-void MD5Init(struct MD5Context *context);
 void MD5Update(struct MD5Context *context, unsigned char const *buf,
                unsigned len);
 void MD5Final(unsigned char digest[16], struct MD5Context *context);


### PR DESCRIPTION
Remove the following functions from `md5_internal.h` and give them internal linkage by marking them as `static`:

- `MD5Init`
- `MD5Update`
- `MD5Final`

These functions are never called outside of `md5_internal.c`, and they cause linker conflicts with libeap.

---

Adapted from https://github.com/nqminds/edgesec/commit/14b490ebdab06078acea0b3c41afd3b689b4cc51.

In that commit, all the functions were renamed to `MD5Init_base`, `MD5Update_base`, `MD5Final_base`, but again, we never call them outside of `md5_internal.c` so there's no need to rename them.
