### PR TITLE
Fix incorrect format specifier for an `int` in `process_get_bridges_cmd()`

### DIFF
--- a/src/supervisor/cmd_processor.c
+++ b/src/supervisor/cmd_processor.c
@@ -522,7 +522,7 @@ ssize_t process_get_bridges_cmd(int sock,
     {
       char *reallocated_reply_buf = os_realloc(reply_buf, total);
       if (reallocated_reply_buf == NULL) {
-        log_errno("realloc: failed to allocate %s bytes", total);
+        log_errno("realloc: failed to allocate %d bytes", total);
         free(reply_buf);
         utarray_free(tuple_list_arr);
         return -1;


### PR DESCRIPTION
We're using `%s` to format an `int`, which is incorrect.

Fixes: b04ad88be46b67a335fd2f78ad34eec6e75a373f

---

Yep, I made this bug yesterday in PR https://github.com/nqminds/edgesec/pull/477 :facepalm:

In my defence, the `s` and `d` keys on my keyboard are quite close together.