### PR TITLE
Fix `unlink()` error message in `cleanup_tmp_domain_socket_path()`

### DIFF
--- a/src/utils/sockctl.c
+++ b/src/utils/sockctl.c
@@ -77,7 +77,7 @@ static const char *create_tmp_domain_socket_path(void) {
  */
 static int cleanup_tmp_domain_socket_path(const char *socket_path) {
   if (unlink(socket_path)) {
-    log_errno("Failed to unlink() %d", socket_path);
+    log_errno("Failed to unlink() %s", socket_path);
     return -1;
   }
   if (strncmp(TMP_UNIX_SOCK_FOLDER_PREFIX, socket_path,


### PR DESCRIPTION
Fix the error message when `unlink()` fails to cleanup the temporary domain socket in `cleanup_tmp_domain_socket_path()`.

We should be using `"%s"` to log a string.