### PR TITLE
Improve the `get_config_dhcpinfo()` function

### DIFF
--- a/src/dhcp/dhcp_config_utils.c
+++ b/src/dhcp/dhcp_config_utils.c
@@ -11,51 +11,37 @@ bool get_config_dhcpinfo(const char *info, config_dhcpinfo_t *el) {
   UT_array *info_arr;
   utarray_new(info_arr, &ut_str_icd);
 
-  if (split_string_array(info, ',', info_arr) < 0) {
+  ssize_t substrings = split_string_array(info, ',', info_arr);
+  if (substrings < 5) {
+    log_error("get_config_dhcpinfo: Expected 5 comma-separated substrings but "
+              "got %ld in string %s",
+              substrings, info);
     goto err;
   }
 
-  if (!utarray_len(info_arr)) {
+  char **vlanid_string = utarray_eltptr(info_arr, 0);
+  char **ip_addr_low = utarray_eltptr(info_arr, 1);
+  char **ip_addr_upp = utarray_eltptr(info_arr, 2);
+  char **subnet_mask = utarray_eltptr(info_arr, 3);
+  char **lease_time = utarray_eltptr(info_arr, 4);
+
+  errno = 0;
+  *el = (config_dhcpinfo_t){
+      .vlanid = (int)strtol(*vlanid_string, NULL, 10),
+  };
+  if (errno == EINVAL) {
+    log_errno("get_config_dhcpinfo: Failed to convert vlanid: %s to an integer",
+              *vlanid_string);
     goto err;
   }
 
-  char **p = NULL;
-  p = (char **)utarray_next(info_arr, p);
-  if (*p != NULL) {
-    errno = 0;
-    el->vlanid = (int)strtol(*p, NULL, 10);
-    if (errno == EINVAL)
-      goto err;
-  } else
-    goto err;
-
-  p = (char **)utarray_next(info_arr, p);
-  if (*p != NULL) {
-    os_strlcpy(el->ip_addr_low, *p, OS_INET_ADDRSTRLEN);
-  } else
-    goto err;
-
-  p = (char **)utarray_next(info_arr, p);
-  if (*p != NULL)
-    os_strlcpy(el->ip_addr_upp, *p, OS_INET_ADDRSTRLEN);
-  else
-    goto err;
-
-  p = (char **)utarray_next(info_arr, p);
-  if (*p != NULL)
-    os_strlcpy(el->subnet_mask, *p, OS_INET_ADDRSTRLEN);
-  else
-    goto err;
-
-  p = (char **)utarray_next(info_arr, p);
-  if (*p != NULL)
-    os_strlcpy(el->lease_time, *p, DHCP_LEASE_TIME_SIZE);
-  else
-    goto err;
+  os_strlcpy(el->ip_addr_low, *ip_addr_low, OS_INET_ADDRSTRLEN);
+  os_strlcpy(el->ip_addr_upp, *ip_addr_upp, OS_INET_ADDRSTRLEN);
+  os_strlcpy(el->subnet_mask, *subnet_mask, OS_INET_ADDRSTRLEN);
+  os_strlcpy(el->lease_time, *lease_time, DHCP_LEASE_TIME_SIZE);
 
   utarray_free(info_arr);
   return true;
-
 err:
   utarray_free(info_arr);
   return false;

--- a/src/dhcp/dhcp_config_utils.c
+++ b/src/dhcp/dhcp_config_utils.c
@@ -1,5 +1,6 @@
 #include <stdlib.h>
 #include <errno.h>
+#include <limits.h>
 #include <utarray.h>
 
 #include "../utils/net.h"
@@ -26,10 +27,14 @@ bool get_config_dhcpinfo(const char *info, config_dhcpinfo_t *el) {
   char **lease_time = utarray_eltptr(info_arr, 4);
 
   errno = 0;
+  long vlanid_long = strtol(*vlanid_string, NULL, 10);
+  if (errno == 0 && vlanid_long > UINT_MAX) {
+    errno = ERANGE;
+  }
   *el = (config_dhcpinfo_t){
-      .vlanid = (int)strtol(*vlanid_string, NULL, 10),
+      .vlanid = (int)vlanid_long,
   };
-  if (errno == EINVAL) {
+  if (errno) {
     log_errno("get_config_dhcpinfo: Failed to convert vlanid: %s to an integer",
               *vlanid_string);
     goto err;


### PR DESCRIPTION
Improve the `get_config_dhcpinfo()` function by making the following changes:
  - Simplifies the function, as `split_string_array()` should always return a valid utarray (or return `-1`)
  - Adds a check for an `long`->`int` overflow when parsing `vlanid`.
