### PR TITLE
Compile and test linux presets with AddressSanitizer to catch memory issues

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -78,6 +78,8 @@ option(BUILD_PCAP_LIB "Build pcap library" ON)
 option(BUILD_PROTOBUFC_LIB "Build protobuf-c library" ON)
 option(BUILD_HOSTAPD_EAP_LIB "Build hostapd eap library" OFF)
 
+option(SANITIZE_ADDRESS "Enable AddressSanitizer for debug builds." OFF)
+
 option(USE_NETLINK_SERVICE "Use netlink service" OFF)
 cmake_dependent_option(BUILD_MNL_LIB "Build mnl library" ON USE_NETLINK_SERVICE OFF)
 cmake_dependent_option(BUILD_NETLINK_LIB "Build netlink library" ON USE_NETLINK_SERVICE OFF)
@@ -269,6 +271,29 @@ if (NOT BUILD_ONLY_DOCS)
         "${PROJECT_SOURCE_DIR}/middlewares_list.c"
         # The _deps/ folder is created by CMake's FetchContent
         "${PROJECT_SOURCE_DIR}/_deps/*"
+    )
+  endif()
+
+  if (SANITIZE_ADDRESS)
+    include(CheckCCompilerFlag)
+
+    set(CMAKE_REQUIRED_LINK_OPTIONS "-fsanitize=address")
+    check_c_compiler_flag("-fsanitize=address" C_COMPILER_SUPPORTS_ASAN)
+    set(CMAKE_REQUIRED_LINK_OPTIONS "")
+
+    if (NOT C_COMPILER_SUPPORTS_ASAN)
+      message(
+        FATAL_ERROR
+        "${CMAKE_C_COMPILER} version ${CMAKE_C_COMPILER_VERSION} does not "
+        "support -fsanitize=address for target "
+        "${CMAKE_SYSTEM_PROCESSOR}-${CMAKE_SYSTEM_NAME}"
+      )
+    endif()
+    add_compile_options(
+      $<$<CONFIG:Debug>:$<$<COMPILE_LANGUAGE:C>:-fsanitize=address>> # use AddressSanitizer to check addresses
+    )
+    add_link_options(
+      $<$<CONFIG:Debug>:$<$<LINK_LANGUAGE:C>:-fsanitize=address>> # need to link AddressSantizer lib
     )
   endif()
 

--- a/CMakePresets.json
+++ b/CMakePresets.json
@@ -55,7 +55,11 @@
         "BUILD_HOSTAPD": true,
         "BUILD_HOSTAPD_EAP_LIB": true,
         "USE_CRYPTO_SERVICE": false,
-        "BUILD_OPENSSL_LIB": false
+        "BUILD_OPENSSL_LIB": false,
+        "SANITIZE_ADDRESS": {
+          "type": "BOOL",
+          "value": true
+        }
       }
     },
     {
@@ -186,7 +190,8 @@
       "hidden": true,
       "displayName": "CMake config for cross-compiling OpenWRT with the SDK",
       "cacheVariables": {
-        "BUILD_TESTING": false
+        "BUILD_TESTING": false,
+        "SANITIZE_ADDRESS": false
       },
       "condition": {
         "type": "equals",


### PR DESCRIPTION
Compile edgesec tests with the [`-fsanitize=address` flag](https://clang.llvm.org/docs/AddressSanitizer.html) which enables [AddressSanitizer (aka ASan)](https://github.com/google/sanitizers/wiki/AddressSanitizer).

> [AddressSanitizer](https://github.com/google/sanitizers/wiki/AddressSanitizer) (aka ASan) is a memory error detector for C/C++. It finds:
> 
> - [Use after free](https://github.com/google/sanitizers/wiki/AddressSanitizerExampleUseAfterFree) (dangling pointer dereference)
> - [Heap buffer overflow](https://github.com/google/sanitizers/wiki/AddressSanitizerExampleHeapOutOfBounds)
> - [Stack buffer overflow](https://github.com/google/sanitizers/wiki/AddressSanitizerExampleStackOutOfBounds)
> - [Global buffer overflow](https://github.com/google/sanitizers/wiki/AddressSanitizerExampleGlobalOutOfBounds)
> - [Use after return](https://github.com/google/sanitizers/wiki/AddressSanitizerExampleUseAfterReturn)
> - [Use after scope](https://github.com/google/sanitizers/wiki/AddressSanitizerExampleUseAfterScope)
> - [Initialization order bugs](https://github.com/google/sanitizers/wiki/AddressSanitizerInitializationOrderFiasco)
> - [Memory leaks](https://github.com/google/sanitizers/wiki/AddressSanitizerLeakSanitizer)

I've enabled it on on Linux presets by default.

The OpenWRT SDK presets have it disabled, as old versions of GCC have poor support for running Address Sanitizer on non-x86 platforms.

(plus, with the OpenWRT SDK presets, we're not running tests, so compiling with address sanitizer on doesn't really do much)

#### Bugs caught

The following PRs were fixing bugs that address sanitizer caught!

- https://github.com/nqminds/edgesec/pull/514
- https://github.com/nqminds/edgesec/pull/515
- https://github.com/nqminds/edgesec/pull/516
- https://github.com/nqminds/edgesec/pull/517
- https://github.com/nqminds/edgesec/pull/518
- https://github.com/nqminds/edgesec/pull/519
- https://github.com/nqminds/edgesec/pull/524
- https://github.com/nqminds/edgesec/pull/525
- https://github.com/nqminds/edgesec/pull/526
- https://github.com/nqminds/edgesec/pull/527
- https://github.com/nqminds/edgesec/pull/529
- https://github.com/nqminds/edgesec/pull/530
- https://github.com/nqminds/edgesec/pull/531
- https://github.com/nqminds/edgesec/pull/532
- https://github.com/nqminds/edgesec/pull/535
- https://github.com/nqminds/edgesec/pull/536

#### Future work

Address sanitizer is supported on FreeBSD, so we could enable it there too. This will probably also help with [CheriBSD support](https://github.com/nqminds/edgesec/milestone/1), since some of these are probably causing the CheriBSD tests to fail.