### PR TITLE
Fix a memory leak in `__rtnl_talk_iov()`

### DIFF
--- a/lib/libnetlink/lib/libnetlink.c
+++ b/lib/libnetlink/lib/libnetlink.c
@@ -996,14 +996,19 @@ next:
 						rtnl_talk_error(h, err, errfn);
 				}
 
+				if (i < iovlen) {
+					free(buf);
+					goto next;
+				}
+
+				if (error) {
+					free(buf);
+					return -i;
+				}
+
 				if (answer)
 					*answer = (struct nlmsghdr *)buf;
-				else
-					free(buf);
-
-				if (i < iovlen)
-					goto next;
-				return error ? -i : 0;
+				return 0;
 			}
 
 			if (answer) {


### PR DESCRIPTION
Fixes a memory leak in libnetlink.

This patch was taken from https://github.com/shemminger/iproute2/commit/0faec4d050b607f7544b6cf9a4c2d57e191f981f.

I've copied the original patch message below:

> If `__rtnl_talk_iov` fails then callers are not expected to free `answer`.
> 
> Currently if `NLMSG_ERROR` was received with an error then the netlink buffer was stored in `answer`, while still returning an error
> 
> This leak can be observed by running this snippet over time. This triggers an `NLMSG_ERROR` because for each neighbour update, `ip` will try to query for the name of interface 9999 in the wrong netns. (which in itself is a separate bug)
> 
>  ```bash
>  set -e
> 
>  ip netns del test-a || true
>  ip netns add test-a
>  ip netns del test-b || true
>  ip netns add test-b
> 
>  ip -n test-a netns set test-b auto
>  ip -n test-a link add veth_a index 9999 type veth \
>   peer name veth_b netns test-b
>  ip -n test-b link set veth_b up
> 
>  ip -n test-a monitor link address prefix neigh nsid label all-nsid \
>   > /dev/null &
>  monitor_pid=$!
>  clean() {
>   kill $monitor_pid
>   ip netns del test-a
>   ip netns del test-b
>  }
>  trap clean EXIT
> 
>  while true; do
>   ip -n test-b neigh add dev veth_b 1.2.3.4 lladdr AA:AA:AA:AA:AA:AA
>   ip -n test-b neigh del dev veth_b 1.2.3.4
>  done
>  ```
> 
> Fixes: https://github.com/shemminger/iproute2/commit/55870dfe7f8b1d14c4b52fb689f6d91cbf28a60c ("Improve batch and dump times by caching link lookups")