### PR TITLE
Improves `test_edgesec.c`

### DIFF
--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -50,7 +50,7 @@ if (USE_RADIUS_SERVICE)
     LINK_LIBRARIES radius radius_client attributes sockctl runctl cmocka::cmocka log config Threads::C11Threads
   )
   target_compile_definitions(test_edgesec PRIVATE TEST_CONFIG_INI_PATH="${CMAKE_BINARY_DIR}/test-config.ini")
-  set_tests_properties(test_edgesec PROPERTIES TIMEOUT 10)
+  set_tests_properties(test_edgesec PROPERTIES TIMEOUT 15)
 endif()
 
 add_cmocka_test(test_runctl

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -50,7 +50,7 @@ if (USE_RADIUS_SERVICE)
     LINK_LIBRARIES radius radius_client attributes sockctl runctl cmocka::cmocka log config Threads::C11Threads
   )
   target_compile_definitions(test_edgesec PRIVATE TEST_CONFIG_INI_PATH="${CMAKE_BINARY_DIR}/test-config.ini")
-  set_tests_properties(test_edgesec PROPERTIES TIMEOUT 15)
+  set_tests_properties(test_edgesec PROPERTIES TIMEOUT 20)
 endif()
 
 add_cmocka_test(test_runctl

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -47,7 +47,7 @@ target_compile_definitions(test_config PRIVATE TEST_CONFIG_INI_PATH="${CMAKE_BIN
 if (USE_RADIUS_SERVICE)
   add_cmocka_test(test_edgesec
     SOURCES test_edgesec.c
-    LINK_LIBRARIES radius radius_client attributes sockctl runctl cmocka::cmocka log config
+    LINK_LIBRARIES radius radius_client attributes sockctl runctl cmocka::cmocka log config Threads::C11Threads
   )
   target_compile_definitions(test_edgesec PRIVATE TEST_CONFIG_INI_PATH="${CMAKE_BINARY_DIR}/test-config.ini")
   set_tests_properties(test_edgesec PROPERTIES TIMEOUT 10)


### PR DESCRIPTION
Improves `test_edgesec.c` by making the following changes:

- [**test(edgesec): use `threads.h` in test_edgesec**](https://github.com/nqminds/edgesec/commit/a8d1aa93e6fbd86a662c67cc432a857f8ea7f27c) 

  Use `#include <threads.h>` (aka ISO C11 standard threads) instead of `#include <pthreads.h>` in `test_edgesec.c`
  Using C11 standard threads caught a double-free error, so it's already
better!
- [**test(edgesec): stop eloop threads gracefully**](https://github.com/nqminds/edgesec/commit/d76a2787da075bbc33d1177fe9336bf99ddbb82b)
  Currently, the eloop threads are never actually stopped. We call `edge_eloop_terminate()`, but this is not thread-safe.

  To fix this, we can use a threadsafe atomic from `<stdatomic.h>`, which is constantly checked by eloop, which then automatically closes the eloop when the atomic is set.

  This also allows us to call `thrd_join()` on the threads and check their return code.

  Basically, before this PR, calling `edge_eloop_terminate()` from the main test thread did nothing.

- [**test(edgesec): store error msg from ap thread**](https://github.com/nqminds/edgesec/commit/199b8cfc7c37fc3edaec24516c943b338916d902) 

  Currently, in `test_edgesec`, if the AP thread has an error, `fail_msg()` is called, which normally fails the CMocka test with the given error message. However, [CMocka **is not thread safe**][1].

  Instead, we can make the AP Thread store the error message in a buffer, and call `thrd_exit(EXIT_FAILURE)` to exit the thread with an error exit code.

  We can then check for this thread exitcode later on, when we call `thrd_join()`, e.g. in `teardown_edgesec_test()`.

- [**test(edgesec): test ap server thread failures**](https://github.com/nqminds/edgesec/commit/8f63f7abb87daa92e1942972b76449a1a4828958) 

  Add a test that tests whether the AP server thread fails correctly.

  Previously, our test code wasn't correctly failing on errors.

  This should also help fix flakey code-coverage results in `test_edgesec.c`, see https://github.com/nqminds/edgesec/issues/435.

  This test is pretty slow, as we need to wait 10 seconds for `writeread_domain_data_str()` to timeout. In the future, we should find a way to speed up this test (maybe by using a different function to send data to the AP server socket).

[1]: https://api.cmocka.org/

---

~@mereacre, if you've got any idea how we can easily replace this line, without having to wait 10 seconds for a timeout, let me know! https://github.com/nqminds/edgesec/blob/43f5b5284a81f7c0d344200a9adf86bb3ef56a56/tests/test_edgesec.c#L376-L381~ _Edit: Fixed in https://github.com/nqminds/edgesec/pull/453/commits/d6c0a99924b84f8f58c98972045d6828264da64b_

