### PR TITLE
Test `is_proc_app()` and `is_proc_running()`

### DIFF
--- a/tests/utils/test_os.c
+++ b/tests/utils/test_os.c
@@ -731,6 +731,16 @@ static void test_is_proc_app(__maybe_unused void **state) {
 #endif /* __linux__ */
 }
 
+static void test_is_proc_running(__maybe_unused void **state) {
+#if __linux__
+  assert_true(is_proc_running("test_os"));
+  assert_false(is_proc_running("hello world, this is a long and complex exe"));
+#else  /* __linux__ */
+  // `/proc` only exists in Linux OS
+  return;
+#endif /* __linux__ */
+};
+
 int main(int argc, char *argv[]) {
   (void)argc;
   (void)argv;
@@ -755,7 +765,8 @@ int main(int argc, char *argv[]) {
                                       teardown_os_strlcpy_test),
       cmocka_unit_test(test_hexstr2bin),
       cmocka_unit_test(test_signal_process),
-      cmocka_unit_test(test_is_proc_app)};
+      cmocka_unit_test(test_is_proc_app),
+      cmocka_unit_test(test_is_proc_running)};
 
   return cmocka_run_group_tests(tests, NULL, NULL);
 }


### PR DESCRIPTION
Add some basic tests that ensure that the `is_proc_app()` and `is_proc_running()` functions work, as since https://github.com/nqminds/edgesec/commit/98ad7c655807b63f47dc32b1d4925a9c7b74e7f1, there are no longer tested.

Because `/proc/[pid]` is Linux specific, I'm only running these tests `#if __linux__`.
(FreeBSD used to have it in the old days, and still has [linprocfs](https://man.freebsd.org/cgi/man.cgi?query=linprocfs&apropos=0&sektion=5&manpath=FreeBSD+13.0-RELEASE&arch=default&format=html), but it's not enabled by default)

### Documentation and function declaration 

https://github.com/nqminds/edgesec/blob/f7179087fd54479b656b51d32b597fc0812b45c2/src/utils/os.h#L445-L462

https://github.com/nqminds/edgesec/blob/f7179087fd54479b656b51d32b597fc0812b45c2/src/utils/os.h#L496-L502