### PR TITLE
Fix `pctx.pcap_data` memory leak in `edgesec-recap`

### DIFF
--- a/src/edgesec-recap.c
+++ b/src/edgesec-recap.c
@@ -740,6 +740,8 @@ cleanup:
     fclose(pctx.pcap_fd);
   }
 
+  os_free(pctx.pcap_data);
+
   os_free(pctx.out_path);
   // sqlite3 close on a NULL ptr is fine
   // any uncommited transactions will be automatically rolled-back on close


### PR DESCRIPTION
Free the memory of `pctx.pcap_data` when edgesec-recap closes.

This isn't too big of a deal, since on pretty much every OS that we care about, the OS will automatically free this leaked memory when edgesec-recap exits. Still, it's worth explicitly `free()`-ing this memory, otherwise static analyzers, or [Valgrind](https://valgrind.org/) will print a bunch of warnings.