### PR TITLE
test(uci_wrt): fix memory leaks in `uci_wrt` tests

### DIFF
--- a/tests/utils/test_uci_wrt.c
+++ b/tests/utils/test_uci_wrt.c
@@ -71,6 +71,7 @@ static void test_uwrt_get_interfaces(void **state) {
   assert_non_null(interfaces);
   ptr = (netif_info_t *)utarray_next(interfaces, ptr);
   assert_null(ptr);
+  utarray_free(interfaces);
 
   uwrt_free_context(context);
 }
@@ -92,8 +93,7 @@ static void test_uwrt_create_interface(void **state) {
   assert_string_equal(ptr->ip_addr, "10.0.0.1");
   utarray_free(interfaces);
 
-  char *property = os_strdup("network.br0");
-
+  char property[] = "network.br0";
   assert_int_equal(uci_lookup_ptr(context->uctx, &p, property, true), UCI_OK);
   assert_int_equal(uci_delete(context->uctx, &p), UCI_OK);
   assert_int_equal(uci_save(context->uctx, p.p), UCI_OK);


### PR DESCRIPTION
Fix the memory leaks in the `uci_wrt` tests.

---

Unfortunately we can't add an `__attribute__((malloc(utarray_free, 1)))` attribute to the `uwrt_get_interfaces` function to help prevent this from happening again, because `utarray_free()` isn't a function, it's a pre-processor macro.

https://github.com/nqminds/edgesec/blob/71d2dcdb39478e532d3b6d62dc3c587b9d5177b1/tests/utils/test_uci_wrt.c#L70
