### PR TITLE
refactor(os): remove unused `upper_string()` func

### DIFF
--- a/src/utils/os.c
+++ b/src/utils/os.c
@@ -1076,18 +1076,6 @@ char *rtrim(char *str, const char *seps) {
   return str;
 }
 
-void upper_string(char *s) {
-  int idx = 0;
-  if (s) {
-    while (s[idx] != '\0') {
-      if (s[idx] >= 'a' && s[idx] <= 'z') {
-        s[idx] = s[idx] - 32;
-      }
-      idx++;
-    }
-  }
-}
-
 void replace_string_char(char *s, char in, char out) {
   int idx = 0;
   if (s) {

--- a/src/utils/os.h
+++ b/src/utils/os.h
@@ -356,13 +356,6 @@ int run_argv_command(const char *path, const char *const argv[],
                      process_callback_fn fn, void *ctx);
 
 /**
- * @brief Convert the string to upper case
- *
- * @param s The input string
- */
-void upper_string(char *s);
-
-/**
  * @brief Replace a character in a string with a given characater
  *
  * @param s The input string


### PR DESCRIPTION
This function was only used in the old `restsrv.c` code, which was removed from edgesec in commit e4931bcf404b14a4ec23f80932dcdc8bd57ae6fa.

The last time this function was used:
https://github.com/nqminds/edgesec/blob/cbcdc8237f199208afe40278e2e7512241d60546/src/restsrv.c#L253