### PR TITLE
build(radius_config): make radius_config CMake lib

### DIFF
--- a/src/radius/CMakeLists.txt
+++ b/src/radius/CMakeLists.txt
@@ -22,6 +22,10 @@ target_link_libraries(radius
   PUBLIC common attributes
   PRIVATE wpabuf md5 md5_internal log os)
 
+add_library(radius_config INTERFACE)
+set_target_properties(radius_config PROPERTIES PUBLIC_HEADER "radius_config.h")
+target_link_libraries(radius_config INTERFACE net os)
+
 add_library(radius_server radius_server.c)
 target_link_libraries(radius_server PUBLIC os eloop::eloop PRIVATE radius wpabuf log net)
 


### PR DESCRIPTION
Make a CMake `INTERFACE` library for `radius_config`, so that we can properly track dependencies on `net` and `os`.