### PR TITLE
Mark `log_*()` functions with `__attribute__((format))` for improved compiler warnings

### DIFF
--- a/src/utils/log.h
+++ b/src/utils/log.h
@@ -85,12 +85,16 @@ void log_set_meta(bool enable);
 int log_open_file(char *path);
 void log_close_file(void);
 
+PRINTF_FORMAT(4, 5)
 void log_levels(uint8_t level, const char *file, uint32_t line,
                 const char *format, ...);
+PRINTF_FORMAT(4, 5)
 void log_errno_error(uint8_t level, const char *file, uint32_t line,
                      const char *format, ...);
+PRINTF_FORMAT(4, 5)
 void log_error_exit(uint8_t level, const char *file, uint32_t line,
                     const char *format, ...);
+PRINTF_FORMAT(4, 5)
 void log_error_exit_proc(uint8_t level, const char *file, uint32_t line,
                          const char *format, ...);
 

--- a/src/utils/log.h
+++ b/src/utils/log.h
@@ -34,6 +34,13 @@ enum { LOGC_TRACE, LOGC_DEBUG, LOGC_INFO, LOGC_WARN, LOGC_ERROR };
   { "\x1b[94m", "\x1b[36m", "\x1b[32m", "\x1b[33m", "\x1b[31m" }
 
 #ifdef __GNUC__
+/**
+ * @brief Specifies that the given function is a wrapper around `printf()`.
+ * @param a The argument of the format specifier (1st argument is 1)
+ * @param b The first arg of the variable argument list.
+ * (aka the number of the `...` arg).
+ * @see https://clang.llvm.org/docs/AttributeReference.html#format
+ */
 #define PRINTF_FORMAT(a, b) __attribute__((format(printf, (a), (b))))
 #else
 #define PRINTF_FORMAT(a, b)

--- a/src/utils/log.h
+++ b/src/utils/log.h
@@ -33,7 +33,8 @@ enum { LOGC_TRACE, LOGC_DEBUG, LOGC_INFO, LOGC_WARN, LOGC_ERROR };
 #define LEVEL_COLORS                                                           \
   { "\x1b[94m", "\x1b[36m", "\x1b[32m", "\x1b[33m", "\x1b[31m" }
 
-#ifdef __GNUC__
+#if defined __has_attribute
+#if __has_attribute(format)
 /**
  * @brief Specifies that the given function is a wrapper around `printf()`.
  * @param a The argument of the format specifier (1st argument is 1)
@@ -44,7 +45,10 @@ enum { LOGC_TRACE, LOGC_DEBUG, LOGC_INFO, LOGC_WARN, LOGC_ERROR };
 #define PRINTF_FORMAT(a, b) __attribute__((format(printf, (a), (b))))
 #else
 #define PRINTF_FORMAT(a, b)
-#endif
+#endif /* __has_attribute(format) */
+#else
+#define PRINTF_FORMAT(a, b)
+#endif /* defined __has_attribute */
 
 static inline int snprintf_error(size_t size, int res) {
   return res < 0 || (unsigned int)res >= size;


### PR DESCRIPTION
In `src/utils/log.h`, there is a currently unused macro (since https://github.com/nqminds/edgesec/commit/2a18535cb57f7059dba72eb50490bda587291fe8) called `PRINTF_FORMAT` that can be used to tell compilers that a given function passes arguments to `printf`.

https://github.com/nqminds/edgesec/blob/8cd691957f4b727f81d08a0e452caf22102de317/src/utils/log.h#L40-L44

This syntax is `__attribute__((format(printf, (a), (b))))`, and is supported by GCC and Clang. [^1]

See https://clang.llvm.org/docs/AttributeReference.html#format

This PR adds documentation to the macro, adds support for this macro to Clang, and then marks all the `log_*` functions in `src/utils/log.h` with the macro.

[^1]: `__attribute((format` is even supported by the [ARM compiler][1] and [IBM C/C++ compiler][2].

[1]: https://developer.arm.com/documentation/dui0375/g/Compiler-specific-Features/--attribute----format---function-attribute
[2]: https://www.ibm.com/docs/en/xl-c-and-cpp-aix/16.1?topic=attributes-format

The compiler errors that were generated led to me finding the following bugs:
  - #486
  - #487 
  - #488
  - #489 
  - #490 
  - #491 
  - #492 
  - #493 
  - #494 
  - #496 
  - #497 
  - #498 
  - #499 
  - #500




