### PR TITLE
refactor(os): make `read_file_string()` param const

### DIFF
--- a/src/utils/os.c
+++ b/src/utils/os.c
@@ -1445,7 +1445,7 @@ ssize_t read_file(const char *path, uint8_t **out) {
   return read_size;
 }
 
-int read_file_string(char *path, char **out) {
+int read_file_string(const char *path, char **out) {
   uint8_t *data = NULL;
   ssize_t data_size = 0;
 

--- a/src/utils/os.h
+++ b/src/utils/os.h
@@ -655,11 +655,12 @@ ssize_t read_file(const char *path, uint8_t **out);
 /**
  * @brief Read the entire file into a string
  *
- * @param path The file path
- * @param out The output string
+ * @param[in] path The file path
+ * @param[out] out The pointer to the output string. You must `free()` this
+ * variable if `read_file_string()` is successful.
  * @return 0 on success, -1 on failure
  */
-int read_file_string(char *path, char **out);
+int read_file_string(const char *path, char **out);
 
 /**
  * @brief Opens a file for writing and write a


### PR DESCRIPTION
Make `read_file_string()`'s `path` param `const`, since we don't change it in the function.