### PR TITLE
Run `check_if_should_terminate()` immediately to avoid race-conditions in code-coverage

### DIFF
--- a/tests/test_edgesec.c
+++ b/tests/test_edgesec.c
@@ -297,16 +297,14 @@ static int setup_edgesec_test(void **state) {
   assert_non_null(ctx->ap_server.eloop);
   assert_non_null(ctx->supervisor.eloop);
 
-  assert_return_code(edge_eloop_register_timeout(ctx->ap_server.eloop, 0, 10000,
-                                                 check_if_should_terminate,
-                                                 ctx->ap_server.eloop,
-                                                 &(ctx->ap_server.should_die)),
+  assert_return_code(edge_eloop_register_timeout(
+                         ctx->ap_server.eloop, 0, 0, check_if_should_terminate,
+                         ctx->ap_server.eloop, &(ctx->ap_server.should_die)),
                      0);
 
   assert_return_code(edge_eloop_register_timeout(
-                         ctx->supervisor.eloop, 0, 10000,
-                         check_if_should_terminate, ctx->ap_server.eloop,
-                         &(ctx->supervisor.should_die)),
+                         ctx->supervisor.eloop, 0, 0, check_if_should_terminate,
+                         ctx->ap_server.eloop, &(ctx->supervisor.should_die)),
                      0);
 
   *state = ctx;


### PR DESCRIPTION
Currently, `check_if_should_terminate()` runs 10ms after being registered for the first time.
 
In rare-cases, this is long enough that all the test-code is already done, and therefore `check_if_should_terminate()` quits the thread without ever registering another `check_if_should_terminate()` timeout.

This causes issues with code-coverage, as it means that the following branch sometimes never runs:

https://github.com/nqminds/edgesec/blob/e0acb2cacc426fc2993f0fa314e1c3a3f1a4ea16/tests/test_edgesec.c#L269-L270

See the below code-coverage result:

> ![image](https://user-images.githubusercontent.com/19716675/223388578-f1dc9c55-a6ce-40c2-b8c4-5a6bc3e2790a.png)
> 
> Code-coverage result, screenshot taken from https://app.codecov.io/gh/nqminds/edgesec/pull/493/blob/tests/test_edgesec.c#L270.
> Please note that half of the line is covered. This is because it ran on GCC, but didn't run on LLVM/Clang.

I've changed the initial timeout for `check_if_should_terminate()` to 0ms (aka run ASAP). That way it should immediately then register a rerun in 10ms, so that the rerun code is always covered and run.

---

Side-note, using the `eloop_*()` family of functions makes me nostalgic for using the JavaScript event-loop, with functions like [`setTimeout()`](https://developer.mozilla.org/en-US/docs/Web/API/setTimeout) :smile: 