### PR TITLE
fix(os): fix NULL deref in `list_dir()`

### DIFF
--- a/src/utils/os.c
+++ b/src/utils/os.c
@@ -782,6 +782,12 @@ int list_dir(const char *dirpath, list_dir_fn fun, void *args) {
 
     /* Print directory + filename */
     char *path = construct_path(dirpath, dp->d_name);
+    if (path == NULL) {
+      log_errno("construct_path fail");
+      returnValue = -1;
+      goto exit_list_dir;
+    }
+
     if (fun != NULL) {
       if (!fun(path, args)) {
         log_trace("list_dir callback fail");


### PR DESCRIPTION
Fix a potential NULL dereference error in `list_dir()` in `src/utils/os.c`, if the call to `construct_path()` returns `NULL` due to a memory allocation error.

### Documentation for `construct_path()`

https://github.com/nqminds/edgesec/blob/8dc7acb0364487c925df4e4566ef7cabe6f72b79/src/utils/os.h#L410-L418