### PR TITLE
Add a new GCC attribute called `__must_free` to warn if pointers aren't deallocated

### DIFF
--- a/src/utils/allocs.h
+++ b/src/utils/allocs.h
@@ -29,7 +29,7 @@
  * @param size Number of bytes to allocate
  * @return void* Pointer to allocated and zeroed memory or %NULL on failure
  */
-__must_check static inline void *os_zalloc(size_t size) {
+__must_free static inline void *os_zalloc(size_t size) {
   return calloc(size, 1);
 }
 
@@ -52,8 +52,8 @@ __must_check static inline void *os_zalloc(size_t size) {
 #define os_free(p) free((p))
 #endif
 
-__must_check static inline void *os_realloc_array(void *ptr, size_t nmemb,
-                                                  size_t size) {
+__must_free static inline void *os_realloc_array(void *ptr, size_t nmemb,
+                                                 size_t size) {
   if (size && nmemb > (~(size_t)0) / size)
     return NULL;
   return os_realloc(ptr, nmemb * size);
@@ -89,7 +89,7 @@ __must_check static inline void *os_realloc_array(void *ptr, size_t nmemb,
  * see
  * https://w1.fi/cgit/hostap/commit/?id=dbdda355d0add3f7d96e3279321d3a63abfc4b32
  */
-__must_check static inline void *os_memdup(const void *src, size_t len) {
+__must_free static inline void *os_memdup(const void *src, size_t len) {
   void *r = os_malloc(len);
 
   if (r && src)
@@ -102,5 +102,5 @@ __must_check static inline void *os_memdup(const void *src, size_t len) {
  * @param s The input string
  * @return char* The dublicate string pointer, NULL on error
  */
-__must_check char *os_strdup(const char *s);
+__must_free char *os_strdup(const char *s);
 #endif

--- a/src/utils/attributes.h
+++ b/src/utils/attributes.h
@@ -71,4 +71,25 @@
 #define STRUCT_PACKED
 #endif /* defined __has_attribute */
 
+#if __GNUC__ >= 11 // this syntax will throw an error in GCC 10 or Clang, since
+                   // __attribute__((malloc)) accepts no args
+/**
+ * Declares that the attributed function must be free()-ed with `__must_free()`.
+ *
+ * Expects that this function returns a pointer that must be `free()`-ed with
+ * `free()`.
+ *
+ * Please be aware that `__attribute((malloc))` instead does something
+ * completely different and should **NOT** be used. It tells the compiler about
+ * pointer aliasing, which does not apply to functions like `realloc()`, and
+ * so are not part of this macro.
+ *
+ * @see
+ * https://gcc.gnu.org/onlinedocs/gcc-11.1.0/gcc/Common-Function-Attributes.html#index-malloc-function-attribute
+ */
+#define __must_free __attribute__((malloc(free, 1))) __must_check
+#else
+#define __must_free __must_check
+#endif /* __GNUC__ >= 11 */
+
 #endif /* ATTRIBUTES_H */


### PR DESCRIPTION
Add the `__must_free` attribute, that in GCC 11 or later, is defined as:

`#define __must_free __attribute__((malloc(free, 1)))`.

Basically, it tells GCC that the result of these functions must:
 1. be checked for `NULL`
 2. must be deallocated by `free()`

Otherwise, when compiling code that uses these functions in GCC with the `-fanalyzer` option, you'll get a warning that looks a bit like this:

```
<source>:17:1: warning: leak of 'x' [CWE-401] [-Wanalyzer-malloc-leak]
  'my_func': events 1-2
    |
    |   15 |   char * x = my_malloc(sizeof(int));
    |      |              ^~~~~~~~~~~~~~~~~~~~~~
    |      |              |
    |      |              (1) allocated here
    |   16 |   printf("%p", x);
    |   17 | }
    |      | ~             
    |      | |
    |      | (2) 'x' leaks here; was allocated at (1)
    |
Compiler returned: 0
```

Ideally, we should add this attribute to every function in edgesec that returns a value that must be `free()`-ed.
