### PR TITLE
Make functions and variables in `edgesec.c` `static`

### DIFF
--- a/src/edgesec.c
+++ b/src/edgesec.c
@@ -146,8 +146,6 @@ void process_app_options(int argc, char *argv[], uint8_t *verbosity,
   }
 }
 
-char *get_app_name(char *app_path) { return basename(app_path); }
-
 int main(int argc, char *argv[]) {
   bool daemon = false;
   uint8_t verbosity = 0;

--- a/src/edgesec.c
+++ b/src/edgesec.c
@@ -50,9 +50,9 @@ const char description_string[] =
     "     credentials/MAC address.\n"
     "  6. State machine: Networking monitoring and management.\n";
 
-pthread_mutex_t log_lock;
+static pthread_mutex_t log_lock;
 
-void log_lock_fun(bool lock) {
+static void log_lock_fun(bool lock) {
   if (lock) {
     pthread_mutex_lock(&log_lock);
   } else {
@@ -60,11 +60,11 @@ void log_lock_fun(bool lock) {
   }
 }
 
-void show_app_version(void) {
+static void show_app_version(void) {
   fprintf(stdout, "edgesec app version %s\n", EDGESEC_VERSION);
 }
 
-void show_app_help(char *app_name) {
+static void show_app_help(char *app_name) {
   show_app_version();
   fprintf(stdout, "Usage:\n");
   fprintf(stdout, USAGE_STRING, basename(app_name));
@@ -83,7 +83,7 @@ void show_app_help(char *app_name) {
 
 /* Diagnose an error in command-line arguments and
    terminate the process */
-PRINTF_FORMAT(1, 2) void log_cmdline_error(const char *format, ...) {
+PRINTF_FORMAT(1, 2) static void log_cmdline_error(const char *format, ...) {
   va_list argList;
 
   fflush(stdout); /* Flush any pending stdout */
@@ -97,9 +97,9 @@ PRINTF_FORMAT(1, 2) void log_cmdline_error(const char *format, ...) {
   exit(EXIT_FAILURE);
 }
 
-void process_app_options(int argc, char *argv[], uint8_t *verbosity,
-                         bool *daemon, char **config_filename,
-                         char **log_filename) {
+static void process_app_options(int argc, char *argv[], uint8_t *verbosity,
+                                bool *daemon, char **config_filename,
+                                char **log_filename) {
   int opt;
 
   while ((opt = getopt(argc, argv, OPT_STRING)) != -1) {

--- a/src/edgesec.c
+++ b/src/edgesec.c
@@ -60,17 +60,6 @@ void log_lock_fun(bool lock) {
   }
 }
 
-void sighup_handler(int sig, void *ctx) {
-  (void)sig;
-
-  char *log_filename = (char *)ctx;
-
-  if (log_filename != NULL) {
-    log_close_file();
-    log_open_file(log_filename);
-  }
-}
-
 void show_app_version(void) {
   fprintf(stdout, "edgesec app version %s\n", EDGESEC_VERSION);
 }


### PR DESCRIPTION
Make all functions in `edgesec.c` `static` (and file-scoped variables), since they are never used outside of this file.

The CHERI LLVM compiler is currently throwing an error when compiling edgesec for CHERI RISCV-purecap (probably due to a compiler/linker bug). It seems to be some sort of linker error due to the `log_lock_fun` function.

By making the `log_lock_fun` `static` (i.e. giving it internal linkage), this should hopefully mean that the linker never has to look at the function, so it should avoid this issue.

I've also removed the `get_app_name()` and `sighup_handler()` functions from `edgesec.c`, since they're no longer used (and making them `static` throws an unused function error).