### PR TITLE
Add the `PRINTF_FORMAT` attribute to more functions for improved compiler warnings

### DIFF
--- a/src/edgesec-recap.c
+++ b/src/edgesec-recap.c
@@ -111,7 +111,7 @@ void show_app_help(char *app_name) {
 
 /* Diagnose an error in command-line arguments and
    terminate the process */
-void log_cmdline_error(const char *format, ...) {
+PRINTF_FORMAT(1, 2) void log_cmdline_error(const char *format, ...) {
   va_list argList;
 
   fflush(stdout); /* Flush any pending stdout */

--- a/src/edgesec.c
+++ b/src/edgesec.c
@@ -94,7 +94,7 @@ void show_app_help(char *app_name) {
 
 /* Diagnose an error in command-line arguments and
    terminate the process */
-void log_cmdline_error(const char *format, ...) {
+PRINTF_FORMAT(1, 2) void log_cmdline_error(const char *format, ...) {
   va_list argList;
 
   fflush(stdout); /* Flush any pending stdout */

--- a/src/supervisor/subscriber_events.h
+++ b/src/supervisor/subscriber_events.h
@@ -43,9 +43,11 @@ int add_events_subscriber(struct supervisor_context *context,
  *
  * @param context The supervisor context
  * @param type The event type
- * @param format The event text
+ * @param format The event format text, passed to vsnprintf()
+ * @param ... The event format variables, passed to vsnprintf()
  * @return 0 on success, -1 on failure
  */
+PRINTF_FORMAT(3, 4)
 int send_events_subscriber(struct supervisor_context *context,
                            enum SUBSCRIBER_EVENT type, const char *format, ...);
 #endif


### PR DESCRIPTION
Mark more functions with `PRINTF_FORMAT`, so that the compiler knows it takes a format string as an input, and warns us if we use an invalid format string.

As discussed in https://github.com/nqminds/edgesec/pull/501#issuecomment-1458144372