### PR TITLE
Make the `cmd` parameter in `get_command_function() `const`

### DIFF
--- a/src/supervisor/cmd_processor.c
+++ b/src/supervisor/cmd_processor.c
@@ -971,7 +971,7 @@ ssize_t process_sign_blob_cmd(int sock, struct client_address *client_addr,
 }
 #endif
 
-process_cmd_fn get_command_function(char *cmd) {
+process_cmd_fn get_command_function(const char *cmd) {
   if (!strcmp(cmd, CMD_PING)) {
     return process_ping_cmd;
   } else if (!strcmp(cmd, CMD_SUBSCRIBE_EVENTS)) {

--- a/src/supervisor/cmd_processor.h
+++ b/src/supervisor/cmd_processor.h
@@ -440,5 +440,5 @@ ssize_t process_sign_blob_cmd(int sock, struct client_address *client_addr,
  * @param cmd The command string
  * @return process_cmd_fn The returned function pointer
  */
-process_cmd_fn get_command_function(char *cmd);
+process_cmd_fn get_command_function(const char *cmd);
 #endif


### PR DESCRIPTION
Make the `cmd` parameter of `get_command_function()` `const`.

We only read this string and never change it, so we might as well make it `const`.

---

Side-note, all the `strcmp(...)` are a bit slow, since it's $O(n)$ (i.e. it scales linearly with the number of command types.

We could switch to using a hashmap (like [uthash.h](https://troydhanson.github.io/uthash/userguide.html)), which would be $O(1)$ (i.e. constant time with every command type), but if we only have 25 message types, I've got no idea how big the speedup will be :shrug:

Still, it's something to consider the more message types we add.