### PR TITLE
test(edgesec): fix `test_edgesec()` config memory leak

### DIFF
--- a/src/config.h
+++ b/src/config.h
@@ -28,6 +28,8 @@
  * @brief The App configuration structures. Used for configuring the networking
  * services.
  *
+ * This is normally initialised with load_app_config() and cleaned with
+ * free_app_config().
  */
 struct app_config {
   UT_array *
@@ -83,7 +85,8 @@ struct app_config {
  * @brief Load the app configuration
  *
  * @param filename The app configuration file
- * @param config The configuration structure
+ * @param[in, out] config The configuration structure to store config in.
+ * Must be cleaned up with free_app_config().
  * @return 0 on success, -1 otherwise
  */
 int load_app_config(const char *filename, struct app_config *config);

--- a/tests/test_edgesec.c
+++ b/tests/test_edgesec.c
@@ -365,6 +365,8 @@ static void test_edgesec(void **state) {
   ctx->supervisor.cleanup_thread = true;
 
   assert_int_equal(run_ctl(&config, ctx->supervisor.eloop), 0);
+
+  free_app_config(&config);
 }
 
 /**


### PR DESCRIPTION
Some of the values in `config` were allocated on the heap by `load_app_config()`:

https://github.com/nqminds/edgesec/blob/cbd6701393d7cd5ff3b134fb46056f206e2704b9/tests/test_edgesec.c#L350

Because of that, we must call `free_app_config()` to deallocate this variables.

---

Should we document this in the `load_app_config()` documentation?

https://github.com/nqminds/edgesec/blob/429d6179ec00553fe1959c105fb6dcb9a3ea4018/src/config.h#L86