### PR TITLE
test(eloop): use `PRIu16` to log `in_port_t`

### DIFF
--- a/tests/utils/test_eloop_threaded.c
+++ b/tests/utils/test_eloop_threaded.c
@@ -76,7 +76,7 @@ static void send_data_to_sock(void *eloop_ctx, void *user_ctx) {
   struct test_eloop_sock_ctx *eloop_sock_ctx = eloop_ctx;
   struct test_eloop_sock_user_ctx *user_sock_ctx = user_ctx;
 
-  log_debug("Sending %zd bytes to fd %d on port %d, contents: %s",
+  log_debug("Sending %zd bytes to fd %d on port %" PRIu16 ", contents: %s",
             user_sock_ctx->length, eloop_sock_ctx->client_socket_fd,
             eloop_sock_ctx->serv_address.caddr.addr_in.sin_port,
             user_sock_ctx->data);


### PR DESCRIPTION
According to the POSIX standard, `in_port_t` should always be equivalent to `uint16_t`, see [IEEE Std 1003.1, 2004 (aka POSIX.1-2004), `netinet/in.h`][1].

`PRIu16` is the format macro constant for `uint16_t`, defined in [`<stdint.h>`](stdint.h)

[1]: https://pubs.opengroup.org/onlinepubs/000095399/basedefs/netinet/in.h.html