### PR TITLE
Enable `OPENSSL_API_COMPAT` and remove all functions deprecated in OpenSSL 1.1.1

### DIFF
--- a/src/utils/cryptou.c
+++ b/src/utils/cryptou.c
@@ -9,6 +9,16 @@
  */
 
 #include <stdint.h>
+
+/*
+ * Our minimum supported OpenSSL version is v1.1.1
+ * (Ubuntu 20.04).
+ * See https://www.openssl.org/docs/man3.1/man7/openssl_user_macros.html
+ */
+#define OPENSSL_API_COMPAT 10101
+// don't show deprecated OpenSSL funcs
+#define OPENSSL_NO_DEPRECATED 1
+
 #include <openssl/conf.h>
 #include <openssl/crypto.h>
 #include <openssl/err.h>

--- a/src/utils/cryptou.c
+++ b/src/utils/cryptou.c
@@ -254,8 +254,8 @@ X509 *crypto_generate_cert(EVP_PKEY *pkey, struct certificate_meta *meta) {
   }
 
   /* certificate expiration date: 365 days from now (60s * 60m * 24h * 365d) */
-  X509_gmtime_adj(X509_get_notBefore(x509), meta->not_before);
-  X509_gmtime_adj(X509_get_notAfter(x509), meta->not_after);
+  X509_gmtime_adj(X509_getm_notBefore(x509), meta->not_before);
+  X509_gmtime_adj(X509_getm_notAfter(x509), meta->not_after);
 
   if (!X509_set_pubkey(x509, pkey)) {
     log_trace("X509_set_pubkey fail with code=%lu", ERR_get_error());


### PR DESCRIPTION
Define [OPENSSL_API_COMPAT][1] and [OPENSSL_NO_DEPRECATED][2] macros before including OpenSSL headers to prevent including OpenSSL functions that are deprecated since Since OpenSSL 1.1.1.

OpenSSL 1.1.1 is the minimum version of OpenSSL we support, as it's the version in:
  - [Ubuntu 20.04 LTS ("focal")][3]
  - [Debian 10 ("buster")][4]

[1]: https://www.openssl.org/docs/man3.0/man7/OPENSSL_API_COMPAT.html#OPENSSL_API_COMPAT
[2]: https://www.openssl.org/docs/man3.0/man7/OPENSSL_API_COMPAT.html#OPENSSL_NO_DEPRECATED
[3]: https://packages.ubuntu.com/it/focal/libssl-dev
[4]: https://packages.debian.org/buster/libssl-dev

---

This flag caught two functions that are deprecated in OpenSSL 1.1.1: `X509_get_notBefore` and `X509_get_notAfter`

I've replaced them with the similar `X509_getm_notBefore` and `X509_getm_notAfter` functions.

See [`man X509_getm_notBefore(3)`](https://www.openssl.org/docs/man3.1/man3/X509_getm_notBefore.html)
