### PR TITLE
test(runctl): fix `test_init_context()` memory leak

### DIFF
--- a/tests/test_runctl.c
+++ b/tests/test_runctl.c
@@ -148,12 +148,10 @@ int __wrap_run_dhcp(struct dhcp_conf *dconf, UT_array *dns_server_array,
 static void test_init_context(void **state) {
   (void)state; /* unused */
   struct supervisor_context context;
-  UT_array *config_ifinfo_arr = NULL;
-  utarray_new(config_ifinfo_arr, &config_ifinfo_icd);
   struct app_config app_config = {0,
                                   .default_open_vlanid = 0,
                                   .connection_db_path = ":memory:",
-                                  .config_ifinfo_array = config_ifinfo_arr,
+                                  .config_ifinfo_array = NULL,
                                   .set_ip_forward = true,
                                   .ap_detect = true,
                                   .create_interfaces = true,
@@ -193,7 +191,6 @@ static void test_init_context(void **state) {
   free_crypt_service(context.crypt_ctx);
 #endif
   iface_free_context(context.iface_ctx);
-  utarray_free(config_ifinfo_arr);
 }
 
 /**

--- a/tests/test_runctl.c
+++ b/tests/test_runctl.c
@@ -191,6 +191,7 @@ static void test_init_context(void **state) {
   free_crypt_service(context.crypt_ctx);
 #endif
   iface_free_context(context.iface_ctx);
+  utarray_free(context.config_ifinfo_array);
 }
 
 /**


### PR DESCRIPTION
`test_init_context()` in `test/test_runctl.c` creates `ctx->config_ifinfo_array`, but it's never deallocated.

In fact, it's even allocated twice to the same variable.

**Allocated here**:
- https://github.com/nqminds/edgesec/blob/8e2f61a9287e16998998ab91fd0e4a9d983cccc2/tests/test_runctl.c#L152
- https://github.com/nqminds/edgesec/blob/e940f3a613585f5be2a7ad4dbf6f3618ee1cf616/tests/test_runctl.c#L172

I've removed the extraneous allocation, and added a `utarray_free(context.config_ifinfo_array);` at the end of the test function to fix this memory leak.

---

Side-note, the cleanup code for a `struct supervisor_context` and `struct app_config` is currently a bit messy. Can we somehow refactor this into cleanup functions?

- https://github.com/nqminds/edgesec/blob/8e2f61a9287e16998998ab91fd0e4a9d983cccc2/src/runctl.c#L567-L612
- https://github.com/nqminds/edgesec/blob/8e2f61a9287e16998998ab91fd0e4a9d983cccc2/tests/test_runctl.c#L183-L196