### PR TITLE
Simplify `uci_lookup_section_ref()` function

### DIFF
--- a/src/utils/uci_wrt.c
+++ b/src/utils/uci_wrt.c
@@ -96,9 +96,7 @@ char *uci_lookup_section_ref(struct uci_section *s, struct uci_type_list *list,
       *typestr = p;
     }
 
-    if (*typestr != NULL) {
-      sprintf(*typestr, "@%s[%d]", ti->name, ti->idx);
-    }
+    sprintf(*typestr, "@%s[%d]", ti->name, ti->idx);
 
     ret = *typestr;
   } else {

--- a/src/utils/uci_wrt.c
+++ b/src/utils/uci_wrt.c
@@ -57,8 +57,9 @@ void uci_reset_typelist(struct uci_type_list *list) {
   }
 }
 
-char *uci_lookup_section_ref(struct uci_section *s, struct uci_type_list *list,
-                             char **typestr) {
+static char *uci_lookup_section_ref(struct uci_section *s,
+                                    struct uci_type_list *list,
+                                    char **typestr) {
   struct uci_type_list *ti = list;
   char *ret;
   int maxlen;

--- a/src/utils/uci_wrt.c
+++ b/src/utils/uci_wrt.c
@@ -85,13 +85,8 @@ char *uci_lookup_section_ref(struct uci_section *s, struct uci_type_list *list,
 
   if (s->anonymous) {
     maxlen = strlen(s->type) + 1 + 2 + 10;
-    if (*typestr == NULL) {
-      if ((*typestr = os_malloc(maxlen)) == NULL) {
-        log_errno("os_malloc");
-        return NULL;
-      }
-    } else {
-      void *p = os_realloc(*typestr, maxlen);
+    {
+      char *p = os_realloc(*typestr, maxlen);
       if (p == NULL) {
         log_errno("os_realloc");
         os_free(*typestr);

--- a/src/utils/uci_wrt.c
+++ b/src/utils/uci_wrt.c
@@ -60,11 +60,9 @@ void uci_reset_typelist(struct uci_type_list *list) {
 static char *uci_lookup_section_ref(struct uci_section *s,
                                     struct uci_type_list *list,
                                     char **typestr) {
-  struct uci_type_list *ti = list;
-  char *ret;
-  int maxlen;
 
   /* look up in section type list */
+  struct uci_type_list *ti = list;
   while (ti != NULL) {
     if (strcmp(ti->name, s->type) == 0) {
       break;
@@ -84,8 +82,10 @@ static char *uci_lookup_section_ref(struct uci_section *s,
     ti->name = s->type;
   }
 
+  char *ret;
+
   if (s->anonymous) {
-    maxlen = strlen(s->type) + 1 + 2 + 10;
+    int maxlen = strlen(s->type) + 1 + 2 + 10;
     {
       char *p = os_realloc(*typestr, maxlen);
       if (p == NULL) {


### PR DESCRIPTION
Simplifies the `uci_lookup_section_ref()` function.

- Removes a `malloc()` call that we don't need (since `malloc(x)` is equivalent to `realloc(NULL, x)` (046570f6dc2d1d2dbe36d27cdee61083b1ba48f7)
- Removes an unnecessary `NULL` check (we've already checked for memory allocation failures earlier in the function)  (6576dfdbea68137a5300e5cb6f89a53803082854)
- Makes the `uci_lookup_section_ref()` function `static`, since we never use it outside of `uci_wrt.c` (5eb29b821b567ea6371245f06e31aa589a84ab64)
- Declare variables as close as possible to where the variables are actually used, since that's supported in C99 (1b93f254730c7c9e4bfa656f24b3328be163ede9)

---

There's a bunch of extra stuff I haven't changed, since I don't actually understand what this function does. Also, it looks like the function currently has a bug in it (see https://github.com/nqminds/edgesec/issues/481), so I didn't want to change anything/document anything that was incorrect behaviour.

