### PR TITLE
Move `get_config_dhcpinfo()` function into `src/dhcp/dhcp_config_utils.c`

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -49,7 +49,7 @@ target_link_libraries(runctl PRIVATE
 )
 
 add_library(config config.c)
-target_link_libraries(config PUBLIC supervisor_config LibUTHash::LibUTHash PRIVATE MinIni::minIni os log)
+target_link_libraries(config PUBLIC supervisor_config LibUTHash::LibUTHash PRIVATE MinIni::minIni dhcp_config_utils os log)
 
 add_executable(edgesec edgesec.c)
 if (USE_CRYPTO_SERVICE)

--- a/src/config.c
+++ b/src/config.c
@@ -18,6 +18,7 @@
 #include <minIni.h>
 #include <unistd.h>
 
+#include "./dhcp/dhcp_config_utils.h"
 #include "config.h"
 #include "utils/allocs.h"
 #include "utils/os.h"
@@ -28,60 +29,6 @@ static const UT_icd config_ifinfo_icd = {sizeof(config_ifinfo_t), NULL, NULL,
                                          NULL};
 static const UT_icd config_dhcpinfo_icd = {sizeof(config_dhcpinfo_t), NULL,
                                            NULL, NULL};
-
-bool get_config_dhcpinfo(char *info, config_dhcpinfo_t *el) {
-  UT_array *info_arr;
-  utarray_new(info_arr, &ut_str_icd);
-
-  if (split_string_array(info, ',', info_arr) < 0) {
-    goto err;
-  }
-
-  if (!utarray_len(info_arr)) {
-    goto err;
-  }
-
-  char **p = NULL;
-  p = (char **)utarray_next(info_arr, p);
-  if (*p != NULL) {
-    errno = 0;
-    el->vlanid = (int)strtol(*p, NULL, 10);
-    if (errno == EINVAL)
-      goto err;
-  } else
-    goto err;
-
-  p = (char **)utarray_next(info_arr, p);
-  if (*p != NULL) {
-    os_strlcpy(el->ip_addr_low, *p, OS_INET_ADDRSTRLEN);
-  } else
-    goto err;
-
-  p = (char **)utarray_next(info_arr, p);
-  if (*p != NULL)
-    os_strlcpy(el->ip_addr_upp, *p, OS_INET_ADDRSTRLEN);
-  else
-    goto err;
-
-  p = (char **)utarray_next(info_arr, p);
-  if (*p != NULL)
-    os_strlcpy(el->subnet_mask, *p, OS_INET_ADDRSTRLEN);
-  else
-    goto err;
-
-  p = (char **)utarray_next(info_arr, p);
-  if (*p != NULL)
-    os_strlcpy(el->lease_time, *p, DHCP_LEASE_TIME_SIZE);
-  else
-    goto err;
-
-  utarray_free(info_arr);
-  return true;
-
-err:
-  utarray_free(info_arr);
-  return false;
-}
 
 bool get_config_ifinfo(char *info, config_ifinfo_t *el) {
   UT_array *info_arr;

--- a/src/dhcp/CMakeLists.txt
+++ b/src/dhcp/CMakeLists.txt
@@ -14,6 +14,16 @@ endif ()
 add_library(dhcp_service dhcp_service.c)
 target_link_libraries(dhcp_service PUBLIC dhcp_config PRIVATE dnsmasq log os)
 
+add_library(dhcp_config_utils dhcp_config_utils.c)
+target_link_libraries(dhcp_config_utils
+  PUBLIC
+    dhcp_config
+  PRIVATE
+    LibUTHash::LibUTHash
+    net
+    os
+)
+
 add_library(dhcp_config INTERFACE)
 set_target_properties(dhcp_config PROPERTIES PUBLIC_HEADER "dhcp_config.h")
 target_link_libraries(dhcp_config INTERFACE LibUTHash::LibUTHash allocs os net)

--- a/src/dhcp/dhcp_config_utils.c
+++ b/src/dhcp/dhcp_config_utils.c
@@ -1,0 +1,62 @@
+#include <stdlib.h>
+#include <errno.h>
+#include <utarray.h>
+
+#include "../utils/net.h"
+#include "../utils/os.h"
+
+#include "./dhcp_config_utils.h"
+
+bool get_config_dhcpinfo(char *info, config_dhcpinfo_t *el) {
+  UT_array *info_arr;
+  utarray_new(info_arr, &ut_str_icd);
+
+  if (split_string_array(info, ',', info_arr) < 0) {
+    goto err;
+  }
+
+  if (!utarray_len(info_arr)) {
+    goto err;
+  }
+
+  char **p = NULL;
+  p = (char **)utarray_next(info_arr, p);
+  if (*p != NULL) {
+    errno = 0;
+    el->vlanid = (int)strtol(*p, NULL, 10);
+    if (errno == EINVAL)
+      goto err;
+  } else
+    goto err;
+
+  p = (char **)utarray_next(info_arr, p);
+  if (*p != NULL) {
+    os_strlcpy(el->ip_addr_low, *p, OS_INET_ADDRSTRLEN);
+  } else
+    goto err;
+
+  p = (char **)utarray_next(info_arr, p);
+  if (*p != NULL)
+    os_strlcpy(el->ip_addr_upp, *p, OS_INET_ADDRSTRLEN);
+  else
+    goto err;
+
+  p = (char **)utarray_next(info_arr, p);
+  if (*p != NULL)
+    os_strlcpy(el->subnet_mask, *p, OS_INET_ADDRSTRLEN);
+  else
+    goto err;
+
+  p = (char **)utarray_next(info_arr, p);
+  if (*p != NULL)
+    os_strlcpy(el->lease_time, *p, DHCP_LEASE_TIME_SIZE);
+  else
+    goto err;
+
+  utarray_free(info_arr);
+  return true;
+
+err:
+  utarray_free(info_arr);
+  return false;
+}

--- a/src/dhcp/dhcp_config_utils.c
+++ b/src/dhcp/dhcp_config_utils.c
@@ -7,7 +7,7 @@
 
 #include "./dhcp_config_utils.h"
 
-bool get_config_dhcpinfo(char *info, config_dhcpinfo_t *el) {
+bool get_config_dhcpinfo(const char *info, config_dhcpinfo_t *el) {
   UT_array *info_arr;
   utarray_new(info_arr, &ut_str_icd);
 

--- a/src/dhcp/dhcp_config_utils.h
+++ b/src/dhcp/dhcp_config_utils.h
@@ -32,6 +32,6 @@
  * @retval true  On success.
  * @retval false On failure.
  */
-bool get_config_dhcpinfo(char *info, config_dhcpinfo_t *el);
+bool get_config_dhcpinfo(const char *info, config_dhcpinfo_t *el);
 
 #endif /* DHCP_CONFIG_UTILS_H */

--- a/src/dhcp/dhcp_config_utils.h
+++ b/src/dhcp/dhcp_config_utils.h
@@ -1,0 +1,37 @@
+/**
+ * @file
+ * @author Alois Klink
+ * @date 2023
+ * @copyright
+ * SPDX-FileCopyrightText: © 2023 NQMCyber Ltd and edgesec contributors
+ * SPDX-License-Identifier: LGPL-3.0-or-later
+ * @brief Functions that help work with DHCP Configuration structures.
+ */
+#ifndef DHCP_CONFIG_UTILS_H
+#define DHCP_CONFIG_UTILS_H
+
+#include <stdbool.h>
+
+#include "./dhcp_config.h"
+
+/**
+ * @brief Creates a `config_dhcpinfo_t` from a string.
+ *
+ * @param[in] info - The string to parse.
+ * The format of this string is a comma-separated value line of:
+ * `<vlanid>,<ip_addr_low>,<ip_addr_upp>,<subnet_mask>,<lease_time>`
+ *
+ * `vlanid` must be a decimal integer.
+ *
+ * All other parameters are passed as a `dhcp-range` option to dnsmasq,
+ * see [`man dnsmasq(8)`](https://linux.die.net/man/8/dnsmasq).
+ *
+ * For example: `0,10.0.0.2,10.0.0.254,255.255.255.0,24h`.
+ *
+ * @param[out] el - The parsed dhcp info.
+ * @retval true  On success.
+ * @retval false On failure.
+ */
+bool get_config_dhcpinfo(char *info, config_dhcpinfo_t *el);
+
+#endif /* DHCP_CONFIG_UTILS_H */

--- a/tests/dhcp/CMakeLists.txt
+++ b/tests/dhcp/CMakeLists.txt
@@ -4,7 +4,7 @@ include_directories(
 
 add_cmocka_test(test_dnsmasq
   SOURCES test_dnsmasq.c
-  LINK_LIBRARIES dnsmasq log cmocka::cmocka
+  LINK_LIBRARIES dhcp_config dhcp_config_utils dnsmasq log cmocka::cmocka
 )
 target_link_options(test_dnsmasq
   PRIVATE

--- a/tests/dhcp/test_dnsmasq.c
+++ b/tests/dhcp/test_dnsmasq.c
@@ -14,6 +14,7 @@
 #include <unistd.h>
 
 #include "dhcp/dhcp_config.h"
+#include "dhcp/dhcp_config_utils.h"
 #include "dhcp/dnsmasq.h"
 #include "utils/log.h"
 
@@ -160,64 +161,6 @@ static void test_define_dhcp_interface_name(void **state) {
     assert_int_equal(define_dhcp_interface_name(&dconf, 12345, ifname), -1);
   }
 #endif
-}
-
-bool get_config_dhcpinfo(char *info, config_dhcpinfo_t *el) {
-  UT_array *info_arr;
-  utarray_new(info_arr, &ut_str_icd);
-
-  ssize_t count = split_string_array(info, ',', info_arr);
-
-  log_trace("Number of substrings=%zd", count);
-
-  if (!utarray_len(info_arr))
-    goto err;
-
-  char **p = NULL;
-  p = (char **)utarray_next(info_arr, p);
-  log_trace("vlanid=%s", *p);
-  if (*p != NULL) {
-    errno = 0;
-    el->vlanid = (int)strtol(*p, NULL, 10);
-    if (errno == EINVAL)
-      goto err;
-  } else
-    goto err;
-
-  p = (char **)utarray_next(info_arr, p);
-  log_trace("ip_addr_low=%s", *p);
-  if (*p != NULL) {
-    strcpy(el->ip_addr_low, *p);
-  } else
-    goto err;
-
-  p = (char **)utarray_next(info_arr, p);
-  log_trace("ip_addr_upp=%s", *p);
-  if (*p != NULL)
-    strcpy(el->ip_addr_upp, *p);
-  else
-    goto err;
-
-  p = (char **)utarray_next(info_arr, p);
-  log_trace("subnet_mask=%s", *p);
-  if (*p != NULL)
-    strcpy(el->subnet_mask, *p);
-  else
-    goto err;
-
-  p = (char **)utarray_next(info_arr, p);
-  log_trace("lease_time=%s", *p);
-  if (*p != NULL)
-    strcpy(el->lease_time, *p);
-  else
-    goto err;
-
-  utarray_free(info_arr);
-  return true;
-
-err:
-  utarray_free(info_arr);
-  return false;
 }
 
 static void test_generate_dnsmasq_conf(void **state) {


### PR DESCRIPTION
In edgesec, we have two slightly different definitions of `get_config_dhcpinfo()`, in:
  - https://github.com/nqminds/edgesec/blob/da4f33eb7377563e02b032398f52a4f21fc570a2/src/config.c#L32-L84
  - https://github.com/nqminds/edgesec/blob/da4f33eb7377563e02b032398f52a4f21fc570a2/tests/dhcp/test_dnsmasq.c#L165-L221

This PR proposes replacing these two definitions with a single definition in a new file called `src/dhcp/dhcp_config_utils.c`.

Minor differences:
  - I've taken the definition from the `src/config.c` file. The one in `tests/dhcp/test_dnsmasq.c` was almost exactly the same, except it had a bunch of `log_trace()` commands, which I removed.
  - I've made the `info` parameter `const` since we only read from it.