### PR TITLE
Tidy up `process_get_bridges_cmd()` using C99 syntax

### DIFF
--- a/src/supervisor/cmd_processor.c
+++ b/src/supervisor/cmd_processor.c
@@ -506,9 +506,8 @@ ssize_t process_get_bridges_cmd(int sock, struct client_address *client_addr,
   char *reply_buf = NULL;
   log_trace("GET_BRIDGES");
 
-  struct bridge_mac_tuple *p = NULL;
-  while ((p = (struct bridge_mac_tuple *)utarray_next(tuple_list_arr, p)) !=
-         NULL) {
+  for (struct bridge_mac_tuple *p = utarray_front(tuple_list_arr); p != NULL;
+       p = utarray_next(tuple_list_arr, p)) {
     char temp[255];
     int line_size = snprintf(temp, 255, MACSTR "," MACSTR "\n",
                              MAC2STR(p->src_addr), MAC2STR(p->dst_addr));


### PR DESCRIPTION
Refactors and tidies up the source-code for the `process_get_bridges_cmd()` by declaring variables only when they are used (supported since C99).

In this PR, I've also added the following changes (it may be easier to review this PR commit by commit):

- Change the `process_get_bridges_cmd()` function to return early,
so that we can un-indent most of the function code, and move it out of the `if-` scope, see
 [**refactor(cmd_processor): return early in `process_get_bridges_cmd()`**](https://github.com/nqminds/edgesec/commit/8dfb3f23f2bcec42806cad0ff11e1238b76a13ea)
- Replace the `while()`-loop with a `for()`-loop to iterate over the utarray, as shown in the examples in https://troydhanson.github.io/uthash/utarray.html, see [**refactor(cmd_processor): use `for`-loop, not `while`**](https://github.com/nqminds/edgesec/commit/0ec1681705431f201c4e0d9007643fc90c1e93f7)
