### PR TITLE
build(libnetlink): remove C++ requirement

### DIFF
--- a/lib/libnetlink/CMakeLists.txt
+++ b/lib/libnetlink/CMakeLists.txt
@@ -1,6 +1,8 @@
 # at least v3.13 is required for install(x) where x is from add_subdirectory()
 cmake_minimum_required(VERSION 3.13)
-project(LIBNETLINK)
+project(LIBNETLINK
+  LANGUAGES C
+)
 
 list(APPEND CMAKE_MODULE_PATH "${CMAKE_CURRENT_SOURCE_DIR}/../../CMakeModules")
 


### PR DESCRIPTION
By default, when we call `project()` without any `LANGUAGES` in libnetlink's `CMakeLists.txt` file, CMake defaults to `C` and `C++`, see https://cmake.org/cmake/help/latest/command/enable_language.html

Since libnetlink only uses C code, we should explicitly say that it only uses C, so that we can remove it's dependency on C++.