### PR TITLE
Cleanup `ctx.crypt_ctx` correctly by calling `free_crypt_service()`

### DIFF
--- a/src/crypt/CMakeLists.txt
+++ b/src/crypt/CMakeLists.txt
@@ -18,4 +18,4 @@ else ()
 endif ()
 
 add_library(crypt_service crypt_service.c)
-target_link_libraries(crypt_service PUBLIC LibUTHash::LibUTHash SQLite::SQLite3 PRIVATE generic_hsm_driver base64 sqlite_crypt_writer cryptou log os)
+target_link_libraries(crypt_service PUBLIC LibUTHash::LibUTHash SQLite::SQLite3 attributes PRIVATE generic_hsm_driver base64 sqlite_crypt_writer cryptou log os)

--- a/tests/supervisor/test_supervisor.c
+++ b/tests/supervisor/test_supervisor.c
@@ -91,7 +91,9 @@ static void test_get_mac_conn_cmd(void **state) {
   free_mac_mapper(&ctx.mac_mapper);
   free_sqlite_macconn_db(ctx.macconn_db);
   utarray_free(ctx.config_ifinfo_array);
-  free(ctx.crypt_ctx); // only needed if WITH_CRYPTO_SERVICE
+#ifdef WITH_CRYPTO_SERVICE
+  free_crypt_service(ctx.crypt_ctx);
+#endif
 }
 
 int main(int argc, char *argv[]) {


### PR DESCRIPTION
The `test_get_mac_conn_cmd` test in `test_supervisor.c` was not correctly cleaning up the `ctx.crypt_ctx` object, when we were compiling tests with `WITH_CRYPTO_SERVICE=ON`.

We should be using `free_crypt_service()` to avoid a memory leak.

Fixes: https://github.com/nqminds/edgesec/commit/0913b22966baa4f0ef7c1518fc636e2a534b565d

---

In order to prevent this from happening again, I've added documentation to the `load_crypt_service()` function to say that `free_crypt_service()` should be called on the result. If we're compiling with GCC >= 11, I've also added the `__attribute__((malloc(free_crypt_service, 1)))` compiler attribute to `load_crypt_service()`, so that the compiler warns us if we use the wrong deallocator. 

