### PR TITLE
Fix logging on 32-bit machines in `edgesec-recap` executable

### DIFF
--- a/src/edgesec-recap.c
+++ b/src/edgesec-recap.c
@@ -429,7 +429,7 @@ int process_pkt_read_state(struct recap_context *pctx) {
 }
 
 int process_file_stream_state(struct recap_context *pctx) {
-  log_trace("Processing file stream %zu bytes", pctx->total_size);
+  log_trace("Processing file stream %" PRIu64 " bytes", pctx->total_size);
 
   switch (pctx->state) {
     case PCAP_FILE_STATE_INIT:


### PR DESCRIPTION
Currently, `process_file_stream_state()` formats a `uint64_t` using `%zu`. This is valid on 64-bit machines, but on 32-bit machines, this value is too small. Instead, `PRIu64` should be used.

`PRIu64` is declared in the [Format macros constants section of standard ISO C`<inttypes.h>`](https://en.cppreference.com/w/c/types/integer).