### PR TITLE
feat(os): add `os_strcmp` definition

### DIFF
--- a/src/utils/os.h
+++ b/src/utils/os.h
@@ -68,6 +68,10 @@
 #define os_strstr(s1, s2) strstr((s1), (s2))
 #endif
 
+#ifndef os_strcmp
+#define os_strcmp(s1, s2) strcmp((s1), (s2))
+#endif
+
 struct find_dir_type {
   int proc_running;
   char *proc_name;


### PR DESCRIPTION
Source-code taken from the hostap project expect a `os_strcmp` call that points to [`strcmp`][1].

[1]: https://en.cppreference.com/w/c/string/byte/strcmp

---

Adapted from commit https://github.com/nqminds/edgesec/commit/208bd48fab403ef2fc736aefcdcc90b14a6a3960 except I've kept the same `os_strcmp` name as in the hostap source-code, so that we can change less code.

We don't need to worry about linker conflicts, because it's only a pre-processor macro, not a function.