### PR TITLE
refactor: move `mac_conn_fn` type to `radius_config`

### DIFF
--- a/src/radius/CMakeLists.txt
+++ b/src/radius/CMakeLists.txt
@@ -22,6 +22,10 @@ target_link_libraries(radius
   PUBLIC common attributes
   PRIVATE wpabuf md5 md5_internal log os)
 
+add_library(radius_config INTERFACE)
+set_target_properties(radius_config PROPERTIES PUBLIC_HEADER "radius_config.h")
+target_link_libraries(radius_config INTERFACE net os)
+
 add_library(radius_server radius_server.c)
 target_link_libraries(radius_server PUBLIC os eloop::eloop PRIVATE radius wpabuf log net)
 

--- a/src/radius/CMakeLists.txt
+++ b/src/radius/CMakeLists.txt
@@ -30,4 +30,4 @@ add_library(radius_server radius_server.c)
 target_link_libraries(radius_server PUBLIC os eloop::eloop PRIVATE radius wpabuf log net)
 
 add_library(radius_service radius_service.c)
-target_link_libraries(radius_service PRIVATE radius_server)
+target_link_libraries(radius_service PUBLIC radius_config PRIVATE radius_server)

--- a/src/radius/radius_config.h
+++ b/src/radius/radius_config.h
@@ -29,4 +29,6 @@ struct radius_conf {
   char radius_secret[RADIUS_SECRET_LEN]; /**< Radius secret string */
 };
 
+typedef struct mac_conn_info (*mac_conn_fn)(uint8_t mac_addr[],
+                                            void *mac_conn_arg);
 #endif

--- a/src/radius/radius_server.h
+++ b/src/radius/radius_server.h
@@ -77,8 +77,6 @@ struct radius_session {
   struct hostapd_radius_attr *accept_attr;
 };
 
-typedef struct mac_conn_info (*mac_conn_fn)(uint8_t mac_addr[],
-                                            void *mac_conn_arg);
 /**
  * struct radius_client - Internal RADIUS server data for a client
  */

--- a/src/radius/radius_service.h
+++ b/src/radius/radius_service.h
@@ -14,6 +14,7 @@
 #include <eloop.h>
 #include "../supervisor/supervisor.h"
 
+#include "radius_config.h"
 #include "radius_server.h"
 
 /**


### PR DESCRIPTION
> **Warning** This PR is based on the follow PRs. Please merge those PRs first before reviewing this PR.
>   - #447

Add the `typedef` for `mac_conn_fn` (aka the RADIUS service callback function type) into `radius_config.h` from `raidus_server.h`.

---

Adapted from https://github.com/nqminds/edgesec/commit/2704b75351c6f688450766efd33a2ccd67fa1ff1#diff-b7d28264f51b9a714c5a677956b5d87cbb993f1882bc1cf2543309b11bd55b97R32.

I'm guessing you wanted to keep `src/radius/radius_server.h` as untouched as possible, to make it easier to pull in changes from newer versions of hostapd?