### PR TITLE
Makes `is_proc_app()` stricter, so that it only looks at the process name

### DIFF
--- a/src/utils/os.c
+++ b/src/utils/os.c
@@ -843,7 +843,7 @@ static bool is_string_in_cmdline_file(const char *filename, const char *str) {
   return false;
 }
 
-long is_proc_app(const char *path, const char *proc_name) {
+pid_t is_proc_app(const char *path, const char *proc_name) {
   pid_t pid;
   { // use a separate scope for this, to avoid allocating too much on the stack
     char pid_basename_buffer[MAX_OS_PATH_LEN];
@@ -857,7 +857,7 @@ long is_proc_app(const char *path, const char *proc_name) {
   char cmdline_path[MAX_OS_PATH_LEN];
   char *resolved_path;
 
-  if (errno != ERANGE && pid != 0L) {
+  if (errno != ERANGE && pid != 0) {
     snprintf(exe_path, MAX_OS_PATH_LEN - 1, "%s/exe", path);
     snprintf(cmdline_path, MAX_OS_PATH_LEN - 1, "%s/cmdline", path);
     if ((resolved_path = realpath(exe_path, NULL)) != NULL) {

--- a/src/utils/os.c
+++ b/src/utils/os.c
@@ -825,11 +825,10 @@ static bool is_string_in_cmdline_file(const char *filename, const char *str) {
 
   char *line = NULL;
   size_t len = 0;
-  ssize_t nread;
 
   // /proc/.../cmdline files have arg0, arg1, arg2... delimited by NUL-chars
   // see man proc(5) https://linux.die.net/man/5/proc
-  while ((nread = getdelim(&line, &len, '\0', fp)) != -1) {
+  while (getdelim(&line, &len, '\0', fp) != -1) {
     if (strstr(line, str)) {
       free(line);
       fclose(fp);

--- a/src/utils/os.c
+++ b/src/utils/os.c
@@ -803,6 +803,19 @@ exit_list_dir:
   return returnValue;
 }
 
+/**
+ * @brief Checks to see if the given `str` is in the given `/proc/.../cmdline`
+ *
+ * This will return `true` if the string is **anywhere** in the command line
+ * for the function, including in the process arguments.
+ *
+ * @param filename - The filename to search in. Should be a `/proc/.../cmdline`
+ * file.
+ * @param str - The string to search for.
+ * @return `true` is the string is in the `/proc/.../cmdline` file.
+ * @see [man proc(5)](https://linux.die.net/man/5/proc) for details on the
+ * `/proc/.../cmdline` format.
+ */
 bool is_string_in_cmdline_file(char *filename, char *str) {
   FILE *fp = fopen(filename, "r");
   if (fp == NULL) {
@@ -814,6 +827,8 @@ bool is_string_in_cmdline_file(char *filename, char *str) {
   size_t len = 0;
   ssize_t nread;
 
+  // /proc/.../cmdline files have arg0, arg1, arg2... delimited by NUL-chars
+  // see man proc(5) https://linux.die.net/man/5/proc
   while ((nread = getdelim(&line, &len, '\0', fp)) != -1) {
     if (strstr(line, str)) {
       free(line);

--- a/src/utils/os.c
+++ b/src/utils/os.c
@@ -855,18 +855,18 @@ pid_t is_proc_app(const char *path, const char *proc_name) {
 
   char exe_path[MAX_OS_PATH_LEN];
   char cmdline_path[MAX_OS_PATH_LEN];
-  char *resolved_path;
 
   if (errno != ERANGE && pid != 0) {
     snprintf(exe_path, MAX_OS_PATH_LEN - 1, "%s/exe", path);
     snprintf(cmdline_path, MAX_OS_PATH_LEN - 1, "%s/cmdline", path);
-    if ((resolved_path = realpath(exe_path, NULL)) != NULL) {
+
+    char resolved_path_buffer[PATH_MAX];
+    char *resolved_path = realpath(exe_path, resolved_path_buffer);
+    if (resolved_path != NULL) {
       bool in_file = is_string_in_cmdline_file(cmdline_path, proc_name);
       if (strcmp(basename(resolved_path), proc_name) == 0 || in_file) {
-        os_free(resolved_path);
         return pid;
       }
-      os_free(resolved_path);
     }
   }
 

--- a/src/utils/os.c
+++ b/src/utils/os.c
@@ -816,7 +816,7 @@ exit_list_dir:
  * @see [man proc(5)](https://linux.die.net/man/5/proc) for details on the
  * `/proc/.../cmdline` format.
  */
-static bool is_string_in_cmdline_file(char *filename, char *str) {
+static bool is_string_in_cmdline_file(const char *filename, const char *str) {
   FILE *fp = fopen(filename, "r");
   if (fp == NULL) {
     log_errno("fopen");

--- a/src/utils/os.c
+++ b/src/utils/os.c
@@ -816,7 +816,7 @@ exit_list_dir:
  * @see [man proc(5)](https://linux.die.net/man/5/proc) for details on the
  * `/proc/.../cmdline` format.
  */
-bool is_string_in_cmdline_file(char *filename, char *str) {
+static bool is_string_in_cmdline_file(char *filename, char *str) {
   FILE *fp = fopen(filename, "r");
   if (fp == NULL) {
     log_errno("fopen");

--- a/src/utils/os.c
+++ b/src/utils/os.c
@@ -843,12 +843,19 @@ static bool is_string_in_cmdline_file(const char *filename, const char *str) {
   return false;
 }
 
-long is_proc_app(char *path, char *proc_name) {
+long is_proc_app(const char *path, const char *proc_name) {
+  pid_t pid;
+  { // use a separate scope for this, to avoid allocating too much on the stack
+    char pid_basename_buffer[MAX_OS_PATH_LEN];
+    os_strlcpy(pid_basename_buffer, path, sizeof(pid_basename_buffer));
+    const char *pid_string = basename(pid_basename_buffer);
+
+    pid = strtoul(pid_string, NULL, 10);
+  }
+
   char exe_path[MAX_OS_PATH_LEN];
   char cmdline_path[MAX_OS_PATH_LEN];
   char *resolved_path;
-
-  pid_t pid = strtoul(basename(path), NULL, 10);
 
   if (errno != ERANGE && pid != 0L) {
     snprintf(exe_path, MAX_OS_PATH_LEN - 1, "%s/exe", path);

--- a/src/utils/os.c
+++ b/src/utils/os.c
@@ -823,6 +823,8 @@ static bool is_string_in_cmdline_file(const char *filename, const char *str) {
     return false;
   }
 
+  // The output buffer for `getdelim()`, getdelim() will automatically realloc()
+  // this if it's too small to hold the next line
   char *line = NULL;
   size_t len = 0;
 
@@ -834,10 +836,9 @@ static bool is_string_in_cmdline_file(const char *filename, const char *str) {
       fclose(fp);
       return true;
     }
-    free(line);
-    line = NULL;
   }
 
+  free(line);
   fclose(fp);
   return false;
 }

--- a/src/utils/os.h
+++ b/src/utils/os.h
@@ -450,12 +450,21 @@ typedef bool (*list_dir_fn)(char *, void *args);
 int list_dir(const char *dirpath, list_dir_fn fun, void *args);
 
 /**
- * @brief Check if a process path from /proc folder contains the process name
+ * @brief Check if the given process's basename matches proc_name.
  *
- * @param path The process path from /proc fodler
- * @param proc_name The process name
- * @return The process PID if the process contains the given `proc_name` stirng,
- * or `0` if it doesn't.
+ * Checks both:
+ * - the realpath (aka `/proc/[pid]/exe`), and
+ * - the given argv0 (from `/proc/[pid]/cmdline`).
+ *
+ * As an example, if a process was started with `/usr/bin/gcc`,
+ * which is a symlink to `/usr/bin/x86_64-linux-gnu-gcc-11`,
+ * then both`is_proc_app(..., "gcc")` AND `is_proc_app(...,
+ * "x86_64-linux-gnu-gcc-11")` will work.
+ *
+ * @param path The `/proc/[pid]` folder for the process
+ * @param proc_name The process name to search for.
+ * @return The process PID if the process's basename contains the given
+ * `proc_name` string, or `0` if it doesn't.
  */
 pid_t is_proc_app(const char *path, const char *proc_name);
 

--- a/src/utils/os.h
+++ b/src/utils/os.h
@@ -456,7 +456,7 @@ int list_dir(const char *dirpath, list_dir_fn fun, void *args);
  * @param proc_name The process name
  * @return long The process PID
  */
-long is_proc_app(char *path, char *proc_name);
+long is_proc_app(const char *path, const char *proc_name);
 
 /**
  * @brief Kill a process by name

--- a/src/utils/os.h
+++ b/src/utils/os.h
@@ -454,9 +454,10 @@ int list_dir(const char *dirpath, list_dir_fn fun, void *args);
  *
  * @param path The process path from /proc fodler
  * @param proc_name The process name
- * @return long The process PID
+ * @return The process PID if the process contains the given `proc_name` stirng,
+ * or `0` if it doesn't.
  */
-long is_proc_app(const char *path, const char *proc_name);
+pid_t is_proc_app(const char *path, const char *proc_name);
 
 /**
  * @brief Kill a process by name

--- a/tests/ap/CMakeLists.txt
+++ b/tests/ap/CMakeLists.txt
@@ -8,7 +8,7 @@ add_cmocka_test(test_hostapd
 )
 target_link_options(test_hostapd
   PRIVATE
-  "LINKER:--wrap=kill_process,--wrap=signal_process,--wrap=reset_interface,--wrap=run_process,--wrap=list_dir,--wrap=check_sock_file_exists"
+  "LINKER:--wrap=kill_process,--wrap=signal_process,--wrap=reset_interface,--wrap=run_process,--wrap=list_dir,--wrap=check_sock_file_exists,--wrap=is_proc_running"
 )
 
 if (USE_UCI_SERVICE)

--- a/tests/ap/test_hostapd.c
+++ b/tests/ap/test_hostapd.c
@@ -71,6 +71,11 @@ int __wrap_check_sock_file_exists(char *path) {
   return 0;
 }
 
+int __wrap_is_proc_running(char *proc_name) {
+  assert_string_equal(proc_name, "hostapd");
+  return 1;
+}
+
 static void test_generate_hostapd_conf(void **state) {
   (void)state; /* unused */
   struct apconf hconf;


### PR DESCRIPTION
### 📝 Summary

#### 🐛 The problem

`is_proc_app()` currently returns the `pid_t` if the proc_name is the PID's `/proc/[pid]/exe`'s basename, OR if the proc_name is anywhere in the `/proc/[pid]/cmdline`.

This is far far far too broad.

For example, if I run the following:

```bash
/usr/bin/bash -c 'echo "Modifying /etc/hostapd.conf"; sed ...'
```

`is_proc_app(pid_dir, "hostapd")` will return that PID, because `hostapd` is in the argv2 string!

This also causes a bunch of false positives. For example, `signal_process("dnsmasq", SIGHUP);` kills `test_dnsmasq`, and so prevents tests from being run in parallel (fixes https://github.com/nqminds/edgesec/issues/425).

And `is_proc_running("hostapd")` returns `true` for `test_hostapd`.

#### 👷 The fix

Instead, it makes a lot more sense only to check the basename of the argv0 string.

For example, when calling the following command, **ONLY** the following `proc_name`s will return a PID:
- "gcc"
- "x86_64-linux-gnu-gcc-11" (assuming that `/usr/bin/gcc` is a symlink
  to `/usr/bin/x86_64-linux-gnu-gcc-11`).

```bash
/usr/bin/gcc -option1 -option2 'arg that doesn't matter'
```

### 📏 Implementation details

I've done quite a bit of documentation/refactoring when trying to get these functions working properly, so please review this PR commit-by-commit!