### PR TITLE
Make format string in `log_trace` a literal to avoid format string injection attacks/bugs

### DIFF
--- a/tests/utils/test_log_thread_safe.c
+++ b/tests/utils/test_log_thread_safe.c
@@ -31,7 +31,7 @@ static void lock_fn(bool lock) {
 
 static void *threadFunc(void *arg) {
   for (int i = 0; i < 1000; i++)
-    log_trace((char *)arg);
+    log_trace("%s", (char *)arg);
   return NULL;
 }
 


### PR DESCRIPTION
Make the format-string in `log_trace()` in the `test_log_thread_safe` a string literal to avoid format string injection attacks/bugs (see <https://en.m.wikipedia.org/wiki/Uncontrolled_format_string>).