### PR TITLE
docs(README): test in parallel

### DIFF
--- a/README.md
+++ b/README.md
@@ -58,7 +58,7 @@ configures, compiles (using all cores, but `nice -n19` for lower CPU priority),
 tests (if a test config exists), then installs into the `./tmp` folder.
 
 ```bash
-export PRESET=linux && cmake --preset "$PRESET" && nice -n19 cmake --build --preset "$PRESET" -j=$(nproc) && { if ctest --list-presets | grep "\"$PRESET\""; then ctest --preset "$PRESET" --output-on-failure; fi } && cmake --install "./build/$PRESET" --prefix "./tmp/$PRESET"
+export PRESET=linux && cmake --preset "$PRESET" && nice -n19 cmake --build --preset "$PRESET" -j=$(nproc) && { if ctest --list-presets | grep "\"$PRESET\""; then ctest --preset "$PRESET" --output-on-failure -j=$(nproc); fi } && cmake --install "./build/$PRESET" --prefix "./tmp/$PRESET"
 ```
 
 For older versions of CMake, or for manual configuration, please see the next headings for more details.


### PR DESCRIPTION
`ctest` previously had some race conditions that caused intermittent failures when running in high job counts (e.g. `ctest -j16`) (see issue https://github.com/nqminds/edgesec/issues/425)

However, since commit https://github.com/nqminds/edgesec/commit/a7e09d0a120cf6c7b227275fa1e842738d940b0f, this has now been fixed and `ctest -j16` works fine!

This speeds up tests by a few seconds!