### PR TITLE
Use `%d` to log `int` value in `radius_server_receive_auth()` (fix for 32-bit OSes)

### DIFF
--- a/src/radius/radius_server.c
+++ b/src/radius/radius_server.c
@@ -652,7 +652,7 @@ static void radius_server_receive_auth(int sock, void *eloop_ctx,
 
   client = radius_server_get_client(data, &from.sin.sin_addr);
 
-  log_trace("Received data with length %ld", len);
+  log_trace("Received data with length %d", len);
 
   if (client == NULL) {
     log_trace("Unknown client %s - packet ignored", abuf);


### PR DESCRIPTION
Currently, we're using `"%ld"` to log an `int` value instead of the correct `"%d"` format specifier.

On 64-bit OSes, this makes no difference, but on 32-bit OSes, `long int` and `int` have different sizes.