### PR TITLE
Handle `ENOMEM` in `read_pcap()` in the `edgesec-recap` binary

### DIFF
--- a/src/edgesec-recap.c
+++ b/src/edgesec-recap.c
@@ -196,11 +196,15 @@ ssize_t read_pcap(struct recap_context *pctx, size_t len) {
   ssize_t current_size = read_size + pctx->data_size;
 
   if (read_size > 0) {
-    if ((pctx->pcap_data = os_realloc(pctx->pcap_data, current_size)) == NULL) {
+    char *reallocated_pcap_data = os_realloc(pctx->pcap_data, current_size);
+    if (reallocated_pcap_data == NULL) {
       log_errno("os_realloc");
       os_free(data);
+      // don't free `pctx->pcap_data`, since it might be realloc-ed by the next
+      // read_pcap() call
       return -1;
     }
+    pctx->pcap_data = reallocated_pcap_data;
     os_memcpy(&pctx->pcap_data[pctx->data_size], data, read_size);
     pctx->data_size = current_size;
   }


### PR DESCRIPTION
Currently, if `os_realloc()` in `read_pcap()` fails due to an `ENOMEM` error, there will be a memory leak, since we lose the original pointer. This is because the anti-pattern `PTR = realloc (PTR, sz)` leaks memory on failure.

Instead, we need to do:

```c
void *NEW_PTR = realloc (PTR, sz);
if (NEW_PTR == NULL) {
  // handle error
} else {
  PTR = NEW_PTR;
}
```