### PR TITLE
Fix `make_dirs_to_path()` error message

### DIFF
--- a/src/supervisor/sqlite_macconn_writer.c
+++ b/src/supervisor/sqlite_macconn_writer.c
@@ -34,7 +34,7 @@ int open_sqlite_macconn_db(const char *db_path, sqlite3 **sql) {
   int rc;
 
   if (make_dirs_to_path(db_path, 0755)) {
-    log_errno("Failed to create folders for sqlite macconn db: %s", db);
+    log_errno("Failed to create folders for sqlite macconn db: %s", db_path);
     return -1;
   }
 


### PR DESCRIPTION
Fix the error that is printed when `make_dirs_to_path()` fails in `open_sqlite_macconn_db()`. Currently, the wrong variable is printed, as it should be the path that is printed, not a NULL pointer.