### PR TITLE
fix(cmd_processor): handle ENOMEM in `process_get_all_cmd()`

### DIFF
--- a/src/supervisor/cmd_processor.h
+++ b/src/supervisor/cmd_processor.h
@@ -187,7 +187,7 @@ ssize_t process_get_map_cmd(int sock, struct client_address *client_addr,
  * @param client_addr The client address for replies
  * @param context The supervisor structure instance
  * @param cmd_arr The array of received commands
- * @return ssize_t Size of reply written data
+ * @return ssize_t Size of reply written data, or `-1` on failure
  */
 ssize_t process_get_all_cmd(int sock, struct client_address *client_addr,
                             struct supervisor_context *context,


### PR DESCRIPTION
Handle `ENOMEM` errors in `process_get_all_cmd()`.

Previously, this function wasn't checking whether `os_zalloc` or `os_realloc` was working correctly.

**Changes**:

I've changed the function so that if `mac_list_len` is `0`, `write_socket_data(sock, "", strlen("")...)` will now be called instead of `write_socket_data(sock, NULL, strlen(NULL)...)`. This seems better to me, since previously, calling `strlen(NULL)` would have been undefined behaviour.