### PR TITLE
refactor(common): match wpa log levels to edgesec

### DIFF
--- a/src/radius/common.h
+++ b/src/radius/common.h
@@ -196,12 +196,12 @@ static inline void bin_clear_free(void *bin, size_t len) {
  * parameter for functions like wpa_hexdump_ascii().
  */
 enum hostap_log_level {
-  MSG_EXCESSIVE,
-  MSG_MSGDUMP,
-  MSG_DEBUG,
-  MSG_INFO,
-  MSG_WARNING,
-  MSG_ERROR
+  MSG_EXCESSIVE = LOGC_TRACE,
+  MSG_MSGDUMP = LOGC_TRACE,
+  MSG_DEBUG = LOGC_DEBUG,
+  MSG_INFO = LOGC_INFO,
+  MSG_WARNING = LOGC_WARN,
+  MSG_ERROR = LOGC_ERROR
 };
 
 /**
@@ -212,7 +212,7 @@ enum hostap_log_level {
  * https://w1.fi/cgit/hostap/tree/src/utils/wpa_debug.h?h=hostap_2_10#n62
  */
 #define wpa_printf(level, ...)                                                 \
-  log_levels(LOGC_TRACE, __FILENAME__, __LINE__, __VA_ARGS__)
+  log_levels(level, __FILENAME__, __LINE__, __VA_ARGS__)
 
 /**
  * Print data as a hex string into a buffer.
@@ -242,13 +242,13 @@ enum hostap_log_level {
  * see https://w1.fi/cgit/hostap/tree/src/utils/wpa_debug.h?h=hostap_2_10#n118
  * However, it prints every byte as hex, and never prints bytes as ASCII.
  */
-static inline void wpa_hexdump_ascii(
-    __maybe_unused enum hostap_log_level
-        level, // used by hostap, but our implementation doesn't use it
-    const char *title, const void *buf, size_t len) {
+static inline void wpa_hexdump_ascii(enum hostap_log_level level,
+                                     const char *title, const void *buf,
+                                     size_t len) {
   char hex_buf[33];
   printf_hex(hex_buf, sizeof(hex_buf), buf, len, false);
-  log_trace("%s - hexdump(len=%lu):%s", title, len, hex_buf);
+  log_levels(level, __FILENAME__, __LINE__, "%s - hexdump(len=%lu):%s", title,
+             len, hex_buf);
 }
 
 static inline void printf_encode(char *txt, size_t maxlen, const uint8_t *data,


### PR DESCRIPTION
Match the log levels used by source-code taken from hostap with the log levels used by edgesec, instead of always just using `LOGC_TRACE`.

This means that messages from the radius server will now be logged by default, and they'll be colour-coded for severity.

@mereacre, I don't know how verbose the `radius_server` is. If it's too much logging compared to the rest of edgesec, you're welcome to push down the values of `enum hostap_log_level`, e.g. so that `MSG_ERROR` only equals to an edgesec `LOGC_WARN`, for instance.