### PR TITLE
refactor(hostapd): include `radius_config`

### DIFF
--- a/src/ap/CMakeLists.txt
+++ b/src/ap/CMakeLists.txt
@@ -6,7 +6,7 @@ add_library(ap_config INTERFACE) # header-only library
 target_link_libraries(ap_config INTERFACE allocs os radius_server)
 
 add_library(hostapd hostapd.c)
-target_link_libraries(hostapd PRIVATE log os iface ap_config)
+target_link_libraries(hostapd PUBLIC radius_config PRIVATE log os iface ap_config)
 if (USE_UCI_SERVICE)
   target_link_libraries(hostapd PRIVATE OpenWRT::UCI)
 endif()

--- a/src/ap/hostapd.h
+++ b/src/ap/hostapd.h
@@ -17,6 +17,7 @@
 #include <stdbool.h>
 #include <sys/types.h>
 
+#include "../radius/radius_config.h"
 #include "../radius/radius_server.h"
 #include "../utils/allocs.h"
 #include "../utils/os.h"

--- a/src/radius/CMakeLists.txt
+++ b/src/radius/CMakeLists.txt
@@ -22,6 +22,10 @@ target_link_libraries(radius
   PUBLIC common attributes
   PRIVATE wpabuf md5 md5_internal log os)
 
+add_library(radius_config INTERFACE)
+set_target_properties(radius_config PROPERTIES PUBLIC_HEADER "radius_config.h")
+target_link_libraries(radius_config INTERFACE net os)
+
 add_library(radius_server radius_server.c)
 target_link_libraries(radius_server PUBLIC os eloop::eloop PRIVATE radius wpabuf log net)
 


### PR DESCRIPTION
> **Warning** This PR is based on the follow PRs. Please merge those PRs first before reviewing this PR.
>   - #447

Add an `#include "../radius/radius_config.h"` to `hostapd.h`.

This file uses the `struct radius_conf` type since https://github.com/nqminds/edgesec/commit/ef7e8a8bf82e05dbe6c97ddb23b27ab86f385950, which is defined in `../radius/radius_config.h`, so we should include that file directly.

---

This was changed in https://github.com/nqminds/edgesec/commit/a57300acc8bbef74d78aa3b24dd92addbbfb023c#diff-a0c8ed555c1e224c6ec46a0265e118f7d0b7ffe6bfe2aae2af7ad57123616feaR21, but I'm not 100% sure why.

I think @mereacre did it because there's `struct radius_conf` in this file, so that's what I've stuck in this PR/commit description (if I'm wrong, let me know @mereacre).