### PR TITLE
Make the `client_addr` parameter in `cmd_processor` `const`

### DIFF
--- a/src/supervisor/cmd_processor.c
+++ b/src/supervisor/cmd_processor.c
@@ -61,7 +61,7 @@ bool process_domain_buffer(char *domain_buffer, size_t domain_buffer_len,
 }
 
 int write_newline_socket_data(int sock, char *data,
-                              struct client_address *client_addr) {
+                              const struct client_address *client_addr) {
   char *msg;
   if ((msg = string_append_char(data, '\n')) == NULL) {
     log_error("string_append_char fail");
@@ -72,7 +72,7 @@ int write_newline_socket_data(int sock, char *data,
   return ret;
 }
 
-ssize_t process_ping_cmd(int sock, struct client_address *client_addr,
+ssize_t process_ping_cmd(int sock, const struct client_address *client_addr,
                          struct supervisor_context *context,
                          UT_array *cmd_arr) {
   (void)context; /* unused */
@@ -88,7 +88,7 @@ ssize_t process_ping_cmd(int sock, struct client_address *client_addr,
 }
 
 ssize_t process_subscribe_events_cmd(int sock,
-                                     struct client_address *client_addr,
+                                     const struct client_address *client_addr,
                                      struct supervisor_context *context,
                                      UT_array *cmd_arr) {
   (void)cmd_arr; /* unused */
@@ -101,7 +101,8 @@ ssize_t process_subscribe_events_cmd(int sock,
   return write_socket_data(sock, OK_REPLY, strlen(OK_REPLY), client_addr);
 }
 
-ssize_t process_accept_mac_cmd(int sock, struct client_address *client_addr,
+ssize_t process_accept_mac_cmd(int sock,
+                               const struct client_address *client_addr,
                                struct supervisor_context *context,
                                UT_array *cmd_arr) {
   char **ptr = (char **)utarray_next(cmd_arr, NULL);
@@ -133,7 +134,7 @@ ssize_t process_accept_mac_cmd(int sock, struct client_address *client_addr,
   return write_socket_data(sock, FAIL_REPLY, strlen(FAIL_REPLY), client_addr);
 }
 
-ssize_t process_deny_mac_cmd(int sock, struct client_address *client_addr,
+ssize_t process_deny_mac_cmd(int sock, const struct client_address *client_addr,
                              struct supervisor_context *context,
                              UT_array *cmd_arr) {
   char **ptr = (char **)utarray_next(cmd_arr, NULL);
@@ -156,7 +157,7 @@ ssize_t process_deny_mac_cmd(int sock, struct client_address *client_addr,
   return write_socket_data(sock, FAIL_REPLY, strlen(FAIL_REPLY), client_addr);
 }
 
-ssize_t process_add_nat_cmd(int sock, struct client_address *client_addr,
+ssize_t process_add_nat_cmd(int sock, const struct client_address *client_addr,
                             struct supervisor_context *context,
                             UT_array *cmd_arr) {
   char **ptr = (char **)utarray_next(cmd_arr, NULL);
@@ -179,7 +180,8 @@ ssize_t process_add_nat_cmd(int sock, struct client_address *client_addr,
   return write_socket_data(sock, FAIL_REPLY, strlen(FAIL_REPLY), client_addr);
 }
 
-ssize_t process_remove_nat_cmd(int sock, struct client_address *client_addr,
+ssize_t process_remove_nat_cmd(int sock,
+                               const struct client_address *client_addr,
                                struct supervisor_context *context,
                                UT_array *cmd_arr) {
   char **ptr = (char **)utarray_next(cmd_arr, NULL);
@@ -202,7 +204,8 @@ ssize_t process_remove_nat_cmd(int sock, struct client_address *client_addr,
   return write_socket_data(sock, FAIL_REPLY, strlen(FAIL_REPLY), client_addr);
 }
 
-ssize_t process_assign_psk_cmd(int sock, struct client_address *client_addr,
+ssize_t process_assign_psk_cmd(int sock,
+                               const struct client_address *client_addr,
                                struct supervisor_context *context,
                                UT_array *cmd_arr) {
   char **ptr = (char **)utarray_next(cmd_arr, NULL);
@@ -234,7 +237,7 @@ ssize_t process_assign_psk_cmd(int sock, struct client_address *client_addr,
   return write_socket_data(sock, FAIL_REPLY, strlen(FAIL_REPLY), client_addr);
 }
 
-ssize_t process_get_map_cmd(int sock, struct client_address *client_addr,
+ssize_t process_get_map_cmd(int sock, const struct client_address *client_addr,
                             struct supervisor_context *context,
                             UT_array *cmd_arr) {
   char temp[255];
@@ -272,7 +275,7 @@ ssize_t process_get_map_cmd(int sock, struct client_address *client_addr,
   return write_socket_data(sock, FAIL_REPLY, strlen(FAIL_REPLY), client_addr);
 }
 
-ssize_t process_get_all_cmd(int sock, struct client_address *client_addr,
+ssize_t process_get_all_cmd(int sock, const struct client_address *client_addr,
                             struct supervisor_context *context,
                             UT_array *cmd_arr) {
   (void)cmd_arr; /* unused */
@@ -331,7 +334,7 @@ ssize_t process_get_all_cmd(int sock, struct client_address *client_addr,
   return bytes_sent;
 }
 
-ssize_t process_set_ip_cmd(int sock, struct client_address *client_addr,
+ssize_t process_set_ip_cmd(int sock, const struct client_address *client_addr,
                            struct supervisor_context *context,
                            UT_array *cmd_arr) {
   char **ptr = (char **)utarray_next(cmd_arr, NULL);
@@ -391,7 +394,8 @@ ssize_t process_set_ip_cmd(int sock, struct client_address *client_addr,
   return write_socket_data(sock, FAIL_REPLY, strlen(FAIL_REPLY), client_addr);
 }
 
-ssize_t process_add_bridge_cmd(int sock, struct client_address *client_addr,
+ssize_t process_add_bridge_cmd(int sock,
+                               const struct client_address *client_addr,
                                struct supervisor_context *context,
                                UT_array *cmd_arr) {
   char **ptr = (char **)utarray_next(cmd_arr, NULL);
@@ -439,7 +443,8 @@ ssize_t process_add_bridge_cmd(int sock, struct client_address *client_addr,
   return write_socket_data(sock, FAIL_REPLY, strlen(FAIL_REPLY), client_addr);
 }
 
-ssize_t process_remove_bridge_cmd(int sock, struct client_address *client_addr,
+ssize_t process_remove_bridge_cmd(int sock,
+                                  const struct client_address *client_addr,
                                   struct supervisor_context *context,
                                   UT_array *cmd_arr) {
   char **ptr = (char **)utarray_next(cmd_arr, NULL);
@@ -469,7 +474,8 @@ ssize_t process_remove_bridge_cmd(int sock, struct client_address *client_addr,
   return write_socket_data(sock, FAIL_REPLY, strlen(FAIL_REPLY), client_addr);
 }
 
-ssize_t process_clear_bridges_cmd(int sock, struct client_address *client_addr,
+ssize_t process_clear_bridges_cmd(int sock,
+                                  const struct client_address *client_addr,
                                   struct supervisor_context *context,
                                   UT_array *cmd_arr) {
   char **ptr = (char **)utarray_next(cmd_arr, NULL);
@@ -491,7 +497,8 @@ ssize_t process_clear_bridges_cmd(int sock, struct client_address *client_addr,
   return write_socket_data(sock, FAIL_REPLY, strlen(FAIL_REPLY), client_addr);
 }
 
-ssize_t process_get_bridges_cmd(int sock, struct client_address *client_addr,
+ssize_t process_get_bridges_cmd(int sock,
+                                const struct client_address *client_addr,
                                 struct supervisor_context *context,
                                 UT_array *cmd_arr) {
   (void)cmd_arr; /* unused */
@@ -539,7 +546,7 @@ ssize_t process_get_bridges_cmd(int sock, struct client_address *client_addr,
 }
 
 ssize_t process_register_ticket_cmd(int sock,
-                                    struct client_address *client_addr,
+                                    const struct client_address *client_addr,
                                     struct supervisor_context *context,
                                     UT_array *cmd_arr) {
   char **ptr = (char **)utarray_next(cmd_arr, NULL);
@@ -583,7 +590,8 @@ ssize_t process_register_ticket_cmd(int sock,
   return write_socket_data(sock, FAIL_REPLY, strlen(FAIL_REPLY), client_addr);
 }
 
-ssize_t process_clear_psk_cmd(int sock, struct client_address *client_addr,
+ssize_t process_clear_psk_cmd(int sock,
+                              const struct client_address *client_addr,
                               struct supervisor_context *context,
                               UT_array *cmd_arr) {
   char **ptr = (char **)utarray_next(cmd_arr, NULL);
@@ -603,7 +611,8 @@ ssize_t process_clear_psk_cmd(int sock, struct client_address *client_addr,
 }
 
 #ifdef WITH_CRYPTO_SERVICE
-ssize_t process_put_crypt_cmd(int sock, struct client_address *client_addr,
+ssize_t process_put_crypt_cmd(int sock,
+                              const struct client_address *client_addr,
                               struct supervisor_context *context,
                               UT_array *cmd_arr) {
   char **ptr = (char **)utarray_next(cmd_arr, NULL);
@@ -646,7 +655,8 @@ ssize_t process_put_crypt_cmd(int sock, struct client_address *client_addr,
   return write_socket_data(sock, FAIL_REPLY, strlen(FAIL_REPLY), client_addr);
 }
 
-ssize_t process_get_crypt_cmd(int sock, struct client_address *client_addr,
+ssize_t process_get_crypt_cmd(int sock,
+                              const struct client_address *client_addr,
                               struct supervisor_context *context,
                               UT_array *cmd_arr) {
   char **ptr = (char **)utarray_next(cmd_arr, NULL);
@@ -677,7 +687,8 @@ ssize_t process_get_crypt_cmd(int sock, struct client_address *client_addr,
   return write_socket_data(sock, FAIL_REPLY, strlen(FAIL_REPLY), client_addr);
 }
 
-ssize_t process_gen_randkey_cmd(int sock, struct client_address *client_addr,
+ssize_t process_gen_randkey_cmd(int sock,
+                                const struct client_address *client_addr,
                                 struct supervisor_context *context,
                                 UT_array *cmd_arr) {
   char **ptr = (char **)utarray_next(cmd_arr, NULL);
@@ -712,7 +723,8 @@ ssize_t process_gen_randkey_cmd(int sock, struct client_address *client_addr,
   return write_socket_data(sock, FAIL_REPLY, strlen(FAIL_REPLY), client_addr);
 }
 
-ssize_t process_gen_privkey_cmd(int sock, struct client_address *client_addr,
+ssize_t process_gen_privkey_cmd(int sock,
+                                const struct client_address *client_addr,
                                 struct supervisor_context *context,
                                 UT_array *cmd_arr) {
   char **ptr = (char **)utarray_next(cmd_arr, NULL);
@@ -747,7 +759,8 @@ ssize_t process_gen_privkey_cmd(int sock, struct client_address *client_addr,
   return write_socket_data(sock, FAIL_REPLY, strlen(FAIL_REPLY), client_addr);
 }
 
-ssize_t process_gen_pubkey_cmd(int sock, struct client_address *client_addr,
+ssize_t process_gen_pubkey_cmd(int sock,
+                               const struct client_address *client_addr,
                                struct supervisor_context *context,
                                UT_array *cmd_arr) {
   char **ptr = (char **)utarray_next(cmd_arr, NULL);
@@ -779,7 +792,7 @@ ssize_t process_gen_pubkey_cmd(int sock, struct client_address *client_addr,
   return write_socket_data(sock, FAIL_REPLY, strlen(FAIL_REPLY), client_addr);
 }
 
-ssize_t process_gen_cert_cmd(int sock, struct client_address *client_addr,
+ssize_t process_gen_cert_cmd(int sock, const struct client_address *client_addr,
                              struct supervisor_context *context,
                              UT_array *cmd_arr) {
   struct certificate_meta meta;
@@ -834,7 +847,8 @@ ssize_t process_gen_cert_cmd(int sock, struct client_address *client_addr,
   return write_socket_data(sock, FAIL_REPLY, strlen(FAIL_REPLY), client_addr);
 }
 
-ssize_t process_encrypt_blob_cmd(int sock, struct client_address *client_addr,
+ssize_t process_encrypt_blob_cmd(int sock,
+                                 const struct client_address *client_addr,
                                  struct supervisor_context *context,
                                  UT_array *cmd_arr) {
   char **ptr = (char **)utarray_next(cmd_arr, NULL);
@@ -885,7 +899,8 @@ ssize_t process_encrypt_blob_cmd(int sock, struct client_address *client_addr,
   return write_socket_data(sock, FAIL_REPLY, strlen(FAIL_REPLY), client_addr);
 }
 
-ssize_t process_decrypt_blob_cmd(int sock, struct client_address *client_addr,
+ssize_t process_decrypt_blob_cmd(int sock,
+                                 const struct client_address *client_addr,
                                  struct supervisor_context *context,
                                  UT_array *cmd_arr) {
   char **ptr = (char **)utarray_next(cmd_arr, NULL);
@@ -935,7 +950,8 @@ ssize_t process_decrypt_blob_cmd(int sock, struct client_address *client_addr,
   return write_socket_data(sock, FAIL_REPLY, strlen(FAIL_REPLY), client_addr);
 }
 
-ssize_t process_sign_blob_cmd(int sock, struct client_address *client_addr,
+ssize_t process_sign_blob_cmd(int sock,
+                              const struct client_address *client_addr,
                               struct supervisor_context *context,
                               UT_array *cmd_arr) {
   char **ptr = (char **)utarray_next(cmd_arr, NULL);

--- a/src/supervisor/cmd_processor.h
+++ b/src/supervisor/cmd_processor.h
@@ -60,7 +60,8 @@
 
 #define MAX_QUERY_OP_LEN 3
 
-typedef ssize_t (*process_cmd_fn)(int sock, struct client_address *client_addr,
+typedef ssize_t (*process_cmd_fn)(int sock,
+                                  const struct client_address *client_addr,
                                   struct supervisor_context *context,
                                   UT_array *cmd_arr);
 
@@ -85,7 +86,7 @@ bool process_domain_buffer(char *domain_buffer, size_t domain_buffer_len,
  * @param cmd_arr The array of received commands
  * @return ssize_t Size of reply written data
  */
-ssize_t process_ping_cmd(int sock, struct client_address *client_addr,
+ssize_t process_ping_cmd(int sock, const struct client_address *client_addr,
                          struct supervisor_context *context, UT_array *cmd_arr);
 
 /**
@@ -98,7 +99,7 @@ ssize_t process_ping_cmd(int sock, struct client_address *client_addr,
  * @return ssize_t Size of reply written data
  */
 ssize_t process_subscribe_events_cmd(int sock,
-                                     struct client_address *client_addr,
+                                     const struct client_address *client_addr,
                                      struct supervisor_context *context,
                                      UT_array *cmd_arr);
 
@@ -111,7 +112,8 @@ ssize_t process_subscribe_events_cmd(int sock,
  * @param cmd_arr The array of received commands
  * @return ssize_t Size of reply written data
  */
-ssize_t process_accept_mac_cmd(int sock, struct client_address *client_addr,
+ssize_t process_accept_mac_cmd(int sock,
+                               const struct client_address *client_addr,
                                struct supervisor_context *context,
                                UT_array *cmd_arr);
 
@@ -124,7 +126,7 @@ ssize_t process_accept_mac_cmd(int sock, struct client_address *client_addr,
  * @param cmd_arr The array of received commands
  * @return ssize_t Size of reply written data
  */
-ssize_t process_deny_mac_cmd(int sock, struct client_address *client_addr,
+ssize_t process_deny_mac_cmd(int sock, const struct client_address *client_addr,
                              struct supervisor_context *context,
                              UT_array *cmd_arr);
 
@@ -137,7 +139,7 @@ ssize_t process_deny_mac_cmd(int sock, struct client_address *client_addr,
  * @param cmd_arr The array of received commands
  * @return ssize_t Size of reply written data
  */
-ssize_t process_add_nat_cmd(int sock, struct client_address *client_addr,
+ssize_t process_add_nat_cmd(int sock, const struct client_address *client_addr,
                             struct supervisor_context *context,
                             UT_array *cmd_arr);
 
@@ -150,7 +152,8 @@ ssize_t process_add_nat_cmd(int sock, struct client_address *client_addr,
  * @param cmd_arr The array of received commands
  * @return ssize_t Size of reply written data
  */
-ssize_t process_remove_nat_cmd(int sock, struct client_address *client_addr,
+ssize_t process_remove_nat_cmd(int sock,
+                               const struct client_address *client_addr,
                                struct supervisor_context *context,
                                UT_array *cmd_arr);
 
@@ -163,7 +166,8 @@ ssize_t process_remove_nat_cmd(int sock, struct client_address *client_addr,
  * @param cmd_arr The array of received commands
  * @return ssize_t Size of reply written data
  */
-ssize_t process_assign_psk_cmd(int sock, struct client_address *client_addr,
+ssize_t process_assign_psk_cmd(int sock,
+                               const struct client_address *client_addr,
                                struct supervisor_context *context,
                                UT_array *cmd_arr);
 
@@ -176,7 +180,7 @@ ssize_t process_assign_psk_cmd(int sock, struct client_address *client_addr,
  * @param cmd_arr The array of received commands
  * @return ssize_t Size of reply written data
  */
-ssize_t process_get_map_cmd(int sock, struct client_address *client_addr,
+ssize_t process_get_map_cmd(int sock, const struct client_address *client_addr,
                             struct supervisor_context *context,
                             UT_array *cmd_arr);
 
@@ -189,7 +193,7 @@ ssize_t process_get_map_cmd(int sock, struct client_address *client_addr,
  * @param cmd_arr The array of received commands
  * @return ssize_t Size of reply written data, or `-1` on failure
  */
-ssize_t process_get_all_cmd(int sock, struct client_address *client_addr,
+ssize_t process_get_all_cmd(int sock, const struct client_address *client_addr,
                             struct supervisor_context *context,
                             UT_array *cmd_arr);
 
@@ -202,7 +206,7 @@ ssize_t process_get_all_cmd(int sock, struct client_address *client_addr,
  * @param cmd_arr The array of received commands
  * @return ssize_t Size of reply written data
  */
-ssize_t process_set_ip_cmd(int sock, struct client_address *client_addr,
+ssize_t process_set_ip_cmd(int sock, const struct client_address *client_addr,
                            struct supervisor_context *context,
                            UT_array *cmd_arr);
 
@@ -215,7 +219,8 @@ ssize_t process_set_ip_cmd(int sock, struct client_address *client_addr,
  * @param cmd_arr The array of received commands
  * @return ssize_t Size of reply written data
  */
-ssize_t process_add_bridge_cmd(int sock, struct client_address *client_addr,
+ssize_t process_add_bridge_cmd(int sock,
+                               const struct client_address *client_addr,
                                struct supervisor_context *context,
                                UT_array *cmd_arr);
 
@@ -228,7 +233,8 @@ ssize_t process_add_bridge_cmd(int sock, struct client_address *client_addr,
  * @param cmd_arr The array of received commands
  * @return ssize_t Size of reply written data
  */
-ssize_t process_remove_bridge_cmd(int sock, struct client_address *client_addr,
+ssize_t process_remove_bridge_cmd(int sock,
+                                  const struct client_address *client_addr,
                                   struct supervisor_context *context,
                                   UT_array *cmd_arr);
 
@@ -241,7 +247,8 @@ ssize_t process_remove_bridge_cmd(int sock, struct client_address *client_addr,
  * @param cmd_arr The array of received commands
  * @return ssize_t Size of reply written data
  */
-ssize_t process_clear_bridges_cmd(int sock, struct client_address *client_addr,
+ssize_t process_clear_bridges_cmd(int sock,
+                                  const struct client_address *client_addr,
                                   struct supervisor_context *context,
                                   UT_array *cmd_arr);
 
@@ -254,7 +261,8 @@ ssize_t process_clear_bridges_cmd(int sock, struct client_address *client_addr,
  * @param cmd_arr The array of received commands
  * @return ssize_t Size of reply written data
  */
-ssize_t process_get_bridges_cmd(int sock, struct client_address *client_addr,
+ssize_t process_get_bridges_cmd(int sock,
+                                const struct client_address *client_addr,
                                 struct supervisor_context *context,
                                 UT_array *cmd_arr);
 
@@ -268,7 +276,7 @@ ssize_t process_get_bridges_cmd(int sock, struct client_address *client_addr,
  * @return ssize_t Size of reply written data
  */
 ssize_t process_set_fingerprint_cmd(int sock,
-                                    struct client_address *client_addr,
+                                    const struct client_address *client_addr,
                                     struct supervisor_context *context,
                                     UT_array *cmd_arr);
 
@@ -282,7 +290,7 @@ ssize_t process_set_fingerprint_cmd(int sock,
  * @return ssize_t Size of reply written data
  */
 ssize_t process_query_fingerprint_cmd(int sock,
-                                      struct client_address *client_addr,
+                                      const struct client_address *client_addr,
                                       struct supervisor_context *context,
                                       UT_array *cmd_arr);
 
@@ -298,7 +306,7 @@ ssize_t process_query_fingerprint_cmd(int sock,
  * Returns `strlen(FAIL_REPLY)` on error.
  */
 ssize_t process_register_ticket_cmd(int sock,
-                                    struct client_address *client_addr,
+                                    const struct client_address *client_addr,
                                     struct supervisor_context *context,
                                     UT_array *cmd_arr);
 
@@ -311,7 +319,8 @@ ssize_t process_register_ticket_cmd(int sock,
  * @param cmd_arr The array of received commands
  * @return ssize_t Size of reply written data
  */
-ssize_t process_clear_psk_cmd(int sock, struct client_address *client_addr,
+ssize_t process_clear_psk_cmd(int sock,
+                              const struct client_address *client_addr,
                               struct supervisor_context *context,
                               UT_array *cmd_arr);
 
@@ -325,7 +334,8 @@ ssize_t process_clear_psk_cmd(int sock, struct client_address *client_addr,
  * @param cmd_arr The array of received commands
  * @return ssize_t Size of reply written data
  */
-ssize_t process_put_crypt_cmd(int sock, struct client_address *client_addr,
+ssize_t process_put_crypt_cmd(int sock,
+                              const struct client_address *client_addr,
                               struct supervisor_context *context,
                               UT_array *cmd_arr);
 
@@ -338,7 +348,8 @@ ssize_t process_put_crypt_cmd(int sock, struct client_address *client_addr,
  * @param cmd_arr The array of received commands
  * @return ssize_t Size of reply written data
  */
-ssize_t process_get_crypt_cmd(int sock, struct client_address *client_addr,
+ssize_t process_get_crypt_cmd(int sock,
+                              const struct client_address *client_addr,
                               struct supervisor_context *context,
                               UT_array *cmd_arr);
 
@@ -351,7 +362,8 @@ ssize_t process_get_crypt_cmd(int sock, struct client_address *client_addr,
  * @param cmd_arr The array of received commands
  * @return ssize_t Size of reply written data
  */
-ssize_t process_gen_randkey_cmd(int sock, struct client_address *client_addr,
+ssize_t process_gen_randkey_cmd(int sock,
+                                const struct client_address *client_addr,
                                 struct supervisor_context *context,
                                 UT_array *cmd_arr);
 
@@ -364,7 +376,8 @@ ssize_t process_gen_randkey_cmd(int sock, struct client_address *client_addr,
  * @param cmd_arr The array of received commands
  * @return ssize_t Size of reply written data
  */
-ssize_t process_gen_privkey_cmd(int sock, struct client_address *client_addr,
+ssize_t process_gen_privkey_cmd(int sock,
+                                const struct client_address *client_addr,
                                 struct supervisor_context *context,
                                 UT_array *cmd_arr);
 
@@ -377,7 +390,8 @@ ssize_t process_gen_privkey_cmd(int sock, struct client_address *client_addr,
  * @param cmd_arr The array of received commands
  * @return ssize_t Size of reply written data
  */
-ssize_t process_gen_pubkey_cmd(int sock, struct client_address *client_addr,
+ssize_t process_gen_pubkey_cmd(int sock,
+                               const struct client_address *client_addr,
                                struct supervisor_context *context,
                                UT_array *cmd_arr);
 
@@ -390,7 +404,7 @@ ssize_t process_gen_pubkey_cmd(int sock, struct client_address *client_addr,
  * @param cmd_arr The array of received commands
  * @return ssize_t Size of reply written data
  */
-ssize_t process_gen_cert_cmd(int sock, struct client_address *client_addr,
+ssize_t process_gen_cert_cmd(int sock, const struct client_address *client_addr,
                              struct supervisor_context *context,
                              UT_array *cmd_arr);
 
@@ -403,7 +417,8 @@ ssize_t process_gen_cert_cmd(int sock, struct client_address *client_addr,
  * @param cmd_arr The array of received commands
  * @return ssize_t Size of reply written data
  */
-ssize_t process_encrypt_blob_cmd(int sock, struct client_address *client_addr,
+ssize_t process_encrypt_blob_cmd(int sock,
+                                 const struct client_address *client_addr,
                                  struct supervisor_context *context,
                                  UT_array *cmd_arr);
 
@@ -416,7 +431,8 @@ ssize_t process_encrypt_blob_cmd(int sock, struct client_address *client_addr,
  * @param cmd_arr The array of received commands
  * @return ssize_t Size of reply written data
  */
-ssize_t process_decrypt_blob_cmd(int sock, struct client_address *client_addr,
+ssize_t process_decrypt_blob_cmd(int sock,
+                                 const struct client_address *client_addr,
                                  struct supervisor_context *context,
                                  UT_array *cmd_arr);
 
@@ -429,7 +445,8 @@ ssize_t process_decrypt_blob_cmd(int sock, struct client_address *client_addr,
  * @param cmd_arr The array of received commands
  * @return ssize_t Size of reply written data
  */
-ssize_t process_sign_blob_cmd(int sock, struct client_address *client_addr,
+ssize_t process_sign_blob_cmd(int sock,
+                              const struct client_address *client_addr,
                               struct supervisor_context *context,
                               UT_array *cmd_arr);
 #endif

--- a/src/supervisor/subscriber_events.c
+++ b/src/supervisor/subscriber_events.c
@@ -52,7 +52,7 @@ int sort_subscribers_array(const void *a, const void *b) {
 }
 
 int add_events_subscriber(struct supervisor_context *context,
-                          struct client_address *addr) {
+                          const struct client_address *addr) {
   struct client_address *p = NULL;
 
   p = utarray_find(context->subscribers_array, addr, sort_subscribers_array);

--- a/src/supervisor/subscriber_events.h
+++ b/src/supervisor/subscriber_events.h
@@ -36,7 +36,7 @@ enum SUBSCRIBER_EVENT {
  * @return 0 on success, -1 on failure
  */
 int add_events_subscriber(struct supervisor_context *context,
-                          struct client_address *addr);
+                          const struct client_address *addr);
 
 /**
  * @brief Send an event to the subscribers array

--- a/src/supervisor/system_commands.c
+++ b/src/supervisor/system_commands.c
@@ -171,7 +171,7 @@ int set_ip_cmd(struct supervisor_context *context, uint8_t *mac_addr,
 char *ping_cmd(void) { return os_strdup(PING_REPLY); }
 
 int subscribe_events_cmd(struct supervisor_context *context,
-                         struct client_address *addr) {
+                         const struct client_address *addr) {
   log_debug("SUBSCRIBE_EVENTS with size=%d and type=%d", addr->len, addr->type);
   return add_events_subscriber(context, addr);
 }

--- a/src/supervisor/system_commands.h
+++ b/src/supervisor/system_commands.h
@@ -55,6 +55,6 @@ char *ping_cmd(void);
  * @return 0 on success, -1 on failure
  */
 int subscribe_events_cmd(struct supervisor_context *context,
-                         struct client_address *addr);
+                         const struct client_address *addr);
 
 #endif


### PR DESCRIPTION
Make the `client_addr` parameter in `cmd_processor` `const`, as we only ever read the value and never change anything.

Even when we call `utarray_push_back(..., addr)`, utarray by default does a `memcpy` to insert the new data, so it also doesn't modify the original pointer, see <https://troydhanson.github.io/uthash/utarray.html#_about_ut_icd>.