### PR TITLE
test(supervisor): fix  `get_mac_conn_cmd()` mem leak

### DIFF
--- a/tests/supervisor/test_supervisor.c
+++ b/tests/supervisor/test_supervisor.c
@@ -89,6 +89,7 @@ static void test_get_mac_conn_cmd(void **state) {
   struct mac_conn_info info2 = get_mac_conn_cmd(conn.mac_addr, (void *)&ctx);
   assert_int_equal(info2.vlanid, -1);
 
+  free_sqlite_macconn_db(ctx.macconn_db);
   utarray_free(ctx.config_ifinfo_array);
   free(ctx.crypt_ctx); // only needed if WITH_CRYPTO_SERVICE
 }


### PR DESCRIPTION
Fix a memory leak in `test_get_mac_conn_cmd()`.

`open_sqlite_macconn_db()` was run to create `ctx.macconn_db`, but it was never cleaned up.

https://github.com/nqminds/edgesec/blob/85ae0cfb19dd1d545dd917a473b42459e5c4b5cf/tests/supervisor/test_supervisor.c#L59