### PR TITLE
fix(config): fix `load_radius_conf()` memory leak

### DIFF
--- a/src/config.c
+++ b/src/config.c
@@ -231,7 +231,6 @@ bool load_radius_conf(const char *filename, struct app_config *config) {
   config->rconfig.radius_port = (int)ini_getl("radius", "port", 1812, filename);
 
   // Load radius client ip
-  value = os_malloc(INI_BUFFERSIZE);
   ini_gets("radius", "clientIP", "127.0.0.1", value, INI_BUFFERSIZE, filename);
 
   os_strlcpy(config->rconfig.radius_client_ip, value, OS_INET_ADDRSTRLEN);


### PR DESCRIPTION
The `value` pointer was already allocated at the beginning of the function at https://github.com/nqminds/edgesec/blob/6a0508ec7967b92fba133453e0ec496fadf1ccae/src/config.c#L228

---

We're doing a lot of `free(value);` and `value = malloc(...);`. We should probably refactor this function to avoid all of these duplicate calls, since calling `malloc()` is expensive.