### PR TITLE
Compile and test with Address/UndefinedBehaviorSan on FreeBSD

### DIFF
--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -25,8 +25,10 @@ task:
   env:
     # list of tests that are currently failing on FreeBSD
     FAILING_TESTS: test_edgesec test_dnsmasq test_mdns_service
+  # disable aslr for AddressSanitizer support
   test_script: |
-    ctest --preset freebsd --output-on-failure --output-junit junit-test-results.xml \
+    proccontrol -m aslr -s disable \
+      ctest --preset freebsd --output-on-failure --output-junit junit-test-results.xml \
     || true # We look at junit XML output file for failures
   check_failing_tests_script: |
     # double-check that failing tests actually fail

--- a/CMakePresets.json
+++ b/CMakePresets.json
@@ -37,7 +37,8 @@
         "USE_RADIUS_SERVICE": true,
         "BUILD_HOSTAPD": false,
         "USE_CRYPTO_SERVICE": false,
-        "BUILD_OPENSSL_LIB": false
+        "BUILD_OPENSSL_LIB": false,
+        "SANITIZE_ADDRESS": true
       }
     },
     {

--- a/CMakePresets.json
+++ b/CMakePresets.json
@@ -38,7 +38,8 @@
         "BUILD_HOSTAPD": false,
         "USE_CRYPTO_SERVICE": false,
         "BUILD_OPENSSL_LIB": false,
-        "SANITIZE_ADDRESS": true
+        "SANITIZE_ADDRESS": true,
+        "SANITIZE_UNDEFINED_BEHAVIOR": true
       }
     },
     {


### PR DESCRIPTION
Compile and test with [AddressSanitizer](https://github.com/google/sanitizers/wiki/AddressSanitizer) and [UndefinedBehaviorSanitizer (UBSan)](https://www.chromium.org/developers/testing/undefinedbehaviorsanitizer/) on FreeBSD.

See PRs https://github.com/nqminds/edgesec/pull/540 and https://github.com/nqminds/edgesec/pull/541 which enabled these sanitizers for Linux for more information on why we want them.

### Implementation details

Since on FreeBSD, [ASLR (Address Space Layout Randomization)](https://wiki.freebsd.org/AddressSpaceLayoutRandomization) is enabled by default, (see the below error message), we need to use [`proccontrol`][1] to disable ASLR for the process.

> This sanitizer is not compatible with enabled ASLR and binaries compiled with PIE

[1]: https://man.freebsd.org/cgi/man.cgi?query=proccontrol&apropos=0&sektion=1&manpath=FreeBSD+11-current&format=html

