### PR TITLE
Compile and test for cheribsd-morello-purecap using Cirrus CI

### DIFF
--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -36,6 +36,55 @@ task:
   # uploading coverage is currently a bit difficult
   # since the codecoverage uploader doesn't yet support FreeBSD
 
+# Docker config.json that has read access to aloisklink's Docker container
+registry_config: ENCRYPTED[5a6b9031edaf3284bf98b4510a3927884f65e0c223583b916c73fff30e9ccabdcede640829b0534a39ccc7916630ba36]
+cheribuild_task:
+  name: CheriBSD (morello-purecap)
+  container:
+    image: aloisklink/cheribuild-edgesec:morello-purecap
+  cmake_dependencies_cache:
+    # cache CMake dependencies
+    folder: ./build/dl
+    fingerprint_script:
+      - echo "$CIRRUS_OS"
+      # lib/*.cmake files contains the dependencies that we use
+      - cat lib/*.cmake
+  environment:
+    # list of tests that are currently failing on CheriBSD
+    FAILING_TESTS: >-
+      test_edgesec
+      test_runctl
+      test_capture_service
+      test_header_middleware
+      test_sqlite_header
+      test_sqlite_pcap
+      test_os
+      test_eloop
+      test_sqliteu
+      test_supervisor
+      test_cmd_processor
+      test_sqlite_macconn_writer
+      test_hostapd
+      test_ap_service_failure
+      test_dnsmasq
+      test_mdns_service
+
+  build_script: |
+    /home/ubuntu/cheribuild/cheribuild.py "edgesec-morello-purecap" \
+      --edgesec/source-directory "$(pwd)" \
+      --skip-update
+  test_script: |
+    # could use --test-extra-args='' to pass extra stuff to
+    # https://github.com/CTSRD-CHERI/cheribuild/blob/main/test-scripts/run_ctest_tests.py
+    /home/ubuntu/cheribuild/cheribuild.py "edgesec-morello-purecap" \
+      --edgesec/source-directory "$(pwd)" \
+      --skip-update \
+      --run-tests \
+    || true # We look at junit XML output file for failures
+  check_failing_tests_script: |
+    python3 -c "$CHECK_FAILING_TESTS" \
+      /home/ubuntu/cheri/build/edgesec-morello-purecap-build/test-results*.xml
+
 environment:
   # Script that loads a JUnit XML file generated from CTest,
   # (generated via `ctest --output-junit <file>`)


### PR DESCRIPTION
Add a test in [Cirrus CI][1] that tries to build edgesec for the [CHERIBSD][2] operating system with the [Morello Purecap][3] CHERI architecture.

To do this, we use [cheribuild][4], with a Docker image called [`aloisklink/cheribuild-edgesec`][5] that has all of the common SDK (like LLVM/CMake/QEMU emulator) pre-built.

[1]: https://cirrus-ci.org/
[2]: https://github.com/CTSRD-CHERI/cheribsd
[3]: https://www.morello-project.org/
[4]: https://github.com/CTSRD-CHERI/cheribuild
[5]: https://hub.docker.com/r/aloisklink/cheribuild-edgesec

### Test time

Running these tests is pretty fast: it takes about 18 minutes in total to do a complete run (this is compared to the 8-10 minutes that a normal build takes on GitHub Actions).

> ![image](https://user-images.githubusercontent.com/19716675/225092688-7fc8c858-79fa-44a9-80bc-b1b1c3b310ec.png)
>
> _Screenshot taken from https://cirrus-ci.com/task/6390933567045632_

- **Downloading environment**: It takes about 7 minutes for Cirrus CI to download the `aloisklink/cheribuild-edgesec` docker image from https://hub.docker.com/r/aloisklink/cheribuild-edgesec (it's about 9.3 GiB compressed, and about 30 GiB uncompressed).
- **Compiling**:  It only takes 1 minute to compile, even with only 2 cores.
- **Testing**: Running the edgesec tests in QEMU on an emulated Morello-Purecap CHERIBSD is a bit slow. Tests take 9 minutes. In fact, it's so slow, that I'm pretty sure some of our test failures are just due to the delay in running tests.

---

### PR Dependencies

This PR contains changes that are in following PRs:
- #522.
