### PR TITLE
Use `%zu` to format `size_t` values

### DIFF
--- a/src/radius/common.h
+++ b/src/radius/common.h
@@ -267,7 +267,7 @@ static inline void wpa_hexdump_ascii(enum hostap_log_level level,
                                      size_t len) {
   char hex_buf[33];
   printf_hex(hex_buf, sizeof(hex_buf), buf, len, false);
-  log_levels(level, __FILENAME__, __LINE__, "%s - hexdump(len=%lu):%s", title,
+  log_levels(level, __FILENAME__, __LINE__, "%s - hexdump(len=%zu):%s", title,
              len, hex_buf);
 }
 

--- a/src/utils/os.c
+++ b/src/utils/os.c
@@ -327,7 +327,7 @@ char **copy_argv(const char *const argv[]) {
    */
   char **const argv_copy = (char **)malloc(argv_array_size + strings_length);
   if (argv_copy == NULL) {
-    log_errno("Failed to malloc %d bytes", argv_array_size + strings_length);
+    log_errno("Failed to malloc %zu bytes", argv_array_size + strings_length);
     return NULL;
   }
 
@@ -508,7 +508,7 @@ int run_argv_command(const char *path, const char *const argv[],
   const char **full_arg = os_malloc(sizeof(char *) * (full_argc + 1));
 
   if (full_arg == NULL) {
-    log_errno("Failed to malloc %d bytes", sizeof(char *) * (full_argc + 1));
+    log_errno("Failed to malloc %zu bytes", sizeof(char *) * (full_argc + 1));
     return -1;
   }
 
@@ -980,7 +980,7 @@ char *string_array2string(const char *const strings[]) {
 
   char *buf = os_malloc(total_chars);
   if (buf == NULL) {
-    log_errno("os_malloc: Failed to allocate %d bytes of memory", total_chars);
+    log_errno("os_malloc: Failed to allocate %zu bytes of memory", total_chars);
     return NULL;
   }
 

--- a/tests/ap/test_ap_service_failure.c
+++ b/tests/ap/test_ap_service_failure.c
@@ -142,7 +142,7 @@ static void test_denyacl_ap_command(void **state) {
     const DenyaclApCommand function_to_test =
         denyacl_ap_command_functions_to_test[i];
 
-    log_debug("test_denyacl_ap_command: Testing function %d", i);
+    log_debug("test_denyacl_ap_command: Testing function %zu", i);
 
     log_debug("should succeed when writeread_domain_data_str succeeds!");
     will_return_ptr(__wrap_writeread_domain_data_str,


### PR DESCRIPTION
Use `"%zu"` to format/log `size_t` values.
`z` is the correct length modifier for an integer of size `size_t`.

This doesn't make much of a difference on 64-bit OSes, but it does cause issues when we cross-compile for 32-bit platforms like OpenWRT.

> 
![image](https://user-images.githubusercontent.com/19716675/223229129-e11c2084-c361-4586-bdb4-5a569da95f39.png)

> Taken from the [format specifiers table on cppreference.com](https://en.cppreference.com/w/c/io/fprintf), used under [CC-BY-SA 3.0](https://en.cppreference.com/w/Cppreference:Copyright/CC-BY-SA)