### PR TITLE
refactor(supervisor_config): include `radius_config`

### DIFF
--- a/src/supervisor/CMakeLists.txt
+++ b/src/supervisor/CMakeLists.txt
@@ -63,7 +63,7 @@ endif()
 
 add_library(supervisor_config INTERFACE)
 set_target_properties(supervisor_config PROPERTIES PUBLIC_HEADER "supervisor_config.h")
-target_link_libraries(supervisor_config INTERFACE SQLite::SQLite3 iface ap_config dhcp_config)
+target_link_libraries(supervisor_config INTERFACE SQLite::SQLite3 iface ap_config dhcp_config radius_config)
 
 add_library(supervisor supervisor.c)
 target_include_directories(supervisor PUBLIC $<TARGET_PROPERTY:iface,INCLUDE_DIRECTORIES>)

--- a/src/supervisor/supervisor_config.h
+++ b/src/supervisor/supervisor_config.h
@@ -21,6 +21,7 @@
 #include "../dhcp/dhcp_config.h"
 #include "../dns/dns_config.h"
 #include "../firewall/firewall_service.h"
+#include "../radius/radius_config.h"
 #include "../utils/iface.h"
 #include "../utils/iface_mapper.h"
 


### PR DESCRIPTION
> **Warning** This PR is based on the follow PRs. Please merge those PRs first before reviewing this PR.
>   - #447

Add an `#include "../radius/radius_config.h"` to `supervisor_config.h`.

This file uses the `struct radius_conf` type since https://github.com/nqminds/edgesec/commit/24c49d59fa36b3fc8e97a24a0b0a199fdae18bf1, which is defined in `../radius/radius_config.h`, so we should include that file directly.

---

This was changed in https://github.com/nqminds/edgesec/commit/2704b75351c6f688450766efd33a2ccd67fa1ff1#diff-c92e4b6dccbcdfb60672a8b00773227eddcc9c4ba6ee87a3ac46dcef04b41b4cR19, but I'm not 100% sure why.

I think @mereacre did it because there's `struct radius_conf` in this file, so that's what I've stuck in this PR/commit description (if I'm wrong, let me know @mereacre).