### PR TITLE
fix(os): fix `edge_os_get_reltime()`

### DIFF
--- a/src/utils/CMakeLists.txt
+++ b/src/utils/CMakeLists.txt
@@ -21,7 +21,7 @@ target_link_libraries(hashmap PUBLIC LibUTHash::LibUTHash PRIVATE log)
 
 add_library(os os.c)
 set_target_properties(os PROPERTIES
-  C_EXTENSIONS ON # requires BSD gettimeofday
+  C_EXTENSIONS ON # requires BSD gettimeofday and POSIX clock_gettime
   POSITION_INDEPENDENT_CODE ON
 )
 target_link_libraries(os PUBLIC LibUTHash::LibUTHash PRIVATE hashmap allocs log LibUUID::LibUUID)

--- a/src/utils/os.c
+++ b/src/utils/os.c
@@ -155,11 +155,21 @@ int edge_os_get_time(struct os_time *t) {
 }
 
 int edge_os_get_reltime(struct os_reltime *t) {
-  int res;
-  struct timeval tv;
-  res = gettimeofday(&tv, NULL);
-  t->sec = tv.tv_sec;
-  t->usec = tv.tv_usec;
+  struct timespec current_time = {0};
+
+#ifdef CLOCK_MONOTONIC
+  // should be supported in both Linux and FreeBSD
+  clockid_t clock = CLOCK_MONOTONIC;
+#else
+  // should be supported in any POSIX system
+  clockid_t clock = CLOCK_REALTIME;
+#endif
+  int res = clock_gettime(clock, &current_time);
+
+  // may be 0 if clock_gettime failed
+  t->sec = current_time.tv_sec;
+  t->usec = current_time.tv_nsec / 1000;
+
   return res;
 }
 

--- a/src/utils/os.h
+++ b/src/utils/os.h
@@ -114,9 +114,10 @@ int become_daemon(int flags);
 #define os_get_time(t) edge_os_get_time(t)
 
 /**
- * @brief Get current time (sec, usec)
+ * @brief Get current time (sec, usec) in seconds since UNIX epoch.
  *
- * @param t Pointer to buffer for the time
+ * @param[out] t Pointer to buffer for the time
+ * If there is a failure, may write invalid data.
  * @return int 0 on success, -1 on failure
  */
 int edge_os_get_time(struct os_time *t);
@@ -124,7 +125,11 @@ int edge_os_get_time(struct os_time *t);
 /**
  * @brief Get relative time (sec, usec)
  *
- * @param t Pointer to buffer for the time
+ * Unlike edge_os_get_time(), the time from this function will never go
+ * backwards (e.g. due to NTP).
+ *
+ * @param[out] t Pointer to buffer for the time.
+ * If there is a failure, may write invalid data.
  * @return int 0 on success, -1 on failure
  */
 int edge_os_get_reltime(struct os_reltime *t);

--- a/tests/utils/CMakeLists.txt
+++ b/tests/utils/CMakeLists.txt
@@ -29,7 +29,7 @@ add_cmocka_test(test_net
 
 add_cmocka_test(test_os
   SOURCES test_os.c
-  LINK_LIBRARIES tmpdir os allocs hashmap cmocka::cmocka)
+  LINK_LIBRARIES tmpdir os allocs attributes hashmap cmocka::cmocka)
 
 add_cmocka_test(test_eloop
   SOURCES test_eloop.c


### PR DESCRIPTION
Fix `edge_os_get_reltime()` so that it correctly gets the relative time.

It does this by using the [POSIX `CLOCK_MONOTONIC`][1], which defines a monotonic clock that never goes backwards.

Because `CLOCK_MONOTONIC` is not supported on all POSIX platforms, as backup we can use `CLOCK_REALTIME`, which is the same behavior as edge_os_get_time() (aka the old behavior).

[1]: https://pubs.opengroup.org/onlinepubs/000095399/functions/clock_getres.html

Fixes https://github.com/nqminds/edgesec/issues/408