### PR TITLE
Use `%zd` to format `ssize_t` values

### DIFF
--- a/src/radius/radius_server.c
+++ b/src/radius/radius_server.c
@@ -304,7 +304,7 @@ radius_server_get_new_session(struct radius_server_data *data,
     log_error("Could not get User-Name");
     return NULL;
   }
-  log_trace("User-Name length %ld", user_len);
+  log_trace("User-Name length %zd", user_len);
 
   log_trace("Matching user entry found");
   sess = radius_server_new_session(data, client);

--- a/src/utils/sockctl.c
+++ b/src/utils/sockctl.c
@@ -422,7 +422,7 @@ int writeread_domain_data_str(char *socket_path, const char *write_str,
     goto cleanup_sfd;
   }
 
-  log_trace("Sent %d bytes to %s", send_count, socket_path);
+  log_trace("Sent %zd bytes to %s", send_count, socket_path);
 
   errno = 0;
   struct timeval timeout = {

--- a/src/utils/squeue.c
+++ b/src/utils/squeue.c
@@ -140,7 +140,7 @@ char *concat_string_queue(const struct string_queue *queue, ssize_t count) {
         char *resized_concat_str = os_realloc(concat_str, size);
 
         if (resized_concat_str == NULL) {
-          log_errno("os_realloc: failed to reallocate %d bytes", size);
+          log_errno("os_realloc: failed to reallocate %zd bytes", size);
           os_free(concat_str);
           return NULL;
         } else {

--- a/tests/dhcp/test_dnsmasq.c
+++ b/tests/dhcp/test_dnsmasq.c
@@ -168,7 +168,7 @@ bool get_config_dhcpinfo(char *info, config_dhcpinfo_t *el) {
 
   ssize_t count = split_string_array(info, ',', info_arr);
 
-  log_trace("Number of substrings=%d", count);
+  log_trace("Number of substrings=%zd", count);
 
   if (!utarray_len(info_arr))
     goto err;

--- a/tests/utils/test_eloop_threaded.c
+++ b/tests/utils/test_eloop_threaded.c
@@ -76,7 +76,7 @@ static void send_data_to_sock(void *eloop_ctx, void *user_ctx) {
   struct test_eloop_sock_ctx *eloop_sock_ctx = eloop_ctx;
   struct test_eloop_sock_user_ctx *user_sock_ctx = user_ctx;
 
-  log_debug("Sending %d bytes to fd %d on port %d, contents: %s",
+  log_debug("Sending %zd bytes to fd %d on port %d, contents: %s",
             user_sock_ctx->length, eloop_sock_ctx->client_socket_fd,
             eloop_sock_ctx->serv_address.caddr.addr_in.sin_port,
             user_sock_ctx->data);
@@ -108,7 +108,7 @@ static void eloop_sock_handler_function(int sock, void *eloop_ctx,
                          (struct sockaddr *)&from, &fromlen);
   buf[res] = '\0';
 
-  log_trace("Read %d bytes from buffer, contents %s", res, buf);
+  log_trace("Read %zd bytes from buffer, contents %s", res, buf);
 
   // UTarray doesn't support pushing string arrays, only string pointers
   // because it's some complex C-macros.


### PR DESCRIPTION
Use `"%zd"` to format and/or log `ssize_t` (signed `size_t`) values. `z` is the correct length modifier for an integer of size `size_t`.

This doesn't make much of a difference on 64-bit OSes, but it does cause issues when we cross-compile for 32-bit platforms like OpenWRT.

> 
![image](https://user-images.githubusercontent.com/19716675/223228501-e6a255ed-6e09-4510-b4e4-f2023549fc1a.png)
> Taken from the [format specifiers table on cppreference.com](https://en.cppreference.com/w/c/io/fprintf), used under [CC-BY-SA 3.0](https://en.cppreference.com/w/Cppreference:Copyright/CC-BY-SA)