### PR TITLE
test(edgesec): test "ATTACH" to ap server

### DIFF
--- a/tests/test_edgesec.c
+++ b/tests/test_edgesec.c
@@ -389,6 +389,11 @@ static void test_edgesec_ap_failure(void **state) {
   {
     int sfd = create_domain_client(NULL);
     assert_return_code(sfd, errno);
+    // should do nothing (just log RECEIVED ATTACH)
+    assert_return_code(write_domain_data_s(sfd, ATTACH_AP_COMMAND,
+                                           strlen(ATTACH_AP_COMMAND),
+                                           socket_path),
+                       errno);
     ssize_t send_invalid_cmd_bytes = write_domain_data_s(
         sfd, "INVALID COMMAND", strlen("INVALID COMMAND"), socket_path);
     close_domain_socket(sfd);


### PR DESCRIPTION
Currently, only the OpenWRT test presets of edgesec sends an "ATTACH" command to the AP server, which is compiled with GCC.

This causes an issue with code-coverage, because this means that this branch is only covered by code compiled/tested with GCC, and not via LLVM/Clang. Testing this branch in Clang should hopefully fix this code-coverage issue.

Should hopefully fix https://github.com/nqminds/edgesec/issues/435.