### PR TITLE
Fix `uwrt_lookup_package()` in `uci_wrt.c`

### DIFF
--- a/src/utils/uci_wrt.c
+++ b/src/utils/uci_wrt.c
@@ -292,8 +292,8 @@ static int uwrt_lookup_option(const struct uci_option *o, const char *sref,
  * @retval  0 On success.
  * @retval -1 On failure. The array may be partially filled in an error.
  */
-int uwrt_lookup_section(const struct uci_section *s, const char *sref,
-                        UT_array *kv) {
+static int uwrt_lookup_section(const struct uci_section *s, const char *sref,
+                               UT_array *kv) {
   const struct uci_element *e = NULL;
   const char *cname = s->package->e.name;
   const char *sname = (sref != NULL ? sref : s->e.name);

--- a/src/utils/uci_wrt.c
+++ b/src/utils/uci_wrt.c
@@ -134,7 +134,8 @@ uci_lookup_section_ref(struct uci_section *s,
       char *p = os_realloc(*typestr, maxlen);
       if (p == NULL) {
         log_errno("os_realloc");
-        os_free(*typestr);
+        // don't free() *typestr, next call to uci_lookup_section_ref()
+        // may reuse this value
         return NULL;
       }
 

--- a/src/utils/uci_wrt.c
+++ b/src/utils/uci_wrt.c
@@ -152,7 +152,30 @@ static char *uci_lookup_section_ref(struct uci_section *s,
   return ret;
 }
 
-char *uwrt_get_option(const struct uci_option *o) {
+/**
+ * @brief Gets the value of the given option.
+ *
+ * For list options, the value would be all the list entries concatenated
+ * together.
+ *
+ * For example, given the following UCI file:
+ *
+ * ```uci
+ * config rule
+ *   option string_opt 'my-val'
+ *   list list_open 'list-val-1'
+ *   list list_open 'list-val-2'
+ * ```
+ *
+ * - calling `uwrt_get_option()` on `string_opt` would return `my-val`
+ * - calling `uwrt_get_option()` on `list_opt` would return
+ * `list-val-1list-val-2`
+ *
+ * @param o The option to read.
+ * @return The value of the option as a NUL-terminated string, or `NULL` on
+ * error. Please free() the string when you're done with it.
+ */
+__must_free char *uwrt_get_option(const struct uci_option *o) {
   const struct uci_element *e = NULL;
   char *vname = NULL;
   struct string_queue *squeue = NULL;
@@ -188,6 +211,8 @@ char *uwrt_get_option(const struct uci_option *o) {
     default:
       log_trace("unknown uci type");
   }
+
+  log_trace("Option is %s", vname);
 
   return vname;
 }

--- a/src/utils/uci_wrt.c
+++ b/src/utils/uci_wrt.c
@@ -233,8 +233,8 @@ __must_free static char *uwrt_get_option(const struct uci_option *o) {
  * @retval  0 On success.
  * @retval -1 On failure.
  */
-int uwrt_lookup_option(const struct uci_option *o, const char *sref,
-                       UT_array *kv) {
+static int uwrt_lookup_option(const struct uci_option *o, const char *sref,
+                              UT_array *kv) {
   const char *cname = o->section->package->e.name;
   const char *sname = (sref != NULL ? sref : o->section->e.name);
   const char *oname = o->e.name;

--- a/src/utils/uci_wrt.c
+++ b/src/utils/uci_wrt.c
@@ -217,10 +217,11 @@ __must_free static char *uwrt_get_option(const struct uci_option *o) {
   return vname;
 }
 
-int uwrt_lookup_option(struct uci_option *o, char *sref, UT_array *kv) {
-  char *cname = o->section->package->e.name;
-  char *sname = (sref != NULL ? sref : o->section->e.name);
-  char *oname = o->e.name;
+int uwrt_lookup_option(const struct uci_option *o, const char *sref,
+                       UT_array *kv) {
+  const char *cname = o->section->package->e.name;
+  const char *sname = (sref != NULL ? sref : o->section->e.name);
+  const char *oname = o->e.name;
   char *vname = NULL;
   char *kvstr = NULL;
 

--- a/src/utils/uci_wrt.c
+++ b/src/utils/uci_wrt.c
@@ -152,8 +152,8 @@ static char *uci_lookup_section_ref(struct uci_section *s,
   return ret;
 }
 
-char *uwrt_get_option(struct uci_option *o) {
-  struct uci_element *e = NULL;
+char *uwrt_get_option(const struct uci_option *o) {
+  const struct uci_element *e = NULL;
   char *vname = NULL;
   struct string_queue *squeue = NULL;
 

--- a/src/utils/uci_wrt.c
+++ b/src/utils/uci_wrt.c
@@ -217,6 +217,22 @@ __must_free static char *uwrt_get_option(const struct uci_option *o) {
   return vname;
 }
 
+/**
+ * @brief Adds a string for the UCI option to the given array.
+ *
+ * For the given UCI option, creates a configuration string, similar
+ * to that from `uci show system`, e.g. `system.ntp.enabled=1`.
+ *
+ * Unlike `uci show system`, option values are **NOT** quoted, so are not valid
+ * to pass to `uci set`. (list options are also mangled).
+ *
+ * @param o The UCI option struct.
+ * @param sref The section reference to use. If this is NULL, uses the name
+ * of the section (won't work if the section is anonymous and has no name).
+ * @param[in, out] kv The array to store the output.
+ * @retval  0 On success.
+ * @retval -1 On failure.
+ */
 int uwrt_lookup_option(const struct uci_option *o, const char *sref,
                        UT_array *kv) {
   const char *cname = o->section->package->e.name;

--- a/src/utils/uci_wrt.c
+++ b/src/utils/uci_wrt.c
@@ -262,6 +262,36 @@ static int uwrt_lookup_option(const struct uci_option *o, const char *sref,
   return 0;
 }
 
+/**
+ * @brief Adds strings describing a UCI section into the given array.
+ *
+ * The output is similar to the result of using the UCI CLI command
+ * `uci show <config>.<section>`, except option values are not quoted, see
+ * uwrt_get_option().
+ *
+ * For example, given the below section:
+ *
+ * ```conf
+ * # in file /etc/config/my_config
+ * config rule 'section_name'
+ *   option string_opt 'my-val'
+ *   list list_opt 'list-val-1'
+ *   list list_opt 'list-val-2'
+ * ```
+ *
+ * The UT_array entries would look like:
+ *
+ * 1. `my_config.section_name=rule`
+ * 2. `my_config.section_name.string_opt=my-val`
+ * 3. `my_config.section_name.list_opt=list-val-1list-val-2`
+ *
+ * @param s The UCI section struct.
+ * @param sref The section reference to use. If this is NULL, uses the name
+ * of the section (won't work if the section is anonymous and has no name).
+ * @param[in, out] kv The array to store the output.
+ * @retval  0 On success.
+ * @retval -1 On failure. The array may be partially filled in an error.
+ */
 int uwrt_lookup_section(const struct uci_section *s, const char *sref,
                         UT_array *kv) {
   const struct uci_element *e = NULL;

--- a/src/utils/uci_wrt.c
+++ b/src/utils/uci_wrt.c
@@ -100,9 +100,10 @@ static void uci_clear_section_types_count(
  * (i.e. `@timeserver[0]`) or to `s->e.name` (for named sections), and so may
  * be invalid once either of them are `free()`-ed.
  */
-static char *uci_lookup_section_ref(struct uci_section *s,
-                                    struct uci_section_type_count **section_types_count,
-                                    char **typestr) {
+static const char *
+uci_lookup_section_ref(struct uci_section *s,
+                       struct uci_section_type_count **section_types_count,
+                       char **typestr) {
 
   struct uci_section_type_count *section_type_count;
   HASH_FIND_STR(*section_types_count, s->type, section_type_count);
@@ -295,13 +296,13 @@ int uwrt_lookup_package(struct uci_package *p, UT_array *kv) {
   struct uci_section_type_count *section_types_count = NULL;
 
   char *typestr = NULL;
-  char *sref = NULL;
   int ret = 0;
 
   uci_foreach_element(&p->sections, e) {
     struct uci_section *s = uci_to_section(e);
-    if ((sref = uci_lookup_section_ref(s, &section_types_count, &typestr)) ==
-        NULL) {
+    const char *sref =
+        uci_lookup_section_ref(s, &section_types_count, &typestr);
+    if (sref == NULL) {
       log_trace("uci_lookup_section_ref fail");
       ret = -1;
       goto uwrt_lookup_package_fail;

--- a/src/utils/uci_wrt.c
+++ b/src/utils/uci_wrt.c
@@ -175,7 +175,7 @@ static char *uci_lookup_section_ref(struct uci_section *s,
  * @return The value of the option as a NUL-terminated string, or `NULL` on
  * error. Please free() the string when you're done with it.
  */
-__must_free char *uwrt_get_option(const struct uci_option *o) {
+__must_free static char *uwrt_get_option(const struct uci_option *o) {
   const struct uci_element *e = NULL;
   char *vname = NULL;
   struct string_queue *squeue = NULL;

--- a/src/utils/uci_wrt.c
+++ b/src/utils/uci_wrt.c
@@ -261,11 +261,12 @@ static int uwrt_lookup_option(const struct uci_option *o, const char *sref,
   return 0;
 }
 
-int uwrt_lookup_section(struct uci_section *s, char *sref, UT_array *kv) {
-  struct uci_element *e = NULL;
-  char *cname = s->package->e.name;
-  char *sname = (sref != NULL ? sref : s->e.name);
-  char *vname = s->type;
+int uwrt_lookup_section(const struct uci_section *s, const char *sref,
+                        UT_array *kv) {
+  const struct uci_element *e = NULL;
+  const char *cname = s->package->e.name;
+  const char *sname = (sref != NULL ? sref : s->e.name);
+  const char *vname = s->type;
   char *kvstr = NULL;
 
   if ((kvstr = os_zalloc(strlen(cname) + strlen(sname) + strlen(vname) + 3)) ==

--- a/src/utils/uci_wrt.c
+++ b/src/utils/uci_wrt.c
@@ -6,6 +6,12 @@
  * SPDX-FileCopyrightText: © 2022 NQMCyber Ltd and edgesec contributors
  * SPDX-License-Identifier: LGPL-3.0-or-later
  * @brief File containing the implementation of the uci utilities.
+ * @details
+ * Utility functions for working with UCI (Unified Configuration Interface),
+ * which is most commonly used to configure OpenWRT services.
+ *
+ * Please see <https://openwrt.org/docs/guide-user/base-system/uci> for a
+ * description of UCI data/object model.
  */
 
 #include <arpa/inet.h>
@@ -57,6 +63,25 @@ void uci_reset_typelist(struct uci_type_list *list) {
   }
 }
 
+/**
+ * @brief Find the reference to the given UCI section.
+ *
+ * UCI supports array-like references to UCI sections.
+ *
+ * For example, `system.@timeserver[0]` will be the first `timeserver` section
+ * in `/etc/config/system`.
+ *
+ * @param s - The UCI section to find the reference to.
+ * @param list - Section type list. Should contain all the previous section
+ * entries.
+ * @param[in, out] typestr - malloc()-ed buffer that can be realloc()-ed
+ * as required, or `NULL`. Please `free()` this parameter after this function
+ * has been called.
+ * @return A reference to this section, e.g. `@timeserver[0]`.
+ * This pointer may point to `typestr` (for anonymous sections)
+ * (i.e. `@timeserver[0]`) or to `s->e.name` (for named sections), and so may
+ * be invalid once either of them are `free()`-ed.
+ */
 static char *uci_lookup_section_ref(struct uci_section *s,
                                     struct uci_type_list *list,
                                     char **typestr) {


### PR DESCRIPTION
Fix the `uwrt_lookup_package()` function in `uci_wrt.c`.

`uwrt_lookup_package()` is currently never adding anything to it's `list` param, which means that the count for anonymous section references is always 0. (this is also the cause of the memory leak in #481).

For example, given the following UCI file:

```conf
config rule
  option hi 'hi'

config rule
  option hi 'hi'

config rule
  option hi 'hi2'
```

Output:

| # | Current | Expected |
| -: | -- | -- |
|  0 | `@rule[0]` | `@rule[0]` |
|  1 | `@rule[0]` | `@rule[1]` |
|  2 | `@rule[0]` | `@rule[2]` |

To fix this, I've instead changed `uci_lookup_section_ref()` to use a [uthash.h](https://troydhanson.github.io/uthash/userguide.html) hashmap as a counter, instead of a custom linked-list.

Fixes #481

### Other changes

For the following functions, I've also made their parameters `const` when possible, add documentation of what the functions did, and made them `static`/gave them internal linkage, since they're never used outside of `uci_wrt.c`.

  - `uwrt_get_option()`
  - `uwrt_lookup_option()`
  - `uwrt_lookup_section()`

I've made the return string of `uci_lookup_section_ref()` a `const char *` instead of a `const char *` because it should **NOT** be `free()`-ed, as instead `uci_lookup_section_ref()` `malloc()`'s it's `malloc_buffer` param and that should be `free()`-ed instead.

Finally, I've fixed a double-`free()` error in `malloc_buffer` (originally named `typestr`).

- 1st `free()`:
https://github.com/nqminds/edgesec/blob/3b38b374c146d61207b705df084938b826b7e526/src/utils/uci_wrt.c#L93
- 2nd `free()`:
https://github.com/nqminds/edgesec/blob/3b38b374c146d61207b705df084938b826b7e526/src/utils/uci_wrt.c#L231

### Notes to reviewer (weird behaviour of `uwrt_get_option()`)

The behaviour of `uwrt_get_option()` is a bit weird. It almost exactly matches the syntax from the `uci show system` command-line, except: 

1. It doesn't quote the output.
2. List options are concatenated together.

For example:

```conf
# in file /etc/config/my_config
config rule 'section_name'
  option string_opt 'my-val'
  list list_opt 'list-val-1'
  list list_opt 'list-val-2'
```

The output for `uci_wrt.c` will look like:

```
my_config.section_name=rule
my_config.section_name.string_opt=my-val
my_config.section_name.list_opt=list-val-1list-val-2
```

However, if we ran `uci show my_config` on an OpenWRT box, we would instead get something like:

```
my_config.section_name='rule'
my_config.section_name.string_opt='my-val'
my_config.section_name.list_opt='list-val-1' 'list-val-2'
```

I've documented this behaviour, but we may want to change our `uci_wrt.c` behaviour to match that of the `uci` CLI tool, since I feel like we might have escaping issues with our version.