### PR TITLE
refactor(dnsmasq): make `signal_dhcp_process()` const

### DIFF
--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -24,7 +24,7 @@ task:
     cmake --build --preset freebsd --parallel "$(($(sysctl -n hw.ncpu) + 1))"
   env:
     # list of tests that are currently failing on FreeBSD
-    FAILING_TESTS: test_edgesec test_dnsmasq test_mdns_service
+    FAILING_TESTS: test_edgesec test_mdns_service
   test_script: |
     ctest --preset freebsd --output-on-failure --output-junit junit-test-results.xml \
     || true # We look at junit XML output file for failures

--- a/src/dhcp/dnsmasq.c
+++ b/src/dhcp/dnsmasq.c
@@ -414,9 +414,13 @@ int signal_dhcp_process(char *dhcp_bin_path, char *dhcp_conf_path) {
   return 0;
 }
 #else
-int signal_dhcp_process(char *dhcp_bin_path) {
-  os_strlcpy(dnsmasq_proc_name, basename(dhcp_bin_path), MAX_OS_PATH_LEN);
-
+int signal_dhcp_process(const char *dhcp_bin_path) {
+  {
+    char dhcp_bin_path_buffer[MAX_OS_PATH_LEN];
+    os_strlcpy(dhcp_bin_path_buffer, dhcp_bin_path, MAX_OS_PATH_LEN);
+    os_strlcpy(dnsmasq_proc_name, basename(dhcp_bin_path_buffer),
+               MAX_OS_PATH_LEN);
+  }
   // Signal any running dnsmasq process to reload the config
   if (!signal_process(dnsmasq_proc_name, SIGHUP)) {
     log_error("signal_process fail");

--- a/src/dhcp/dnsmasq.h
+++ b/src/dhcp/dnsmasq.h
@@ -62,7 +62,7 @@ bool kill_dhcp_process(void);
  * @param dhcp_bin_path The DHCP server binary path
  * @return int 0 on success, -1 on failure
  */
-int signal_dhcp_process(char *dhcp_bin_path);
+int signal_dhcp_process(const char *dhcp_bin_path);
 
 /**
  * @brief Clear the DHCP lease entry for a MAC addrress


### PR DESCRIPTION
Make the `dhcp_bin_path` parameter to `signal_dhcp_process()` `const`.

Because we call `basename()` on this value, which may change the input string, we need to first make a temporary copy of the string into a buffer.