### PR TITLE
Make function parameters in `iface_mapper` `const` when possible

### DIFF
--- a/src/utils/iface_mapper.c
+++ b/src/utils/iface_mapper.c
@@ -131,8 +131,6 @@ int copy_vlan_mapper(hmap_vlan_conn *const *hmap, hmap_vlan_conn **copy) {
 }
 
 bool put_vlan_mapper(hmap_vlan_conn **hmap, const struct vlan_conn *conn) {
-  hmap_vlan_conn *s;
-
   if (hmap == NULL) {
     log_trace("hmap param is NULL");
     return false;
@@ -143,6 +141,7 @@ bool put_vlan_mapper(hmap_vlan_conn **hmap, const struct vlan_conn *conn) {
     return false;
   }
 
+  hmap_vlan_conn *s;
   HASH_FIND(hh, *hmap, &conn->vlanid, sizeof(int),
             s); /* id already in the hash? */
 
@@ -154,14 +153,16 @@ bool put_vlan_mapper(hmap_vlan_conn **hmap, const struct vlan_conn *conn) {
       return false;
     }
 
-    // Copy the key and value
-    s->key = conn->vlanid;
-    os_memcpy(&s->value, conn, sizeof(struct vlan_conn));
+    // Initialize with key and value
+    *s = (hmap_vlan_conn){
+        .key = conn->vlanid,
+        .value = *conn,
+    };
 
     HASH_ADD(hh, *hmap, key, sizeof(int), s);
   } else {
     // Copy the value
-    os_memcpy(&s->value, conn, sizeof(struct vlan_conn));
+    s->value = *conn;
   }
 
   return true;
@@ -193,7 +194,7 @@ int find_ifinfo(const UT_array *config_ifinfo_array, const char *ip,
     }
 
     if (addr_ip == addr_subnet) {
-      os_memcpy(ifinfo, p, sizeof(config_ifinfo_t));
+      *ifinfo = *p;
       return 0;
     }
   }

--- a/src/utils/iface_mapper.c
+++ b/src/utils/iface_mapper.c
@@ -26,8 +26,9 @@
 #include "net.h"
 #include "os.h"
 
-int get_if_mapper(hmap_if_conn **hmap, in_addr_t subnet, char *ifname) {
-  hmap_if_conn *s;
+int get_if_mapper(hmap_if_conn *const *hmap, in_addr_t subnet,
+                  char ifname[static IF_NAMESIZE]) {
+  const hmap_if_conn *s;
 
   if (hmap == NULL) {
     log_trace("hmap param is NULL");
@@ -50,7 +51,7 @@ int get_if_mapper(hmap_if_conn **hmap, in_addr_t subnet, char *ifname) {
   return 0;
 }
 
-bool put_if_mapper(hmap_if_conn **hmap, in_addr_t subnet, char *ifname) {
+bool put_if_mapper(hmap_if_conn **hmap, in_addr_t subnet, const char *ifname) {
   hmap_if_conn *s;
 
   if (hmap == NULL) {
@@ -95,14 +96,14 @@ void free_if_mapper(hmap_if_conn **hmap) {
   }
 }
 
-int get_vlan_mapper(hmap_vlan_conn **hmap, int vlanid, struct vlan_conn *conn) {
-  hmap_vlan_conn *s;
-
+int get_vlan_mapper(hmap_vlan_conn *const *hmap, int vlanid,
+                    struct vlan_conn *conn) {
   if (hmap == NULL) {
     log_trace("hmap param is NULL");
     return -1;
   }
 
+  const hmap_vlan_conn *s;
   HASH_FIND(hh, *hmap, &vlanid, sizeof(int), s); /* id already in the hash? */
 
   if (s != NULL) {
@@ -116,8 +117,8 @@ int get_vlan_mapper(hmap_vlan_conn **hmap, int vlanid, struct vlan_conn *conn) {
   return 0;
 }
 
-int copy_vlan_mapper(hmap_vlan_conn **hmap, hmap_vlan_conn **copy) {
-  hmap_vlan_conn *current, *tmp;
+int copy_vlan_mapper(hmap_vlan_conn *const *hmap, hmap_vlan_conn **copy) {
+  const hmap_vlan_conn *current, *tmp;
 
   HASH_ITER(hh, *hmap, current, tmp) {
     if (!put_vlan_mapper(copy, &current->value)) {
@@ -129,7 +130,7 @@ int copy_vlan_mapper(hmap_vlan_conn **hmap, hmap_vlan_conn **copy) {
   return 0;
 }
 
-bool put_vlan_mapper(hmap_vlan_conn **hmap, struct vlan_conn *conn) {
+bool put_vlan_mapper(hmap_vlan_conn **hmap, const struct vlan_conn *conn) {
   hmap_vlan_conn *s;
 
   if (hmap == NULL) {
@@ -175,19 +176,17 @@ void free_vlan_mapper(hmap_vlan_conn **hmap) {
   }
 }
 
-int find_ifinfo(UT_array *config_ifinfo_array, char *ip,
+int find_ifinfo(const UT_array *config_ifinfo_array, const char *ip,
                 config_ifinfo_t *ifinfo) {
-  config_ifinfo_t *p = NULL;
-  in_addr_t addr_subnet;
-  in_addr_t addr_ip;
-
-  while ((p = (config_ifinfo_t *)utarray_next(config_ifinfo_array, p)) !=
-         NULL) {
+  for (const config_ifinfo_t *p = utarray_front(config_ifinfo_array); p != NULL;
+       p = utarray_next(config_ifinfo_array, p)) {
+    in_addr_t addr_subnet;
     if (ip_2_nbo(p->ip_addr, p->subnet_mask, &addr_subnet) < 0) {
       log_trace("ip_2_nbo fail");
       return -1;
     }
 
+    in_addr_t addr_ip;
     if (ip_2_nbo(ip, p->subnet_mask, &addr_ip) < 0) {
       log_trace("ip_2_nbo fail");
       return -1;
@@ -202,8 +201,8 @@ int find_ifinfo(UT_array *config_ifinfo_array, char *ip,
   return 1;
 }
 
-int get_brname_from_ip(UT_array *config_ifinfo_array, char *ip_addr,
-                       char *brname) {
+int get_brname_from_ip(const UT_array *config_ifinfo_array, const char *ip_addr,
+                       char brname[static IF_NAMESIZE]) {
   config_ifinfo_t ifinfo;
 
   if (config_ifinfo_array == NULL) {
@@ -231,8 +230,8 @@ int get_brname_from_ip(UT_array *config_ifinfo_array, char *ip_addr,
   return 0;
 }
 
-int get_ifname_from_ip(UT_array *config_ifinfo_array, char *ip_addr,
-                       char *ifname) {
+int get_ifname_from_ip(const UT_array *config_ifinfo_array, const char *ip_addr,
+                       char ifname[static IF_NAMESIZE]) {
   config_ifinfo_t ifinfo;
 
   if (config_ifinfo_array == NULL) {
@@ -260,15 +259,15 @@ int get_ifname_from_ip(UT_array *config_ifinfo_array, char *ip_addr,
   return 0;
 }
 
-bool create_if_mapper(UT_array *config_ifinfo_array, hmap_if_conn **hmap) {
-  config_ifinfo_t *p = NULL;
-  in_addr_t addr;
-
+bool create_if_mapper(const UT_array *config_ifinfo_array,
+                      hmap_if_conn **hmap) {
   if (config_ifinfo_array != NULL) {
-    while ((p = (config_ifinfo_t *)utarray_next(config_ifinfo_array, p)) !=
-           NULL) {
+    for (const config_ifinfo_t *p = utarray_front(config_ifinfo_array);
+         p != NULL; p = utarray_next(config_ifinfo_array, p)) {
       log_trace("Adding ip=%s subnet=%s ifname=%s to mapper", p->ip_addr,
                 p->subnet_mask, p->ifname);
+
+      in_addr_t addr;
       if (ip_2_nbo(p->ip_addr, p->subnet_mask, &addr) < 0) {
         log_trace("ip_2_nbo fail");
         free_if_mapper(hmap);
@@ -285,17 +284,18 @@ bool create_if_mapper(UT_array *config_ifinfo_array, hmap_if_conn **hmap) {
   return true;
 }
 
-int create_vlan_mapper(UT_array *config_ifinfo_array, hmap_vlan_conn **hmap) {
-  config_ifinfo_t *p = NULL;
-  struct vlan_conn vlan_conn;
+int create_vlan_mapper(const UT_array *config_ifinfo_array,
+                       hmap_vlan_conn **hmap) {
   if (config_ifinfo_array != NULL) {
-    while ((p = (config_ifinfo_t *)utarray_next(config_ifinfo_array, p)) !=
-           NULL) {
+    for (const config_ifinfo_t *p = utarray_front(config_ifinfo_array);
+         p != NULL; p = utarray_next(config_ifinfo_array, p)) {
       log_trace("Adding vlanid=%d and ifname=%s to mapper", p->vlanid,
                 p->ifname);
-      vlan_conn.vlanid = p->vlanid;
+      struct vlan_conn vlan_conn = {
+          .vlanid = p->vlanid,
+          .capture_pid = 0,
+      };
       os_memcpy(vlan_conn.ifname, p->ifname, IF_NAMESIZE);
-      vlan_conn.capture_pid = 0;
       if (!put_vlan_mapper(hmap, &vlan_conn)) {
         log_trace("put_if_mapper fail");
         free_vlan_mapper(hmap);
@@ -306,8 +306,8 @@ int create_vlan_mapper(UT_array *config_ifinfo_array, hmap_vlan_conn **hmap) {
   return 0;
 }
 
-int init_ifbridge_names(UT_array *config_ifinfo_array, char *ifname,
-                        char *brname) {
+int init_ifbridge_names(UT_array *config_ifinfo_array, const char *ifname,
+                        const char *brname) {
   config_ifinfo_t *p = NULL;
 
   while ((p = (config_ifinfo_t *)utarray_next(config_ifinfo_array, p)) !=

--- a/src/utils/iface_mapper.h
+++ b/src/utils/iface_mapper.h
@@ -102,23 +102,25 @@ typedef struct hashmap_vlan_conn {
 /**
  * @brief Get the interface name corresponding to an IP address of the subnet
  *
- * @param hmap The interface connection mapper object
- * @param subnet The IP address of the subnet
- * @param ifname The returned interface name
+ * @param[in] hmap The interface connection mapper object
+ * @param[in] subnet The IP address of the subnet
+ * @param[out] ifname The buffer to store the returned interface name.
+ * Must be at least `IF_NAMESIZE` large.
  * @return int 1 if found, 0 not found, -1 on error
  */
-int get_if_mapper(hmap_if_conn **hmap, in_addr_t subnet, char *ifname);
+int get_if_mapper(hmap_if_conn *const *hmap, in_addr_t subnet,
+                  char ifname[static IF_NAMESIZE]);
 
 /**
- * @brief Insertes an interface and subnet IP value into the interface
+ * @brief Inserts an interface and subnet IP value into the interface
  * connection mapper
  *
- * @param hmap The interface connection mapper object
- * @param subnet The IP address of the subnet
- * @param ifname The interface name
+ * @param[in, out] hmap The interface connection mapper object
+ * @param[in] subnet The IP address of the subnet
+ * @param[in] ifname The interface name
  * @return true on success, false otherwise
  */
-bool put_if_mapper(hmap_if_conn **hmap, in_addr_t subnet, char *ifname);
+bool put_if_mapper(hmap_if_conn **hmap, in_addr_t subnet, const char *ifname);
 
 /**
  * @brief Frees the interface connection mapper object
@@ -130,31 +132,32 @@ void free_if_mapper(hmap_if_conn **hmap);
 /**
  * @brief Get the vlan connection structure corresponding to a VLAN ID
  *
- * @param hmap The VLAN ID to vlan connection mapper object
- * @param vlanid The VLAN ID
- * @param conn The returned VLAN connection structure
+ * @param[in] hmap The VLAN ID to vlan connection mapper object
+ * @param[in] vlanid The VLAN ID
+ * @param[out] conn The returned VLAN connection structure
  * @return int 1 if found, 0 not found, -1 on error
  */
-int get_vlan_mapper(hmap_vlan_conn **hmap, int vlanid, struct vlan_conn *conn);
+int get_vlan_mapper(hmap_vlan_conn *const *hmap, int vlanid,
+                    struct vlan_conn *conn);
 
 /**
  * @brief Makes a copy of the VLAn mapper structure
  *
- * @param hmap The VLAN ID to vlan connection mapper object
- * @param copy The copied VLAN mapper
+ * @param[in] hmap The VLAN ID to vlan connection mapper object
+ * @param[in, out] copy The copied VLAN mapper.
  * @return int 1 if found, 0 not found, -1 on error
  */
-int copy_vlan_mapper(hmap_vlan_conn **hmap, hmap_vlan_conn **copy);
+int copy_vlan_mapper(hmap_vlan_conn *const *hmap, hmap_vlan_conn **copy);
 
 /**
  * @brief Inserts a vlan connection structure and VLAN ID value into the
  * interface connection mapper
  *
- * @param hmap The VLAN ID to interface connection mapper object
- * @param conn The VLAN connection structure
+ * @param[in, out] hmap The VLAN ID to interface connection mapper object
+ * @param[in] conn The VLAN connection structure
  * @return true on success, false otherwise
  */
-bool put_vlan_mapper(hmap_vlan_conn **hmap, struct vlan_conn *conn);
+bool put_vlan_mapper(hmap_vlan_conn **hmap, const struct vlan_conn *conn);
 
 /**
  * @brief Frees the VLAN ID to interface connection mapper object
@@ -172,7 +175,8 @@ void free_vlan_mapper(hmap_vlan_conn **hmap);
  * preallocated at least the size of config_ifinfo_t::ifname)
  * @return 0 on success, -1 otherwise
  */
-int get_ifname_from_ip(UT_array *config_ifinfo_array, char *ip, char *ifname);
+int get_ifname_from_ip(const UT_array *config_ifinfo_array, const char *ip,
+                       char ifname[static IF_NAMESIZE]);
 
 /**
  * @brief Get the bridge name from an IP string
@@ -183,35 +187,36 @@ int get_ifname_from_ip(UT_array *config_ifinfo_array, char *ip, char *ifname);
  * preallocated to at least the size of config_ifinfo_t::brname).
  * @return 0 on success, -1 otherwise
  */
-int get_brname_from_ip(UT_array *config_ifinfo_array, char *ip_addr,
-                       char *brname);
+int get_brname_from_ip(const UT_array *config_ifinfo_array, const char *ip_addr,
+                       char brname[static IF_NAMESIZE]);
 
 /**
  * @brief Create the subnet to interface mapper
  *
- * @param config_ifinfo_array The connection info array
- * @param hmap The subnet to interface mapper
+ * @param[in] config_ifinfo_array The connection info array
+ * @param[in,out] hmap The subnet to interface mapper
  * @return true on success, false otherwise
  */
-bool create_if_mapper(UT_array *config_ifinfo_array, hmap_if_conn **hmap);
+bool create_if_mapper(const UT_array *config_ifinfo_array, hmap_if_conn **hmap);
 
 /**
  * @brief Create the VLAN ID to interface mapper
  *
- * @param config_ifinfo_array The connection info array
- * @param hmap The VLAN ID to interface mapper
+ * @param[in] config_ifinfo_array The connection info array
+ * @param[in,out] hmap The VLAN ID to interface mapper
  * @return 0 on success, -1 otherwise
  */
-int create_vlan_mapper(UT_array *config_ifinfo_array, hmap_vlan_conn **hmap);
+int create_vlan_mapper(const UT_array *config_ifinfo_array,
+                       hmap_vlan_conn **hmap);
 
 /**
  * @brief Initialise the interface names
  *
- * @param config_ifinfo_array The connection info array
- * @param ifname The interface name prefix
- * @param brname The bridge name prefix
+ * @param[in,out] config_ifinfo_array The connection info array
+ * @param[in] ifname The interface name prefix
+ * @param[in] brname The bridge name prefix
  * @return 0 on success, -1 otherwise
  */
-int init_ifbridge_names(UT_array *config_ifinfo_array, char *ifname,
-                        char *brname);
+int init_ifbridge_names(UT_array *config_ifinfo_array, const char *ifname,
+                        const char *brname);
 #endif


### PR DESCRIPTION
Make all the function parameters in `src/utils/iface_mapper.c` `const` when possible.

This PR also removes the unnecessary `memcpy()` calls in `iface_mapper.c`.

`memcpy()` is worse than using struct assignment, since:

1. It also copies padding bytes, which do not need to be copied.
2. On CHERI, `memcpy()` needs to copy the capability tags of any pointer type, which makes `memcpy()` far more complicated.
3. Using `memcpy()` increases the risk of memory bugs, since we need to manually specify types and the number of bytes to copy.
