### PR TITLE
Fix a potential double-`free()` in `run_ctl()`

### DIFF
--- a/src/runctl.c
+++ b/src/runctl.c
@@ -405,6 +405,8 @@ void close_capture_thread(const hmap_vlan_conn *vlan_mapper) {
 int run_ctl(struct app_config *app_config, struct eloop_data *eloop) {
   struct supervisor_context *context = NULL;
 
+  int return_code = -1;
+
   if ((context = os_zalloc(sizeof(struct supervisor_context))) == NULL) {
     log_errno("os_zalloc");
     return -1;
@@ -564,28 +566,7 @@ int run_ctl(struct app_config *app_config, struct eloop_data *eloop) {
   }
 #endif
 
-  close_supervisor(context);
-  close_ap(context);
-  close_dhcp();
-#ifdef WITH_RADIUS_SERVICE
-  close_radius(context->radius_srv);
-#endif
-  hmap_str_keychar_free(&context->hmap_bin_paths);
-  fw_free_context(context->fw_ctx);
-  free_mac_mapper(&context->mac_mapper);
-  free_if_mapper(&context->if_mapper);
-  free_vlan_mapper(&context->vlan_mapper);
-  free_bridge_list(context->bridge_list);
-  free_sqlite_macconn_db(context->macconn_db);
-#ifdef WITH_CRYPTO_SERVICE
-  free_crypt_service(context->crypt_ctx);
-#endif
-  iface_free_context(context->iface_ctx);
-  utarray_free(context->config_ifinfo_array);
-  edge_eloop_free(context->eloop);
-  os_free(context);
-
-  return 0;
+  return_code = 0;
 
 run_engine_fail:
   close_supervisor(context);
@@ -610,5 +591,7 @@ run_engine_fail:
   }
   edge_eloop_free(context->eloop);
   os_free(context);
-  return -1;
+
+  // will be -1 if we got here via `goto run_engine_fail`
+  return return_code;
 }

--- a/src/runctl.c
+++ b/src/runctl.c
@@ -589,7 +589,11 @@ run_engine_fail:
   if (context->config_ifinfo_array != NULL) {
     utarray_free(context->config_ifinfo_array);
   }
-  edge_eloop_free(context->eloop);
+  if (context->eloop != eloop) {
+    // only free context->eloop if it wasn't passed in from function as param
+    // (i.e. it was created in this function)
+    edge_eloop_free(context->eloop);
+  }
   os_free(context);
 
   // will be -1 if we got here via `goto run_engine_fail`

--- a/tests/test_edgesec.c
+++ b/tests/test_edgesec.c
@@ -333,6 +333,7 @@ static int teardown_edgesec_test(void **state) {
     }
 
     edge_eloop_free(ctx->ap_server.eloop);
+    edge_eloop_free(ctx->supervisor.eloop);
   }
 
   free(ctx);


### PR DESCRIPTION
Skip `free()`-ing the `eloop` parameter in `run_ctl()`. If this parameter is passed in to `run_ctl()`, we should let the caller `free()` it instead of us.

This also fixes a memory leak in `test_edgesec.c`.

---

I've also simplified the `run_ctl()` cleanup code by merging the success and `goto run_engine_fail` code.

The only two differences between the two was:
1. the success bit `return 0`, while the failure bit `return -1;`, which was easy to fix.
2. On the success bit, this following line of code was always call:
   https://github.com/nqminds/edgesec/blob/b722d492217a769f0e86904fb0ceac7f92212940/src/runctl.c#L584
    However, on the `goto run_engine_fail` branch, it was hidden behind an `if (.. != NULL)` branch:
    https://github.com/nqminds/edgesec/blob/b722d492217a769f0e86904fb0ceac7f92212940/src/runctl.c#L608-L610