### PR TITLE
Fix `test_mdns_service` on FreeBSD due to uninitialized data in test

### DIFF
--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -24,7 +24,7 @@ task:
     cmake --build --preset freebsd --parallel "$(($(sysctl -n hw.ncpu) + 1))"
   env:
     # list of tests that are currently failing on FreeBSD
-    FAILING_TESTS: test_edgesec test_mdns_service
+    FAILING_TESTS: test_edgesec
   test_script: |
     ctest --preset freebsd --output-on-failure --output-junit junit-test-results.xml \
     || true # We look at junit XML output file for failures

--- a/tests/dns/test_mdns_service.c
+++ b/tests/dns/test_mdns_service.c
@@ -60,7 +60,7 @@ void __wrap_edge_eloop_run(struct eloop_data *eloop) { (void)eloop; }
 static void test_run_mdns(void **state) {
   (void)state;
 
-  struct mdns_context context;
+  struct mdns_context context = {0};
   struct eloop_data *eloop = os_zalloc(sizeof(struct eloop_data));
 
   will_return(__wrap_edge_eloop_init, eloop);
@@ -71,7 +71,7 @@ static void test_run_mdns(void **state) {
 static void test_close_mdns(void **state) {
   (void)state;
 
-  struct mdns_context context;
+  struct mdns_context context = {0};
   struct eloop_data *eloop = os_zalloc(sizeof(struct eloop_data));
   will_return(__wrap_edge_eloop_init, eloop);
   run_mdns(&context);


### PR DESCRIPTION
The `struct mdns_context context` data was not initialized when it was used in `test_run_mdns` and `test_close_mdns`.

On Linux, this wasn't a problem, since the memory just happened to be initialized to NULL, but on FreeBSD, the memory was filled with garbage, which causes a Segmentation fault when trying to run `init_reflections()` on a garbage pointer.

Fixes the `test_mdns_service` on FreeBSD.

---

Should we maybe instead use `init_mdns_context` to initialize this context instead of 0-initializing it? The only issue is that this function is currently not in any `.h` header file, so we can't easily test it :shrug: https://github.com/nqminds/edgesec/blob/780f2b76bb8293471c252370e8dbaf3208d13e8a/src/dns/mdns_service.c#L729-L732