### PR TITLE
fix(sqliteu): fix memory leak in `check_table_exists()`

### DIFF
--- a/src/utils/sqliteu.c
+++ b/src/utils/sqliteu.c
@@ -39,6 +39,7 @@ int check_table_exists(sqlite3 *db, const char *table_name) {
 
   if (sqlite3_bind_text(res, 1, table_name, -1, SQLITE_STATIC) != SQLITE_OK) {
     log_trace("Binding params failed due to %s", sqlite3_errmsg(db));
+    sqlite3_finalize(res);
     return -1;
   }
 


### PR DESCRIPTION
We were not finalizing the `res` variable form `sqlite3_prepare_v2()` when `sqlite3_bind_text()` failed.