### PR TITLE
Cast `%p` format argument to `(void *)` to silence GCC warning

### DIFF
--- a/src/radius/wpabuf.c
+++ b/src/radius/wpabuf.c
@@ -36,9 +36,9 @@ static void wpabuf_overflow(const struct wpabuf *buf, size_t len) {
     wpa_printf(MSG_ERROR, "wpabuf: invalid magic %x", trace->magic);
   }
 #endif /* WPA_TRACE */
-  wpa_printf(MSG_ERROR, "wpabuf %p (size=%lu used=%lu) overflow len=%lu", buf,
-             (unsigned long)buf->size, (unsigned long)buf->used,
-             (unsigned long)len);
+  wpa_printf(MSG_ERROR, "wpabuf %p (size=%lu used=%lu) overflow len=%lu",
+             (const void *)buf, (unsigned long)buf->size,
+             (unsigned long)buf->used, (unsigned long)len);
   wpa_trace_show("wpabuf overflow");
   abort();
 }


### PR DESCRIPTION
GCC throws an warning when trying to pass a non-`void *` pointer to a `%p` in a format string. This might be a bug in GCC, since I'm pretty sure this is explicitly valid behaviour in C.

Manually casting the pointer to `(const void *)` seems to fix this warning from GCC.