### PR TITLE
test(eloop): fix `test_edge_eloop_destroy` params

### DIFF
--- a/tests/utils/test_eloop_threaded.c
+++ b/tests/utils/test_eloop_threaded.c
@@ -292,7 +292,9 @@ static void test_eloop_sock(void **state) {
  */
 extern void eloop_destroy(struct eloop_data *eloop);
 
-static void test_edge_eloop_destroy() {
+static void test_edge_eloop_destroy(void **state) {
+  (void)state; /* unused */
+
   // test coverage changes if `now.usec == 0`
   // rerunning the tests after 1 microsecond should fix this issue
   for (int i = 0; i < 2; i++) {


### PR DESCRIPTION
`test_edge_eloop_destroy()` must have a `void **` parameter.

Weirdly enough, both GCC/Clang don't seem to warn us about this error. However, the CHERI Clang compiler did warn us, but it was with a CHERI specific warning:

```
[113/271] Building C object tests/utils/CMakeFiles/test_eloop_threaded.dir/test_eloop_threaded.c.o
/home/ubuntu/edgesec/tests/utils/test_eloop_threaded.c:330:24: warning: converting function type without prototype 'void ()' to function pointer 'CMUnitTestFunction' (aka 'void (*)(void **)') may cause incorrect parameters to be passed at run time [-Wcheri-prototypes-strict]
      cmocka_unit_test(test_edge_eloop_destroy),
                       ^
/home/ubuntu/edgesec/tests/utils/test_eloop_threaded.c:330:24: note: Calling functions without prototypes is dangerous because on some architectures (e.g. pure-capability MIPS) integer and pointer arguments are passed in different registers. If the call includes a parameter that does not match the function definition, the function will read uninitialized values from the argument registers.
/home/ubuntu/edgesec/tests/utils/test_eloop_threaded.c:295:1: note: 'test_edge_eloop_destroy' declared here
static void test_edge_eloop_destroy() {
^
1 warning generated.
```

We might need to enable `-Wstrict-prototypes` or some other warnings for our test code.

Fixes: 9c1834162ca32f2ef280665ee5ed03bfacd6e637