### PR TITLE
feat(common): add `bin_clear_free` function

### DIFF
--- a/src/radius/common.h
+++ b/src/radius/common.h
@@ -167,6 +167,30 @@ static inline int os_snprintf_error(size_t size, int res) {
   return res < 0 || (unsigned int)res >= size;
 }
 
+/**
+ * Sets the memory to '\0' before freeing it.
+ *
+ * Clears the given memory to `'\0'` before free()-ing it, to avoid leaking
+ * sensitive information.
+ *
+ * @param bin - Pointer to the memory to free()
+ * @param len - Number of bytes to `'\0'` before free()-ing
+ * @see
+ * https://wiki.sei.cmu.edu/confluence/display/c/MEM03-C.+Clear+sensitive+information+stored+in+reusable+resources
+ * @see https://cwe.mitre.org/data/definitions/226.html
+ * @remarks Adapted from commit 19c48da06b6980915e97a84ea8387a9db858c662
+ * of hostap, see
+ * https://w1.fi/cgit/hostap/commit/?id=19c48da06b6980915e97a84ea8387a9db858c662
+ */
+static inline void bin_clear_free(void *bin, size_t len) {
+  if (bin) {
+    // may be optimized out by a smart compiler, we should use
+    // memset_s (C11 Annex K) or memset_explicit (C23) instead
+    os_memset(bin, '\0', len);
+    os_free(bin);
+  }
+}
+
 #define wpa_printf(level, ...)                                                 \
   log_levels(LOGC_TRACE, __FILENAME__, __LINE__, __VA_ARGS__)
 #define wpa_snprintf_hex(buf, buf_size, data, len)                             \


### PR DESCRIPTION
Add `bin_clear_free()`, which is used to set memory to `'\0'` before `free()`-ing it, to avoid leaking sensitive information.

Required by code taken from `hostap`.

Unfortunately, the `memset()` might still be optimized out by a smart compiler. C11 has `memset_s`, but it's part of Annex K, which means basically nobody except Microsoft supports it, so there's not much point if us trying to use it.

C23 has `memset_explicit`, but C23 is not out yet, so we can't use it.

Alternatively, we could use the non-standard [`explicit_bzero`][1] function. It's available in glibc, and most BSDs. But, we'd probably then need to:
  - a) add CMake code to call [`check_symbol_exists`][2]
  - b) add it to a `.c` file, not a `.h` file, to set the appropriate glibc flags.

[1]: https://manpages.ubuntu.com/manpages/jammy/man3/bzero.3.html
[2]: https://cmake.org/cmake/help/latest/module/CheckSymbolExists.html

---

Originally added by commit https://github.com/nqminds/edgesec/commit/dff384c0c21e41af7da63a45bfb3574322a6f9c8.

Unlike that commit, I added documentation, and I changed the `0` to `'\0'`, since I'm guessing this function is normally used to clear strings.