### PR TITLE
refactor(command_mapper): make functions `const`

### DIFF
--- a/src/dns/command_mapper.c
+++ b/src/dns/command_mapper.c
@@ -23,7 +23,7 @@ void free_command_mapper(hmap_command_conn **hmap) {
   }
 }
 
-int put_command_mapper(hmap_command_conn **hmap, char *command) {
+int put_command_mapper(hmap_command_conn **hmap, const char *command) {
   hmap_command_conn *s;
   uint32_t hash_key;
 
@@ -59,8 +59,8 @@ int put_command_mapper(hmap_command_conn **hmap, char *command) {
   return 0;
 }
 
-int check_command_mapper(hmap_command_conn **hmap, char *command) {
-  hmap_command_conn *s = NULL;
+int check_command_mapper(hmap_command_conn *const *hmap, const char *command) {
+  const hmap_command_conn *s = NULL;
   uint32_t hash_key;
 
   if (hmap == NULL) {

--- a/src/dns/command_mapper.h
+++ b/src/dns/command_mapper.h
@@ -40,18 +40,18 @@ void free_command_mapper(hmap_command_conn **hmap);
 /**
  * @brief Insert a command into the command mapper connection object
  *
- * @param hmap Command mapper object
+ * @param[in,out] hmap Command mapper object
  * @param command The command string
  * @return 0 on success, -1 on failure
  */
-int put_command_mapper(hmap_command_conn **hmap, char *command);
+int put_command_mapper(hmap_command_conn **hmap, const char *command);
 
 /**
  * @brief Check if a command is in the command mapper connection object
  *
- * @param hmap Command mapper object
+ * @param[in] hmap Command mapper object
  * @param command The command string
  * @return 1 if command is in hmap, 0 otherwise, -1 on failure
  */
-int check_command_mapper(hmap_command_conn **hmap, char *command);
+int check_command_mapper(hmap_command_conn *const *hmap, const char *command);
 #endif


### PR DESCRIPTION
Make the `put_command_mapper()` and `check_command_mapper()` use a `const` string as an input parameter.

I've also made the `hmap` param to `check_command_mapper()` partially `const`, since we never modify it.