### PR TITLE
refactor(common): fix relative `#includes`

### DIFF
--- a/src/radius/common.h
+++ b/src/radius/common.h
@@ -15,9 +15,9 @@
 
 #include <stddef.h>
 
+#include "../utils/allocs.h"
 #include "../utils/attributes.h"
-#include "utils/allocs.h"
-#include "utils/log.h"
+#include "../utils/log.h"
 
 typedef uint64_t u64;
 typedef uint32_t u32;


### PR DESCRIPTION
The `#include` statements for `allocs.h` and `log.h` was using the directory included directly by CMake in the compiler flags.

---

Adapted from changes in https://github.com/nqminds/edgesec/commit/2704b75351c6f688450766efd33a2ccd67fa1ff1.

---

I'll be honest, I'm not actually sure how the C compiler is finding these files, maybe it is being caused by, but I'm pretty sure that should only affect code in the `tests/ap` folder:

https://github.com/nqminds/edgesec/blob/51b815f7cc16539a486c8b1f61c9f357b7010f59/tests/ap/CMakeLists.txt#L1-L3



