### PR TITLE
Fix memory leaks in `test_get_mac_conn_cmd()`

### DIFF
--- a/tests/supervisor/test_supervisor.c
+++ b/tests/supervisor/test_supervisor.c
@@ -55,7 +55,6 @@ static void test_get_mac_conn_cmd(void **state) {
     utarray_push_back(ctx.config_ifinfo_array, &el);
   }
 
-  create_vlan_mapper(ctx.config_ifinfo_array, &ctx.vlan_mapper);
   open_sqlite_macconn_db(":memory:", &ctx.macconn_db);
 
   struct mac_conn_info info = get_mac_conn_cmd(mac_addr, (void *)&ctx);

--- a/tests/supervisor/test_supervisor.c
+++ b/tests/supervisor/test_supervisor.c
@@ -88,6 +88,7 @@ static void test_get_mac_conn_cmd(void **state) {
   struct mac_conn_info info2 = get_mac_conn_cmd(conn.mac_addr, (void *)&ctx);
   assert_int_equal(info2.vlanid, -1);
 
+  free_mac_mapper(&ctx.mac_mapper);
   free_sqlite_macconn_db(ctx.macconn_db);
   utarray_free(ctx.config_ifinfo_array);
   free(ctx.crypt_ctx); // only needed if WITH_CRYPTO_SERVICE


### PR DESCRIPTION
Currently, both the `ctx.vlan_mapper` and `ctx.mac_mapper` variables are allocated in `test_get_mac_conn_cmd()` and are never deallocated.

It looks like `ctx.vlan_mapper` is never used in this test, so I've removed the `create_vlan_mapper(ctx.config_ifinfo_array, &ctx.vlan_mapper);` call.

I've added `free_mac_mapper(&ctx.mac_mapper);` to the end of the of the test to free the `ctx.mac_mapper` variable.