### PR TITLE
ci(cirrus): improve how failing tests are checked

### DIFF
--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -26,23 +26,48 @@ task:
     # list of tests that are currently failing on FreeBSD
     FAILING_TESTS: test_edgesec test_dnsmasq test_mdns_service
   test_script: |
-    exclude_regex=""
-    for failing_test in $FAILING_TESTS; do
-      exclude_regex="${exclude_regex}|(${failing_test})"
-    done
-    exclude_regex="${exclude_regex:1}" # remove first | in string
-
-    ctest --preset freebsd --output-on-failure --exclude-regex "$exclude_regex"
-  test_failing_tests_script: |
+    ctest --preset freebsd --output-on-failure --output-junit junit-test-results.xml \
+    || true # We look at junit XML output file for failures
+  check_failing_tests_script: |
     # double-check that failing tests actually fail
-    # if they don't fail, then we should be testing them normally
-    for failing_test in $FAILING_TESTS; do
-      if ctest --preset freebsd --output-on-failure --tests-regex "$failing_test"; then
-        >&2 echo "Expected test $failing_test to fail but it passed! Please update .cirrus.yml if this test now works."
-        exit 1
-      fi
-    done
+    python -c "$CHECK_FAILING_TESTS" ./build/freebsd/junit-test-results.xml
   # test_with_coverage_script: |
   #   cmake --build --preset freebsd --parallel "$(($(sysctl -n hw.ncpu) + 1))" --target coverage
   # uploading coverage is currently a bit difficult
   # since the codecoverage uploader doesn't yet support FreeBSD
+
+environment:
+  # Script that loads a JUnit XML file generated from CTest,
+  # (generated via `ctest --output-junit <file>`)
+  # then checks to see if the list of failing tests is exactly the same as the
+  # space separated list of tests in the `FAILING_TEST` environment variable.
+  #
+  # Example:
+  #   FAILING_TESTS='test_a test_b' python3 -c "$CHECK_FAILING_TESTS" junit-test-results.xml
+  CHECK_FAILING_TESTS: |
+    #!/usr/bin/env python3
+    import os
+
+    expected_failing_tests=set(
+      os.getenv("FAILING_TESTS").split(" ")
+    )
+
+    import sys
+    import xml.etree.ElementTree as ET
+
+    tree = ET.parse(sys.argv[1])
+    root = tree.getroot()
+    failing_tests = {
+      testcase.get("name")
+      for testcase in root.findall('testcase')
+      if testcase.get("status") == "fail"
+    }
+
+    import unittest
+    unittest.TestCase().assertSetEqual(
+      expected_failing_tests,
+      failing_tests,
+      "❌ CTest failing tests do not match expected edgesec failing tests."
+    )
+
+    print("✅ CTest failing tests match expected edgesec failing tests.")


### PR DESCRIPTION
### Background

Currently, a bunch of the edgesec tests fail on FreeBSD. Because of that, we have a `FAILING_TESTS` of tests that we expect to fail when running Cirrus CI:

https://github.com/nqminds/edgesec/blob/8e2f61a9287e16998998ab91fd0e4a9d983cccc2/.cirrus.yml#L25-L27

This is so:
  1. CI throws an error if any test fails that isn't listed in `FAILING_TESTS`
  2. CI throws an error if any test succeeds and it is listed in `FAILING_TESTS`

### Reason for change

Our current implementation uses some complicated regex and runs ctest multiples times.

However, we want to add a [`cheribuild`](https://github.com/CTSRD-CHERI/cheribuild) action to CI, and they don't support passing regexes to `ctest`.

Additionally, this new implementation should be a lot faster, since instead of calling `ctest` multiple times, we only call it a single time. This will result in a huge amount of time savings, since each call of `ctest` takes about 3 minutes on the Morello-Purecap emulator!

### New implementation

This PR proposes that we instead call ctest only once, then parse the [JUnit XML file][1] results from it.

This uses CMake 3.21's [`--output-junit <file>`][2] option.

The output JUnit XML file looks something like:

```xml
<?xml version="1.0" encoding="UTF-8"?>
<testsuite name="Linux-cc"
	tests="45"
	failures="1"
	disabled="0"
	skipped="0"
	hostname="elementaldriftwood"
	time="2"
	timestamp="2023-03-14T14:59:10"
	>
	<testcase name="test_config" classname="test_config" time="0.00141511" status="run">
		<system-out>[==========] tests: Running 1 test(s).
			[ RUN      ] test_load_configs
			[       OK ] test_load_configs
			[==========] tests: 1 test(s) run.
			[  PASSED  ] 1 test(s).
		</system-out>
	</testcase>
	<testcase name="test_edgesec" classname="test_edgesec" time="0.021905" status="run">
		<system-out>[==========] tests: Running 2 test(s).
			[ RUN      ] test_edgesec
			2023-03-14 14:59:10.299  [NON-XML-CHAR-0x1B][36mDEBUG[NON-XML-CHAR-0x1B][0m[NON-XML-CHAR-0x1B][0m [NON-XML-CHAR-0x1B][90mrunctl.c:257:[NON-XML-CHAR-0x1B][0m Getting system commands paths...
			The rest of the test output was removed since it exceeds the threshold of 1024 bytes.
		</system-out>
	</testcase>
	<testcase name="test_capture_service" classname="test_capture_service" time="0.00102442" status="run">
		<system-out>[==========] tests: Running 1 test(s).

[---✂️snip✂️---]
        <!-- And this is what a failing test case looks like -->
	<testcase name="test_eloop" classname="test_eloop" time="0.000884876" status="fail">
		<failure message=""/>
		<system-out>[==========] tests: Running 6 test(s).
                
```

Then, we can use a Python script to check if the failing tests in the JUnit XML file exactly match what we expect. We don't even need to install an XML parsing library, because [`xml.etree.ElementTree`](https://docs.python.org/3/library/xml.etree.elementtree.html) is built into Python.

[1]: https://junit.org/junit5/
[2]: https://cmake.org/cmake/help/latest/manual/ctest.1.html#cmdoption-ctest-output-junit

### Failure example

This is what it looks like if a test fails and it's not in `FAILING_TESTS`:

> ![image](https://user-images.githubusercontent.com/19716675/225082826-7c0ed18e-0976-44e8-826f-7c423bb10796.png)
>
> _Screenshot taken from https://cirrus-ci.com/task/4772827472068608_

### Notes to reviewers

This YAML file is for [Cirrus CI](https://cirrus-ci.org/guide/writing-tasks/) (their docs aren't the best though).

@AshleySetter, you're probably the foremost Pythonista[^1] in the office. Any chance you can give a review on the Python part of the code? (just ignore the abomination that is Python in YAML)

[^1]: Pythonist? Parselmouth? :snake: