### PR TITLE
Fix a potential memory leak in `read_file_string()`

### DIFF
--- a/src/utils/os.c
+++ b/src/utils/os.c
@@ -1414,6 +1414,7 @@ ssize_t read_file(const char *path, uint8_t **out) {
 }
 
 int read_file_string(char *path, char **out) {
+  int return_code = -1;
   uint8_t *data = NULL;
   ssize_t data_size = 0;
   char *buffer;
@@ -1422,20 +1423,22 @@ int read_file_string(char *path, char **out) {
 
   if ((data_size = read_file(path, &data)) < 0) {
     log_trace("read_file fail");
-    return -1;
+    goto cleanup;
   }
 
   if ((buffer = (char *)os_zalloc(data_size + 1)) == NULL) {
     log_errno("os_zalloc");
-    return -1;
+    goto cleanup
   }
 
   os_memcpy(buffer, data, data_size);
 
   *out = buffer;
 
+  return_code = 0;
+cleanup:
   os_free(data);
-  return 0;
+  return return_code;
 }
 
 ssize_t open_write_nonblock(const char *path, int *fd, const uint8_t *buffer,

--- a/src/utils/os.c
+++ b/src/utils/os.c
@@ -1363,7 +1363,7 @@ int create_pid_file(const char *pid_file, int flags) {
   return fd;
 }
 
-ssize_t read_file(char *path, uint8_t **out) {
+ssize_t read_file(const char *path, uint8_t **out) {
   long int read_size;
   long int file_size;
   uint8_t *buffer;

--- a/src/utils/os.h
+++ b/src/utils/os.h
@@ -641,7 +641,7 @@ int create_pid_file(const char *pid_file, int flags);
  * Will be `malloc()`-ed, so you must free() this when done.
  * @return ssize_t The file size, -1 on failure
  */
-ssize_t read_file(char *path, uint8_t **out);
+ssize_t read_file(const char *path, uint8_t **out);
 
 /**
  * @brief Read the entire file into a string

--- a/src/utils/os.h
+++ b/src/utils/os.h
@@ -637,7 +637,8 @@ int create_pid_file(const char *pid_file, int flags);
  * @brief Read the entire file
  *
  * @param path The file path
- * @param out The output buffer
+ * @param[out] out Pointer to the output buffer, or NULL on error.
+ * Will be `malloc()`-ed, so you must free() this when done.
  * @return ssize_t The file size, -1 on failure
  */
 ssize_t read_file(char *path, uint8_t **out);


### PR DESCRIPTION
The following branch of `read_file_string()` in `src/utils/os.c` causes a memory leak, because it is missing an `free(data);`

https://github.com/nqminds/edgesec/blob/c83625b9d320cc8db6140181d5108706da48a6ad/src/utils/os.c#L1428-L1431

I've also stuck `free(data)` in the branch for https://github.com/nqminds/edgesec/blob/c83625b9d320cc8db6140181d5108706da48a6ad/src/utils/os.c#L1423-L1426, since data is NULL anyway if `read_file()` has an error, and `free(NULL)` is perfectly safe.

---

One think I also noticed, is that in the following lines of code, we could replace everything with a [`realloc()`](https://en.cppreference.com/w/c/memory/realloc), see https://github.com/nqminds/edgesec/commit/371584fda8b7db611c27556e09c689c787d8f4c6:

https://github.com/nqminds/edgesec/blob/c83625b9d320cc8db6140181d5108706da48a6ad/src/utils/os.c#L1428-L1437

`realloc` either:

1. expands/contracts the pointer to the new size, with the same contents.
2. `malloc()`s a new block, then `memcpy()`s and `free()s` the old data (which is what we're doing now) (except `realloc()` can left the OS doing the copy, which is faster).