### PR TITLE
docs(README): fix badge links

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,8 +1,8 @@
 # [edgesec](https://edgesec.info)
 
-[![GitHub release (latest stable SemVer)](https://img.shields.io/github/v/release/nqminds/edgesec?label=stable&logo=github&sort=semver)](https://github.com/nqminds/nqm-ssh-tunnel/releases)
+[![GitHub release (latest stable SemVer)](https://img.shields.io/github/v/release/nqminds/edgesec?label=stable&logo=github&sort=semver)](https://github.com/nqminds/edgesec/releases)
 [![Build Debian Packages](https://github.com/nqminds/edgesec/actions/workflows/create-debs.yml/badge.svg)](https://github.com/nqminds/edgesec/actions/workflows/create-debs.yml)
-[![GitHub release (latest SemVer including pre-releases)](https://img.shields.io/github/v/release/nqminds/edgesec?include_prereleases&label=latest&logo=github&sort=semver)](https://github.com/nqminds/nqm-ssh-tunnel/releases)
+[![GitHub release (latest SemVer including pre-releases)](https://img.shields.io/github/v/release/nqminds/edgesec?include_prereleases&label=latest&logo=github&sort=semver)](https://github.com/nqminds/edgesec/releases)
 [![GitHub license](https://img.shields.io/github/license/nqminds/edgesec)](https://github.com/nqminds/edgesec/blob/main/LICENSE)
 [![Codecov Code Coverage](https://codecov.io/gh/nqminds/edgesec/branch/main/graph/badge.svg)](https://codecov.io/gh/nqminds/edgesec)
 [![Documented with Doxygen](https://img.shields.io/badge/docs-Doxygen-blue.svg?foo&bar)](https://edgesec.info/doxygen/)


### PR DESCRIPTION
Fix the location of the links when clicking on the two GitHub release badges in the README.md.

These were both pointing to https://github.com/nqminds/ssh-legion instead of the https://github.com/nqminds/edgesec project.