### PR TITLE
Handle `ENOMEM` in `concat_string_queue()`

### DIFF
--- a/src/utils/CMakeLists.txt
+++ b/src/utils/CMakeLists.txt
@@ -66,7 +66,7 @@ endif ()
 add_library(hash OBJECT hash.c)
 
 add_library(squeue squeue.c)
-target_link_libraries(squeue PUBLIC eloop::list PRIVATE allocs os log)
+target_link_libraries(squeue PUBLIC eloop::list attributes PRIVATE allocs os log)
 
 add_library(sqliteu sqliteu.c)
 target_link_libraries(sqliteu PUBLIC SQLite::SQLite3 PRIVATE log os)

--- a/src/utils/attributes.h
+++ b/src/utils/attributes.h
@@ -13,6 +13,8 @@
 #ifndef ATTRIBUTES_H
 #define ATTRIBUTES_H
 
+#include <stdlib.h> // required for `free()` definition in `__must_free`
+
 #ifndef __must_check
 #if defined __has_attribute
 #if __has_attribute(__warn_unused_result__)

--- a/src/utils/squeue.h
+++ b/src/utils/squeue.h
@@ -15,6 +15,8 @@
 
 #include <list.h>
 
+#include "./attributes.h"
+
 /**
  * @brief String queue structure definition
  *
@@ -100,5 +102,6 @@ void free_string_queue(struct string_queue *queue);
  * @return char* The pointer to the concatenated string, NULL for failure or
  * empty queue
  */
-char *concat_string_queue(const struct string_queue *queue, ssize_t count);
+__must_free char *concat_string_queue(const struct string_queue *queue,
+                                      ssize_t count);
 #endif

--- a/tests/utils/test_squeue.c
+++ b/tests/utils/test_squeue.c
@@ -230,6 +230,7 @@ static void test_concat_string_queue(void **state) {
   push_string_queue(sq, "test4");
 
   str = concat_string_queue(sq, -1);
+  assert_non_null(str);
   assert_string_equal(str, "test1test2test3test4");
   os_free(str);
   free_string_queue(sq);
@@ -241,6 +242,7 @@ static void test_concat_string_queue(void **state) {
   push_string_queue(sq, "test4");
 
   str = concat_string_queue(sq, 1);
+  assert_non_null(str);
   assert_string_equal(str, "test1");
   os_free(str);
   free_string_queue(sq);


### PR DESCRIPTION
Handle ENOMEM errors when `realloc()`-ing memory in `concat_string_queue()` properly to avoid memory leaks.
