### PR TITLE
feat(common): define WLAN_REASON_IEEE_802_1X_AUTH_FAILED

### DIFF
--- a/src/radius/common.h
+++ b/src/radius/common.h
@@ -192,6 +192,14 @@ static inline void bin_clear_free(void *bin, size_t len) {
 }
 
 /**
+ * Reason codes (IEEE Std 802.11-2016, 9.4.1.7, Table 9-45)
+ *
+ * @see
+ * https://w1.fi/cgit/hostap/tree/src/common/ieee802_11_defs.h?h=hostap_2_10#n213
+ */
+enum ieee802_11_reason_code { WLAN_REASON_IEEE_802_1X_AUTH_FAILED = 23 };
+
+/**
  * Linked-list of hostapd RADIUS attributes.
  *
  * @see


### PR DESCRIPTION
Define `WLAN_REASON_IEEE_802_1X_AUTH_FAILED`, used by hostapd source-code, see https://w1.fi/cgit/hostap/tree/src/common/ieee802_11_defs.h?h=hostap_2_10#n213

---

Adapted from commit https://github.com/nqminds/edgesec/commit/dff384c0c21e41af7da63a45bfb3574322a6f9c8, except I've changed it to an `enum` instead of a `#define` since it's a bit cleaner that way (and I've added documentation).