### PR TITLE
docs(sockctl): fix typo in comment

### DIFF
--- a/src/utils/sockctl.c
+++ b/src/utils/sockctl.c
@@ -87,7 +87,7 @@ static int cleanup_tmp_domain_socket_path(const char *socket_path) {
   }
 
   // need to make a non-const copy of path since dirname() may change
-  // stirng contents
+  // string contents
   char path[PATH_MAX];
   path[PATH_MAX - 1] = '\0'; // ensure string is always NUL terminated
   strncpy(path, socket_path, PATH_MAX - 1);


### PR DESCRIPTION
Considering I made this commit on a Monday, I'm going to assume it was because I was using the weak keyboard in the office, instead of a super nice mechanical keyboard from home. :smile:

I wonder if it's worth enabling something like [codespell](https://github.com/codespell-project/codespell). It easily integrates with `pre-commit, so it should be pretty easy to run. The only issue is fixing all the false positives.