### PR TITLE
build(cmake): enable UndefinedBehaviorSanitizer

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -297,6 +297,29 @@ if (NOT BUILD_ONLY_DOCS)
     )
   endif()
 
+  if (SANITIZE_UNDEFINED_BEHAVIOR)
+  include(CheckCCompilerFlag)
+
+  set(CMAKE_REQUIRED_LINK_OPTIONS "-fsanitize=undefined")
+  check_c_compiler_flag("-fsanitize=undefined" C_COMPILER_SUPPORTS_UBSAN)
+  set(CMAKE_REQUIRED_LINK_OPTIONS "")
+
+  if (NOT C_COMPILER_SUPPORTS_UBSAN)
+    message(
+      FATAL_ERROR
+      "${CMAKE_C_COMPILER} version ${CMAKE_C_COMPILER_VERSION} does not "
+      "support -fsanitize=undefined for target "
+      "${CMAKE_SYSTEM_PROCESSOR}-${CMAKE_SYSTEM_NAME}"
+    )
+  endif()
+  add_compile_options(
+    $<$<CONFIG:Debug>:$<$<COMPILE_LANGUAGE:C>:-fsanitize=undefined>> # use UndefinedBehaviorSanitizer to check addresses
+  )
+  add_link_options(
+    $<$<CONFIG:Debug>:$<$<LINK_LANGUAGE:C>:-fsanitize=undefined>> # need to link UndefinedBehaviorSanitizer lib
+  )
+endif()
+
   # src must be after codecoverage but before tests
   add_subdirectory(src)
 

--- a/CMakePresets.json
+++ b/CMakePresets.json
@@ -59,7 +59,8 @@
         "SANITIZE_ADDRESS": {
           "type": "BOOL",
           "value": true
-        }
+        },
+        "SANITIZE_UNDEFINED_BEHAVIOR": true
       }
     },
     {
@@ -191,7 +192,8 @@
       "displayName": "CMake config for cross-compiling OpenWRT with the SDK",
       "cacheVariables": {
         "BUILD_TESTING": false,
-        "SANITIZE_ADDRESS": false
+        "SANITIZE_ADDRESS": false,
+        "SANITIZE_UNDEFINED_BEHAVIOR": false
       },
       "condition": {
         "type": "equals",


### PR DESCRIPTION
Enable [UndefinedBehaviorSanitizer (UBSan)][1] on Linux presets by default.

> UndefinedBehaviorSanitizer (UBSan) is a fast undefined behavior detector. UBSan modifies the program at compile-time to catch various kinds of undefined behavior during program execution, for example:
> 
> - Array subscript out of bounds, where the bounds can be statically determined
> - Bitwise shifts that are out of bounds for their data type
> - Dereferencing misaligned or null pointers
> - Signed integer overflow
> - Conversion to, from, or between floating-point types which would overflow the destination


The OpenWRT SDK presets have it disabled, as old versions of GCC have poor support for running UBSanitizer on non-x86 platforms.

[1]: https://clang.llvm.org/docs/UndefinedBehaviorSanitizer.html