### PR TITLE
Use `%lu` to log `unsigned long` value in `edge_eloop_register_timeout()`

### DIFF
--- a/lib/eloop/patches/0003-Bump-timeout-parameters-from-int-to-long.patch
+++ b/lib/eloop/patches/0003-Bump-timeout-parameters-from-int-to-long.patch
@@ -1,4 +1,4 @@
-From 2987c02110ef3c80d05944c894ef81985f36aa00 Mon Sep 17 00:00:00 2001
+From 179c491f0b761207edd2b72870792af3fee55350 Mon Sep 17 00:00:00 2001
 From: Alois Klink <alois@nquiringminds.com>
 Date: Tue, 6 Sep 2022 18:34:47 +0100
 Subject: [PATCH 3/5] Bump timeout parameters from int to long
@@ -10,12 +10,12 @@ I'm guessing that on some platforms, the max int value is only
 Taken from commit
 https://github.com/nqminds/edgesec/commit/00d465d8705fa439b52a513541dc03c1f4231e4d
 ---
- src/utils/eloop.c |  6 +++---
+ src/utils/eloop.c |  8 ++++----
  src/utils/eloop.h | 12 ++++++------
- 2 files changed, 9 insertions(+), 9 deletions(-)
+ 2 files changed, 10 insertions(+), 10 deletions(-)
 
 diff --git a/src/utils/eloop.c b/src/utils/eloop.c
-index 4035a9af3..d1affd29f 100644
+index 4035a9af3..ab5cc07b0 100644
 --- a/src/utils/eloop.c
 +++ b/src/utils/eloop.c
 @@ -694,7 +694,7 @@ void eloop_unregister_sock(struct eloop_data *eloop, int sock, eloop_event_type
@@ -27,6 +27,15 @@ index 4035a9af3..d1affd29f 100644
  			   eloop_timeout_handler handler,
  			   void *eloop_data, void *user_data)
  {
+@@ -748,7 +748,7 @@ overflow:
+ 	 * to be infinite, i.e., the timeout would never happen.
+ 	 */
+ 	log_debug(
+-		   "ELOOP: Too long timeout (secs=%u usecs=%u) to ever happen - ignore it",
++		   "ELOOP: Too long timeout (secs=%lu usecs=%lu) to ever happen - ignore it",
+ 		   secs,usecs);
+ 	os_free(timeout);
+ 	return 0;
 @@ -843,7 +843,7 @@ int eloop_is_timeout_registered(struct eloop_data *eloop, eloop_timeout_handler
  }
  

--- a/lib/eloop/patches/0004-list-add-missing-include-on-stdddef.h.patch
+++ b/lib/eloop/patches/0004-list-add-missing-include-on-stdddef.h.patch
@@ -1,4 +1,4 @@
-From 203dddf79ec58094eff4b2e3c20f6b86999722fc Mon Sep 17 00:00:00 2001
+From e6f1ab0e7e4ab759f3f467228dd4a93ba3becd7d Mon Sep 17 00:00:00 2001
 From: Alois Klink <alois@nquiringminds.com>
 Date: Fri, 11 Nov 2022 14:59:44 +0000
 Subject: [PATCH 4/5] list: add missing include on <stdddef.h>

--- a/lib/eloop/patches/0005-eloop-add-edge_-prefix-to-all-external-funcs.patch
+++ b/lib/eloop/patches/0005-eloop-add-edge_-prefix-to-all-external-funcs.patch
@@ -1,4 +1,4 @@
-From 4f93b015d84cb583f4dcfbe683598c25341172bb Mon Sep 17 00:00:00 2001
+From d66155457f83f29fc34ae3d0d396b892d83b58b6 Mon Sep 17 00:00:00 2001
 From: Alois Klink <alois@nquiringminds.com>
 Date: Fri, 27 Jan 2023 10:57:15 +0000
 Subject: [PATCH 5/5] eloop: add `edge_` prefix to all external funcs
@@ -20,7 +20,7 @@ adding our own custom prefix to every externally linked function.
  2 files changed, 154 insertions(+), 120 deletions(-)
 
 diff --git a/src/utils/eloop.c b/src/utils/eloop.c
-index d1affd29f..61c65514e 100644
+index ab5cc07b0..fd7c4b3a2 100644
 --- a/src/utils/eloop.c
 +++ b/src/utils/eloop.c
 @@ -64,7 +64,7 @@ static void eloop_trace_sock_remove_ref(struct eloop_sock_table *table)


### PR DESCRIPTION
We need to be using `"%lu"` instead of `"%u"` in the `eloop_register_timeout()` log message, since we changed the `eloop_register_timeout()` function to take a `unsigned long` instead of just a plain `unsigned int`.

Please note that the patch file calls the function `eloop_register_timeout ()` instead of `edge_eloop_register_timeout()`, because it's only renamed in [a later patch](https://github.com/nqminds/edgesec/blob/674b1feb9e4eb845405fccd53386466ed938136c/lib/eloop/patches/0005-eloop-add-edge_-prefix-to-all-external-funcs.patch)

---

@mereacre, if you want to view the updated patch/commit in GitHub's UI, here's a link: https://github.com/nqminds/hostap/commit/179c491f0b761207edd2b72870792af3fee55350
