### PR TITLE
Fix buffer overflow with ifname in `iface_mapper`

### DIFF
--- a/src/utils/iface_mapper.c
+++ b/src/utils/iface_mapper.c
@@ -43,7 +43,7 @@ int get_if_mapper(hmap_if_conn **hmap, in_addr_t subnet, char *ifname) {
             s); /* id already in the hash? */
 
   if (s != NULL) {
-    os_memcpy(ifname, s->value, IF_NAMESIZE);
+    os_strlcpy(ifname, s->value, IF_NAMESIZE);
     return 1;
   }
 
@@ -75,12 +75,12 @@ bool put_if_mapper(hmap_if_conn **hmap, in_addr_t subnet, char *ifname) {
 
     // Copy the key and value
     s->key = subnet;
-    os_memcpy(s->value, ifname, IF_NAMESIZE);
+    os_strlcpy(s->value, ifname, IF_NAMESIZE);
 
     HASH_ADD(hh, *hmap, key, sizeof(in_addr_t), s);
   } else {
     // Copy the value
-    os_memcpy(s->value, ifname, IF_NAMESIZE);
+    os_strlcpy(s->value, ifname, IF_NAMESIZE);
   }
 
   return true;


### PR DESCRIPTION
Fix buffer overflows using the `ifname` parameter in the following functions in `src/utils/iface_mapper.c`:
  - `get_if_mapper()`
  - `put_if_mapper()`

Currently, we're using `os_memcpy(ifname, s->value, IF_NAMESIZE);` to copy the string from `ifname`. This is fine if `ifname` is at least IF_NAMESIZE bytes, but it's instead a NUL-terminated string that may be less than IF_NAMESIZE bytes long. In that case, we must only read up to `strlen(ifname)` bytes.

This can be fixed by replacing the `memcpy()` calls with `os_strlcpy()` (edgesec's implementation of [BSD strlcpy()](https://man.freebsd.org/cgi/man.cgi?query=strlcpy&sektion=3) function).