### PR TITLE
refactor: move `hostapd_radius_attr` into common

### DIFF
--- a/src/radius/common.h
+++ b/src/radius/common.h
@@ -192,6 +192,18 @@ static inline void bin_clear_free(void *bin, size_t len) {
 }
 
 /**
+ * Linked-list of hostapd RADIUS attributes.
+ *
+ * @see
+ * https://w1.fi/cgit/hostap/commit/?id=af35e7af7f8bb1ca9f0905b4074fb56a264aa12b
+ */
+struct hostapd_radius_attr {
+  uint8_t type;
+  struct wpabuf *val;
+  struct hostapd_radius_attr *next;
+};
+
+/**
  * Log levels used by source-code taken from hostap. Used as the @c level
  * parameter for functions like wpa_hexdump_ascii().
  */

--- a/src/radius/radius_server.h
+++ b/src/radius/radius_server.h
@@ -45,12 +45,6 @@ struct radius_server_counters {
   uint32_t unknown_types;
 };
 
-struct hostapd_radius_attr {
-  uint8_t type;
-  struct wpabuf *val;
-  struct hostapd_radius_attr *next;
-};
-
 /**
  * struct radius_session - Internal RADIUS server data for a session
  */


### PR DESCRIPTION
Move `struct hostapd_radius_attr` from `src/radius/radius_server.h` to `src/radius/common.h`.

I'm guessing this is to keep `src/radius/radius_server.h` as close to the upstream `hostapd` source-code as possible.

It's used by the hostapd source-code to store RADIUS attributes.

See
https://w1.fi/cgit/hostap/commit/?id=af35e7af7f8bb1ca9f0905b4074fb56a264aa12b

---

Adapted from https://github.com/nqminds/edgesec/commit/dff384c0c21e41af7da63a45bfb3574322a6f9c8. I've instead used `uint8_t` instead of `u8`, to match standard ISO C types, and added documentation.