### PR TITLE
feat(os): add os_strchr definition

### DIFF
--- a/src/utils/os.h
+++ b/src/utils/os.h
@@ -72,6 +72,15 @@
 #define os_strcmp(s1, s2) strcmp((s1), (s2))
 #endif
 
+#ifndef os_strchr
+/**
+ * @brief Macro to strchr() for code taken from hostap.
+ * @remarks strchr() is a type-generic function in C23, and might return a
+ * `const char *` instead of a `char *`.
+ */
+#define os_strchr(s, c) strchr((s), (c))
+#endif
+
 struct find_dir_type {
   int proc_running;
   char *proc_name;


### PR DESCRIPTION
> **Warning** This PR is based on the follow PRs. Please merge those PRs first before reviewing this PR.
>   - #444

Source-code taken from the hostap project expects a `os_strchr` function/macro that points to `strchr`.

I've added a doc-string since [`strchr` is a type-generic function in C23][1], so it's has some unusual behaviour.

[1]: https://en.cppreference.com/w/c/string/byte/strchr

---

Adapted from commit https://github.com/nqminds/edgesec/commit/208bd48fab403ef2fc736aefcdcc90b14a6a3960 except I've kept the same `os_strchr` name as in the hostap source-code, so that we can change less code.

We don't need to worry about linker conflicts, because it's only a pre-processor macro, not a function.