### PR TITLE
Improve the `string_array2string()` function

### DIFF
--- a/src/utils/os.c
+++ b/src/utils/os.c
@@ -960,43 +960,29 @@ bool kill_process(char *proc_name) {
 }
 
 char *string_array2string(char *strings[]) {
-  int idx = 0;
-  ssize_t total = 0;
-  ssize_t len = 0;
-
-  char *buf = NULL;
-
   if (strings == NULL) {
     log_trace("strings is NULL");
     return NULL;
   }
 
-  while (strings[idx] != NULL && /*total <= size && */ len >= 0) {
-    if (buf == NULL) {
-      buf = os_malloc(strlen(strings[idx]) + 2);
-    } else {
-      buf = os_realloc(buf, total + strlen(strings[idx]) + 2);
-    }
-
-    if (buf == NULL) {
-      log_error("realloc failure");
-      return NULL;
-    }
-
-    len = sprintf(&buf[total], "%s ", strings[idx]);
-
-    if (len >= 0) {
-      total += len;
-    } else {
-      log_trace("snprintf fail");
-      os_free(buf);
-      return NULL;
-    }
-
-    idx++;
+  size_t total_chars = 1; // start with 1 for NUL-terminator
+  for (size_t idx = 0; strings[idx] != NULL; idx++) {
+    total_chars += strlen(strings[idx]) + 1 /* space between strings */;
   }
 
-  return buf; // total;
+  char *buf = os_malloc(total_chars);
+  if (buf == NULL) {
+    log_errno("os_malloc: Failed to allocate %d bytes of memory", total_chars);
+    return NULL;
+  }
+
+  buf[0] = '\0'; // initialise buffer as a 0-length string
+  for (size_t idx = 0; strings[idx] != NULL; idx++) {
+    strcat(buf, strings[idx]);
+    strcat(buf, " "); // todo, skip on last loop?
+  }
+
+  return buf;
 }
 
 int run_process(char *argv[], pid_t *child_pid) {

--- a/src/utils/os.c
+++ b/src/utils/os.c
@@ -959,7 +959,7 @@ bool kill_process(char *proc_name) {
   return signal_process(proc_name, SIGTERM);
 }
 
-char *string_array2string(char *strings[]) {
+char *string_array2string(const char *const strings[]) {
   if (strings == NULL) {
     log_trace("strings is NULL");
     return NULL;
@@ -1011,7 +1011,7 @@ int run_process(char *argv[], pid_t *child_pid) {
   }
 
   log_trace("Running process %s with params:", argv[0]);
-  if ((buf = string_array2string(argv)) != NULL) {
+  if ((buf = string_array2string((const char *const *)argv)) != NULL) {
     log_trace("\t %s", buf);
     os_free(buf);
   }

--- a/src/utils/os.h
+++ b/src/utils/os.h
@@ -523,9 +523,10 @@ char *rtrim(char *str, const char *seps);
  * @brief Concatenates an array of strings into a single string
  *
  * @param strings The array of string, the last element is NULL
- * @return char* The concatenated string
+ * @return The concatenated string, which must be `free()`-ed when done, or
+ * `NULL` on error.
  */
-char *string_array2string(char *strings[]);
+char *string_array2string(const char *const strings[]);
 
 /**
  * @brief Generates a random UUID string of MAX_RANDOM_UUID_LEN - 1 characters

--- a/tests/utils/test_os.c
+++ b/tests/utils/test_os.c
@@ -741,6 +741,47 @@ static void test_is_proc_running(__maybe_unused void **state) {
 #endif /* __linux__ */
 };
 
+static void test_string_array2string(__maybe_unused void **state) {
+  {
+    const char *input[] = {
+        "hello",
+        "world",
+        NULL,
+    };
+    const char *expected = "hello world ";
+    char *result = string_array2string(input);
+    assert_non_null(result);
+    assert_string_equal(result, expected);
+    free(result);
+  }
+
+  // should error in NULL input
+  {
+    char *result = string_array2string(NULL);
+    assert_null(result);
+    free(result);
+  }
+
+  // should return an empty string for no inputs
+  {
+    const char *input[] = {NULL};
+    const char *expected = "";
+    char *result = string_array2string(input);
+    assert_non_null(result);
+    assert_string_equal(result, expected);
+    free(result);
+  }
+
+  {
+    const char *input[] = {"", "", "", "", NULL};
+    const char *expected = "    ";
+    char *result = string_array2string(input);
+    assert_non_null(result);
+    assert_string_equal(result, expected);
+    free(result);
+  }
+}
+
 int main(int argc, char *argv[]) {
   (void)argc;
   (void)argv;
@@ -766,7 +807,8 @@ int main(int argc, char *argv[]) {
       cmocka_unit_test(test_hexstr2bin),
       cmocka_unit_test(test_signal_process),
       cmocka_unit_test(test_is_proc_app),
-      cmocka_unit_test(test_is_proc_running)};
+      cmocka_unit_test(test_is_proc_running),
+      cmocka_unit_test(test_string_array2string)};
 
   return cmocka_run_group_tests(tests, NULL, NULL);
 }


### PR DESCRIPTION
Reimplements the `string_array2string()` function in `src/utils/os.c` so that it only uses a single `malloc()`.

The previous implementation kept calling `realloc()` to increase the size of the output buffer, which is a bit slow (and had a memory leak!).

I've also changed the function to use the much faster `strcat()` instead of `sprintf()`.

I've added a test case for this function.

