### PR TITLE
Make `src/utils/log.c` compliant with the POSIX C standard

### DIFF
--- a/src/utils/CMakeLists.txt
+++ b/src/utils/CMakeLists.txt
@@ -1,6 +1,4 @@
 add_library(log log.c)
-# requires POSIX mode_t/umask functions, and BSD gettimeofday
-set_target_properties(log PROPERTIES C_EXTENSIONS ON POSITION_INDEPENDENT_CODE ON)
 
 add_library(allocs allocs.c)
 target_link_libraries(allocs PUBLIC attributes)

--- a/src/utils/log.c
+++ b/src/utils/log.c
@@ -26,6 +26,9 @@
  * @brief File containing the implementation of the logging functions.
  */
 
+// needed for mode_t/umask()
+#define _POSIX_C_SOURCE 200112L
+
 #include <stdarg.h>
 #include <stdbool.h>
 #include <stdio.h>

--- a/src/utils/log.c
+++ b/src/utils/log.c
@@ -67,7 +67,7 @@ static const char *level_names[] = LEVEL_NAMES;
 static const char *level_colors[] = LEVEL_COLORS;
 
 /* Write time to buf in format YYYY-MM-DD HH:MM:SS.ms */
-uint8_t time_to_str(char *buf) {
+static void time_to_str(char buf[static 25]) {
   struct timeval tv;
   struct tm *tm;
 
@@ -88,7 +88,6 @@ uint8_t time_to_str(char *buf) {
   int len = sprintf(buf, "%04d-%02d-%02d %02d:%02d:%02d.%03d ", year, month,
                     day, hour, minutes, seconds, msec);
   buf[len] = '\0';
-  return 0;
 }
 
 #ifdef __GNUC__               /* Prevent 'gcc -Wall' complaining  */


### PR DESCRIPTION
Make the `src/utils/log.c` file compile under standard POSIX C by removing the BSD-only `gettimeofday()` function.

Instead, we can use `timespec_get()`, which is part of the ISO C11 standard, and gets the time with up to nanosecond precision.

---

Other changes to `time_to_str()`:
  - This function only ever returns one value, that's never checked, so we can remove
    it and make its return-type `void`
  - This function is never called outside of this file, so we might as well make it
    `static`.
  - The input buffer must be at least 25 bytes large, so we might as
    well mark it as `char buf[static 25]`.
  - I've also added an error handler for a Y2K38 overflow on 32-bit
machines. I believe `gettimeofday()` will also overflow on 32-bit machines, but :shrug:, it's not a standard function so documentation is a bit light.