### PR TITLE
feat(common): add `enum hostap_log_level` enum

### DIFF
--- a/src/radius/common.h
+++ b/src/radius/common.h
@@ -192,6 +192,19 @@ static inline void bin_clear_free(void *bin, size_t len) {
 }
 
 /**
+ * Log levels used by source-code taken from hostap. Used as the @c level
+ * parameter for functions like wpa_hexdump_ascii().
+ */
+enum hostap_log_level {
+  MSG_EXCESSIVE,
+  MSG_MSGDUMP,
+  MSG_DEBUG,
+  MSG_INFO,
+  MSG_WARNING,
+  MSG_ERROR
+};
+
+/**
  * Logs the given text.
  *
  * @remarks This macro has an API compatible with hostap's wpa_printf()
@@ -229,10 +242,10 @@ static inline void bin_clear_free(void *bin, size_t len) {
  * see https://w1.fi/cgit/hostap/tree/src/utils/wpa_debug.h?h=hostap_2_10#n118
  * However, it prints every byte as hex, and never prints bytes as ASCII.
  */
-static inline void
-wpa_hexdump_ascii(__maybe_unused int level, // used by hostap, but our
-                                            // implementation doesn't use it
-                  const char *title, const void *buf, size_t len) {
+static inline void wpa_hexdump_ascii(
+    __maybe_unused enum hostap_log_level
+        level, // used by hostap, but our implementation doesn't use it
+    const char *title, const void *buf, size_t len) {
   char hex_buf[33];
   printf_hex(hex_buf, sizeof(hex_buf), buf, len, false);
   log_trace("%s - hexdump(len=%lu):%s", title, len, hex_buf);


### PR DESCRIPTION
Adds an enum for all of the log levels that code taken from hostap expects (e.g. like `MSG_INFO`).

---

Adapted from https://github.com/nqminds/edgesec/commit/dff384c0c21e41af7da63a45bfb3574322a6f9c8, but I've changed the `enum` to be named instead of anonymous.

This means that we can specific that the type of `level` param to `wpa_hexdump_ascii()` is `enum hostap_log_level`, which is more specific than just `int`.
