### PR TITLE
Remove dependency on C++

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -5,7 +5,7 @@ project(EDGESEC
   VERSION 0.1.0
   HOMEPAGE_URL "https://github.com/nqminds/edgesec"
   DESCRIPTION "Secure router - reference implementation"
-  LANGUAGES C CXX
+  LANGUAGES C
 )
 # CMake proposal for semver https://gitlab.kitware.com/cmake/cmake/-/issues/23649
 set(PROJECT_VERSION_PRERELEASE alpha.0)
@@ -178,11 +178,6 @@ add_compile_options(
   $<$<COMPILE_LANGUAGE:C>:-Wall>
   $<$<COMPILE_LANGUAGE:C>:-Wextra>
 )
-
-set(CMAKE_CXX_STANDARD 11)
-set(CMAKE_CXX_STANDARD_REQUIRED ON)
-# use -std=c++11 rather than -std=gnu++11
-set(CMAKE_CXX_EXTENSIONS OFF)
 
 # sqlhook is a shared library that links to static libs, so -fPIC is needed
 # todo: enable only for sqlhook dependencies

--- a/lib/openssl.cmake
+++ b/lib/openssl.cmake
@@ -61,7 +61,8 @@ if (USE_CRYPTO_SERVICE)
       DOWNLOAD_DIR "${EP_DOWNLOAD_DIR}" # if empty string, uses default download dir
       INSTALL_DIR "${LIBOPENSSL_INSTALL_DIR}"
       CONFIGURE_COMMAND
-        ${CMAKE_COMMAND} -E env "PATH=$ENV{PATH}" "CC=${CMAKE_C_COMPILER}" "CXX=${CMAKE_CXX_COMPILER}"
+        ${CMAKE_COMMAND} -E env "PATH=$ENV{PATH}" "CC=${CMAKE_C_COMPILER}"
+          "CXX=no-cxx-compiler" # explicitly disable CXX compiler, since OpenSSL doesn't need it
         <SOURCE_DIR>/Configure ${OpenSSL_Configure_Args}
       LIST_SEPARATOR " " # expand ${OpenSSL_Configure_Args} to space-separated list
       # only install software, don't install or build docs


### PR DESCRIPTION
EDGESec only uses C code, so we don't need to get CMake to search for a C++ compiler [^1].

See https://askubuntu.com/a/1211755

OpenSSL still expects a CXX value, but it's not used for the OpenSSL build we compile, so we can just set it to an executable that does not exists. This is so we do start to use C++ in OpenSSL (e.g. due to a future OpenSSL update), we should instantly get an error.

[^1]: This occasionally causes issues with Clang, since `clang++` fails to compile a test program due to a missing `libstdc++`, because even though I have `g++-11` installed (and therefore `libstdc++-11-dev`), Clang sees that I have `gcc-12` installed, and incorrectly assumes that means I have `g++-12` (and GNU's `libstdc++-12-dev`) installed.
