### PR TITLE
test(runctl): fix radius_server_data heap overflow

### DIFF
--- a/tests/test_runctl.c
+++ b/tests/test_runctl.c
@@ -211,7 +211,7 @@ static void test_run_engine(void **state) {
 #endif
 #ifdef WITH_RADIUS_SERVICE
   struct radius_server_data *radius_srv =
-      os_zalloc(sizeof(struct radius_server_data *));
+      os_zalloc(sizeof(struct radius_server_data));
 #endif
 
   struct fwctx *fw_ctx = os_zalloc(sizeof(struct fwctx));


### PR DESCRIPTION
Fix a heap overflow error in `test_run_engine()`, when we weren't allocating enough bytes for a `struct radius_server_data`.

---

We may want to consider adding `__attribute__((alloc_size (1))` to the `os_zalloc()` function to tell the compiler that it returns the number of bytes given by the `size` parameter.

I think compilers/static analysers should hopefully warn us then about [CWE-131: Incorrect Calculation of Buffer Size](https://cwe.mitre.org/data/definitions/131.html).

For example, GCC has `-Wanalyzer-allocation-size` that would warn us.